### PR TITLE
fix: skip placeholder rows in ZM Servers table (refs #120)

### DIFF
--- a/app/src/lib/__tests__/server-resolver.test.ts
+++ b/app/src/lib/__tests__/server-resolver.test.ts
@@ -120,6 +120,63 @@ describe('buildServerMap', () => {
     expect(entry.portalPath).toBe('https://minimal.example.com:443/index.php');
     expect(entry.apiBaseUrl).toBe('https://minimal.example.com:443/api');
   });
+
+  it('skips servers with Port 0', () => {
+    const portZero = makeServer({
+      Id: '50',
+      Name: 'portzero',
+      Hostname: 'real.example.com',
+      Port: 0,
+    });
+    const map = buildServerMap([portZero, pseudoServer]);
+    expect(map.has('50')).toBe(false);
+    expect(map.has('1')).toBe(true);
+  });
+
+  it('skips servers with negative Port', () => {
+    const negativePort = makeServer({
+      Id: '51',
+      Name: 'neg',
+      Hostname: 'real.example.com',
+      Port: -1 as unknown as number,
+    });
+    const map = buildServerMap([negativePort]);
+    expect(map.has('51')).toBe(false);
+  });
+
+  it('skips servers with placeholder hostname "server.localdomain"', () => {
+    const placeholder = makeServer({
+      Id: '52',
+      Name: 'placeholder',
+      Hostname: 'server.localdomain',
+      Port: 443,
+    });
+    const map = buildServerMap([placeholder]);
+    expect(map.has('52')).toBe(false);
+  });
+
+  it('skips servers with placeholder hostname "localhost"', () => {
+    const placeholder = makeServer({
+      Id: '53',
+      Name: 'localhost',
+      Hostname: 'localhost',
+      Port: 443,
+    });
+    const map = buildServerMap([placeholder]);
+    expect(map.has('53')).toBe(false);
+  });
+
+  it('skips rows with combined placeholder hostname and port 0 (common ZM default row)', () => {
+    const zmDefault = makeServer({
+      Id: '1',
+      Name: 'zm-default',
+      Hostname: 'server.localdomain',
+      Port: 0,
+      PathToApi: '/zm/api',
+    });
+    const map = buildServerMap([zmDefault]);
+    expect(map.size).toBe(0);
+  });
 });
 
 describe('resolveMonitorUrls', () => {
@@ -161,6 +218,24 @@ describe('resolveMonitorUrls', () => {
     const result = resolveMonitorUrls('0', serverMap, defaults);
     expect(result.isMultiServer).toBe(false);
     expect(result.recordingUrl).toBe(defaults.cgiUrl);
+  });
+
+  it('falls back to profile defaults when ServerId points at a skipped placeholder row', () => {
+    const mapWithPlaceholder = buildServerMap([
+      makeServer({
+        Id: '1',
+        Name: 'zm-default',
+        Hostname: 'server.localdomain',
+        Port: 0,
+        PathToApi: '/zm/api',
+      }),
+    ]);
+    const result = resolveMonitorUrls('1', mapWithPlaceholder, defaults);
+    expect(result.isMultiServer).toBe(false);
+    expect(result.recordingUrl).toBe(defaults.cgiUrl);
+    expect(result.apiBaseUrl).toBe(defaults.apiUrl);
+    expect(result.apiBaseUrl).not.toContain(':0');
+    expect(result.apiBaseUrl).not.toContain('server.localdomain');
   });
 });
 

--- a/app/src/lib/server-resolver.ts
+++ b/app/src/lib/server-resolver.ts
@@ -60,15 +60,32 @@ export function clearServerMap(): void {
 
 // ========== Functions ==========
 
+// ZoneMinder installs often have a default/placeholder row in the Servers
+// table that was never populated — typically Hostname=server.localdomain
+// or localhost and Port=0. Treating those rows as valid routes breaks
+// monitors whose ServerId points at them, because the resolver then
+// overrides the user's working profile URL with the placeholder.
+const PLACEHOLDER_HOSTNAMES = new Set(['localhost', 'server.localdomain']);
+
+function isPlaceholderRow(server: Server): boolean {
+  if (!server.Hostname) return true;
+  const host = server.Hostname.toLowerCase();
+  if (PLACEHOLDER_HOSTNAMES.has(host)) return true;
+  if (host.endsWith('.localdomain')) return true;
+  if (server.Port != null && Number(server.Port) <= 0) return true;
+  return false;
+}
+
 /**
  * Build a map of ServerId to constructed URLs from a list of servers.
- * Servers without a Hostname are skipped.
+ * Rows with missing/placeholder Hostname or non-positive Port are skipped
+ * so the resolver falls back to the user's configured profile URLs.
  */
 export function buildServerMap(servers: Server[]): ServerUrlMap {
   const map: ServerUrlMap = new Map();
 
   for (const server of servers) {
-    if (!server.Hostname) {
+    if (isPlaceholderRow(server)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Guard \`buildServerMap\` against ZM Servers rows with placeholder Hostname or non-positive Port, so the resolver falls back to the user's configured profile URLs instead of producing broken URLs like \`http://server.localdomain:0/zm/api\`.
- Fixes the issue where clicking into a monitor detail view on Tauri produces port-0 API requests while the hover preview streams correctly.

refs #120

## Root cause

\`lib/server-resolver.ts:76\` used \`server.Port ?? 443\` — nullish coalescing, so \`Port: 0\` slipped through unchanged. Combined with the default \`Hostname: server.localdomain\` that ZoneMinder ships for a freshly-inserted Servers row, any monitor with \`ServerId: 1\` pointing at that row ended up with \`http://server.localdomain:0/zm/api/...\` as its API base. The monitor detail view routes \`getAlarmStatus\` through that base and every request fails with a network error; the hover preview worked because it uses \`currentProfile.cgiUrl\` directly and bypasses the resolver entirely.

## Change

Introduce \`isPlaceholderRow\` that treats a Servers row as skipped when:
- \`Hostname\` is empty
- \`Hostname\` is \`localhost\` or \`server.localdomain\` or ends with \`.localdomain\`
- \`Port <= 0\`

\`resolveMonitorUrls\` already falls back to profile defaults for rows not in the map, so skipping these rows naturally routes through the user's working profile URL.

## Test plan

- [x] \`npm test\` — 1178 passed (6 new tests for the skip cases)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual verification on the reporter's setup: monitor detail view loads, alarm status endpoint no longer sends port-0 requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)