### PR TITLE
feat: desktop hover preview for event list thumbnails

### DIFF
--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -547,6 +547,7 @@ export interface EventCardProps {
   event: Event;
   monitorName: string;
   thumbnailUrls: string[];
+  largeThumbnailUrls?: string[];
   objectFit?: React.CSSProperties['objectFit'];
   thumbnailWidth: number;
   thumbnailHeight: number;

--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -12,6 +12,7 @@ import { useDateTimeFormat } from '../../hooks/useDateTimeFormat';
 import { Card } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { EventThumbnail } from './EventThumbnail';
+import { EventThumbnailHoverPreview } from './EventThumbnailHoverPreview';
 import { Video, Calendar, Clock, Star } from 'lucide-react';
 import { getEventCauseIcon } from '../../lib/event-icons';
 import { getObjectClassIconFromList } from '../../lib/object-class-icons';
@@ -31,7 +32,7 @@ import { TagChipList } from './TagChip';
  * @param props.monitorName - Name of the monitor that recorded the event
  * @param props.thumbnailUrl - URL for the event thumbnail image
  */
-function EventCardComponent({ event, monitorName, thumbnailUrls, objectFit = 'contain', thumbnailWidth, thumbnailHeight, tags, eventFilters }: EventCardProps) {
+function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailUrls, objectFit = 'contain', thumbnailWidth, thumbnailHeight, tags, eventFilters }: EventCardProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { fmtDate, fmtTime } = useDateTimeFormat();
@@ -79,17 +80,24 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, objectFit = 'co
             className="w-full max-h-28"
             style={{ aspectRatio: aspectRatio.toString() }}
           >
-            <EventThumbnail
-              urls={thumbnailUrls}
+            <EventThumbnailHoverPreview
+              urls={largeThumbnailUrls ?? thumbnailUrls}
               cacheKey={event.Id}
               alt={event.Name}
-              className={cn(
-                "w-full h-full group-hover:scale-105 transition-transform duration-300"
-              )}
-              objectFit={objectFit}
-              loading="lazy"
-              data-testid="event-thumbnail"
-            />
+              aspectRatio={aspectRatio}
+            >
+              <EventThumbnail
+                urls={thumbnailUrls}
+                cacheKey={event.Id}
+                alt={event.Name}
+                className={cn(
+                  "w-full h-full group-hover:scale-105 transition-transform duration-300"
+                )}
+                objectFit={objectFit}
+                loading="lazy"
+                data-testid="event-thumbnail"
+              />
+            </EventThumbnailHoverPreview>
           </div>
           <div className="absolute bottom-0.5 left-1/2 -translate-x-1/2 sm:bottom-1 bg-black/50 text-white text-[10px] sm:text-xs px-1 sm:px-1.5 py-0.5 rounded font-medium">
             {event.Length}s

--- a/app/src/components/events/EventListView.tsx
+++ b/app/src/components/events/EventListView.tsx
@@ -75,6 +75,14 @@ const EventItem = ({
     monitorId: Event.MonitorId,
   });
 
+  // Full-size image chain used by the desktop hover preview. No width/height
+  // is passed so ZM returns the original image, which the view scales down.
+  const largeThumbnailUrls = buildThumbnailChain(eventPortalUrl, Event.Id, thumbnailChain, {
+    token: accessToken,
+    minStreamingPort,
+    monitorId: Event.MonitorId,
+  });
+
   const monitorName = monitorData?.Name || `Camera ${Event.MonitorId}`;
 
   return (
@@ -83,6 +91,7 @@ const EventItem = ({
         event={Event}
         monitorName={monitorName}
         thumbnailUrls={thumbnailUrls}
+        largeThumbnailUrls={largeThumbnailUrls}
         objectFit={thumbnailFit}
         thumbnailWidth={thumbnailWidth}
         thumbnailHeight={thumbnailHeight}

--- a/app/src/components/events/EventThumbnailHoverPreview.tsx
+++ b/app/src/components/events/EventThumbnailHoverPreview.tsx
@@ -1,0 +1,151 @@
+/**
+ * Event Thumbnail Hover Preview
+ *
+ * Desktop-only wrapper that shows a larger preview of an event thumbnail
+ * after a short hover delay. The preview is rendered via a portal with
+ * `pointer-events: none` so the underlying thumbnail remains clickable.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { EventThumbnail } from './EventThumbnail';
+
+const HOVER_DELAY_MS = 400;
+const PREVIEW_WIDTH = 400;
+const DESKTOP_MIN_WIDTH = 768;
+const EDGE_MARGIN = 12;
+
+interface EventThumbnailHoverPreviewProps {
+  urls: string[];
+  cacheKey: string;
+  alt?: string;
+  aspectRatio: number;
+  children: ReactNode;
+}
+
+export function EventThumbnailHoverPreview({
+  urls,
+  cacheKey,
+  alt,
+  aspectRatio,
+  children,
+}: EventThumbnailHoverPreviewProps) {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+
+  useEffect(() => {
+    const check = () => setIsDesktop(window.innerWidth >= DESKTOP_MIN_WIDTH);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const computePosition = () => {
+    const anchor = anchorRef.current;
+    if (!anchor) return null;
+    const rect = anchor.getBoundingClientRect();
+    const previewHeight = PREVIEW_WIDTH / aspectRatio;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // Prefer placing to the right of the anchor
+    let left = rect.right + EDGE_MARGIN;
+    if (left + PREVIEW_WIDTH > vw - EDGE_MARGIN) {
+      // Fall back to the left side
+      left = rect.left - PREVIEW_WIDTH - EDGE_MARGIN;
+    }
+    if (left < EDGE_MARGIN) {
+      left = EDGE_MARGIN;
+    }
+
+    let top = rect.top + rect.height / 2 - previewHeight / 2;
+    if (top + previewHeight > vh - EDGE_MARGIN) {
+      top = vh - EDGE_MARGIN - previewHeight;
+    }
+    if (top < EDGE_MARGIN) {
+      top = EDGE_MARGIN;
+    }
+
+    return { left, top };
+  };
+
+  const handleEnter = () => {
+    if (!isDesktop) return;
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      const pos = computePosition();
+      if (pos) {
+        setPosition(pos);
+        setOpen(true);
+      }
+    }, HOVER_DELAY_MS);
+  };
+
+  const handleLeave = () => {
+    clearTimer();
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => {
+      clearTimer();
+      setOpen(false);
+    };
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('wheel', close, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('wheel', close);
+    };
+  }, [open]);
+
+  useEffect(() => () => clearTimer(), []);
+
+  const previewHeight = PREVIEW_WIDTH / aspectRatio;
+
+  return (
+    <div
+      ref={anchorRef}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      className="w-full h-full"
+    >
+      {children}
+      {open && position && createPortal(
+        <div
+          data-testid="event-thumbnail-hover-preview"
+          style={{
+            position: 'fixed',
+            left: position.left,
+            top: position.top,
+            width: PREVIEW_WIDTH,
+            height: previewHeight,
+            pointerEvents: 'none',
+            zIndex: 9999,
+          }}
+          className="rounded-md overflow-hidden shadow-2xl ring-1 ring-border bg-card"
+        >
+          <EventThumbnail
+            urls={urls}
+            cacheKey={`${cacheKey}-hover-preview`}
+            alt={alt}
+            className="w-full h-full"
+            objectFit="contain"
+          />
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/app/tests/features/events.feature
+++ b/app/tests/features/events.feature
@@ -67,6 +67,11 @@ Feature: Event Browsing and Management
     When I download snapshot from first event in montage
     Then I should see the background task drawer if download was triggered
 
+  @web @tauri
+  Scenario: Hovering an event thumbnail in list view shows enlarged preview
+    When I hover the first event thumbnail if events exist
+    Then I should see the enlarged event thumbnail preview if hover was performed
+
   @ios-phone @android @visual
   Scenario: Phone layout shows readable event cards
     Given the viewport is mobile size

--- a/app/tests/steps/events.steps.ts
+++ b/app/tests/steps/events.steps.ts
@@ -9,6 +9,7 @@ const { When, Then } = createBdd();
 let hasEvents = false;
 let favoriteToggled = false;
 let downloadClicked = false;
+let hoverPerformed = false;
 
 // Event List Steps
 Then('I should see events list or empty state', async ({ page }) => {
@@ -57,6 +58,22 @@ When('I click into the first event if events exist', async ({ page }) => {
     await page.waitForURL(/.*events\/\d+/, { timeout: testConfig.timeouts.transition });
     await page.waitForTimeout(500);
   }
+});
+
+When('I hover the first event thumbnail if events exist', async ({ page }) => {
+  if (hasEvents) {
+    const firstThumb = page.getByTestId('event-thumbnail').first();
+    await firstThumb.hover();
+    hoverPerformed = true;
+  }
+});
+
+Then('I should see the enlarged event thumbnail preview if hover was performed', async ({ page }) => {
+  if (!hoverPerformed) return;
+  const preview = page.getByTestId('event-thumbnail-hover-preview');
+  await expect(preview).toBeVisible({ timeout: 2000 });
+  const box = await preview.boundingBox();
+  expect(box?.width).toBeGreaterThanOrEqual(350);
 });
 
 When('I navigate back if I clicked into an event', async ({ page }) => {

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -445,6 +445,27 @@ Displays a single event with thumbnail, details, and actions.
 - Duration and timestamp
 - Quick play button
 - Delete/download actions
+- Desktop hover preview of the thumbnail via
+  ``EventThumbnailHoverPreview`` (see below)
+
+EventThumbnailHoverPreview
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Location**: ``src/components/events/EventThumbnailHoverPreview.tsx``
+
+Wraps an ``EventThumbnail`` and, on desktop viewports
+(``window.innerWidth >= 768``), shows a 400px-wide enlarged preview after
+a 400 ms hover delay. The preview is rendered into ``document.body`` via
+a portal and positioned to the right of the anchor (or left if there is
+no room). It uses ``pointer-events: none`` so the underlying card click
+to open the event still works.
+
+The hover preview consumes a separate ``largeThumbnailUrls`` chain that
+``EventListView`` builds with ``buildThumbnailChain`` with no ``width``
+or ``height`` set — the server returns the original image, and the view
+scales it down to the preview size.
+
+Closes automatically on mouse leave and on window scroll / wheel events.
 
 ZmsEventPlayer
 ~~~~~~~~~~~~~~

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -15,6 +15,8 @@ Events are displayed as cards showing:
 
 The list supports infinite scrolling - older events load automatically as you scroll down.
 
+On desktop, hovering over a thumbnail for a moment shows a 400px-wide preview anchored next to the row. The preview loads a higher-resolution image from the server. The underlying card remains clickable while the preview is visible, so you can still click to open the event.
+
 ## Filtering Events
 
 Filter events using the controls at the top:


### PR DESCRIPTION
Closes #110.

## Summary
- New `EventThumbnailHoverPreview` wrapper shows a 400px-wide preview anchored to an event thumbnail after a 400ms hover delay on desktop (`innerWidth >= 768`).
- Preview is rendered via a portal with `pointer-events: none`, so the underlying card click to open the event still works.
- Preview fetches the full-size image from ZM with no `width`/`height` query params and scales it down in the view (no upscaling of the small tile).
- Flips to the left side of the row if there is no room on the right; closes on mouse leave or scroll/wheel.
- `@web @tauri` e2e scenario added.

## Test plan
- [x] `npm test` (1172 passing)
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [ ] Manual: hover thumbnails in the Events list on desktop — preview appears after ~400ms, click-through still plays the event