### PR TITLE
fix(ios): declare arm64 instead of armv7 in UIRequiredDeviceCapabilities

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -31,6 +31,9 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            ndk {
+                debugSymbolLevel 'FULL'
+            }
         }
     }
     compileOptions {

--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -43,7 +43,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
iOS 11+ is arm64-only; armv7 is a no-op on all supported devices and can trigger App Store validator warnings during submission.