### PR TITLE
Update Node version in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ I am happy to accept PRs, but I don't want [AI slop](https://en.wikipedia.org/wi
 ## Build from Source
 
 ### Prerequisites
-- Node.js 18+ and npm ([download](https://nodejs.org/en/download))
+- Node.js ^20.19.0 || >=22.12.0 and npm ([download](https://nodejs.org/en/download))
 - For desktop builds: Rust toolchain (for Tauri builds)
 
 ### GitHub Actions Setup (For Automated Releases)

--- a/docs/building/ANDROID.md
+++ b/docs/building/ANDROID.md
@@ -6,7 +6,7 @@ This guide walks you through setting up and building the zmNg Android app from s
 
 Before you begin, ensure you have the following installed:
 
-- **Node.js 18+** and npm - [Download here](https://nodejs.org/en/download)
+- **Node.js ^20.19.0 || >=22.12.0** and npm - [Download here](https://nodejs.org/en/download)
 - **Android Studio** - [Download here](https://developer.android.com/studio)
 - **Android SDK** (installed via Android Studio)
 - **Java JDK 17+** (usually bundled with Android Studio)

--- a/docs/building/IOS.md
+++ b/docs/building/IOS.md
@@ -10,7 +10,7 @@ Before you begin, ensure you have the following:
 - **Xcode 14+** - [Download from App Store](https://apps.apple.com/us/app/xcode/id497799835)
 - **Xcode Command Line Tools**
 - **CocoaPods** - Dependency manager for iOS
-- **Node.js 18+** and npm - [Download here](https://nodejs.org/en/download)
+- **Node.js ^20.19.0 || >=22.12.0** and npm - [Download here](https://nodejs.org/en/download)
 - **Apple Developer Account** (for device testing and App Store distribution)
 
 ## Environment Setup


### PR DESCRIPTION
Noted when installing that @vitejs/plugin-react@5.1.2 and vite@7.2.7 both required: { node: '^20.19.0 || >=22.12.0' }, so updated 18+ to reflect that