### PR TITLE
openspec trial: 10s notification triage milestone — foundations

### DIFF
--- a/.agent/skills/openspec-apply-change/SKILL.md
+++ b/.agent/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.agent/skills/openspec-archive-change/SKILL.md
+++ b/.agent/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.agent/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.agent/skills/openspec-bulk-archive-change/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: openspec-bulk-archive-change
+description: Archive multiple completed changes at once. Use when archiving several parallel changes.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.agent/skills/openspec-continue-change/SKILL.md
+++ b/.agent/skills/openspec-continue-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-continue-change
+description: Continue working on an OpenSpec change by creating the next artifact. Use when the user wants to progress their change, create the next artifact, or continue their workflow.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change or archive it."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Want to continue? Just ask me to continue or tell me what to do next."
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.agent/skills/openspec-explore/SKILL.md
+++ b/.agent/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.agent/skills/openspec-ff-change/SKILL.md
+++ b/.agent/skills/openspec-ff-change/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: openspec-ff-change
+description: Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation in one go.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, suggest continuing that change instead
+- Verify each artifact file exists after writing before proceeding to next

--- a/.agent/skills/openspec-new-change/SKILL.md
+++ b/.agent/skills/openspec-new-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: openspec-new-change
+description: Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema (e.g., `proposal` for spec-driven).
+   Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Just describe what this change is about and I'll draft it, or ask me to continue."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest continuing that change instead
+- Pass --schema if using a non-default workflow

--- a/.agent/skills/openspec-onboard/SKILL.md
+++ b/.agent/skills/openspec-onboard/SKILL.md
@@ -1,0 +1,554 @@
+---
+name: openspec-onboard
+description: Guided onboarding for OpenSpec - walk through a complete workflow cycle with narration and real codebase work.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.agent/skills/openspec-propose/SKILL.md
+++ b/.agent/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.agent/skills/openspec-sync-specs/SKILL.md
+++ b/.agent/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.agent/skills/openspec-verify-change/SKILL.md
+++ b/.agent/skills/openspec-verify-change/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: openspec-verify-change
+description: Verify implementation matches change artifacts. Use when the user wants to validate that implementation is complete, correct, and coherent before archiving.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.agent/workflows/opsx-apply.md
+++ b/.agent/workflows/opsx-apply.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.agent/workflows/opsx-archive.md
+++ b/.agent/workflows/opsx-archive.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.agent/workflows/opsx-bulk-archive.md
+++ b/.agent/workflows/opsx-bulk-archive.md
@@ -1,0 +1,239 @@
+---
+description: Archive multiple completed changes at once
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.agent/workflows/opsx-continue.md
+++ b/.agent/workflows/opsx-continue.md
@@ -1,0 +1,111 @@
+---
+description: Continue working on a change - create the next artifact (Experimental)
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name after `/opsx:continue` (e.g., `/opsx:continue add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change with `/opsx:apply` or archive it with `/opsx:archive`."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Run `/opsx:continue` to create the next artifact"
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.agent/workflows/opsx-explore.md
+++ b/.agent/workflows/opsx-explore.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.agent/workflows/opsx-ff.md
+++ b/.agent/workflows/opsx-ff.md
@@ -1,0 +1,94 @@
+---
+description: Create a change and generate all artifacts needed for implementation in one go
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation.
+
+**Input**: The argument after `/opsx:ff` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.agent/workflows/opsx-new.md
+++ b/.agent/workflows/opsx-new.md
@@ -1,0 +1,66 @@
+---
+description: Start a new change using the experimental artifact workflow (OPSX)
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The argument after `/opsx:new` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Run `/opsx:continue` or just describe what this change is about and I'll draft it."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest using `/opsx:continue` instead
+- Pass --schema if using a non-default workflow

--- a/.agent/workflows/opsx-onboard.md
+++ b/.agent/workflows/opsx-onboard.md
@@ -1,0 +1,547 @@
+---
+description: Guided onboarding - walk through a complete OpenSpec workflow cycle with narration
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.agent/workflows/opsx-propose.md
+++ b/.agent/workflows/opsx-propose.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.agent/workflows/opsx-sync.md
+++ b/.agent/workflows/opsx-sync.md
@@ -1,0 +1,131 @@
+---
+description: Sync delta specs from a change to main specs
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.agent/workflows/opsx-verify.md
+++ b/.agent/workflows/opsx-verify.md
@@ -1,0 +1,161 @@
+---
+description: Verify implementation matches change artifacts before archiving
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name after `/opsx:verify` (e.g., `/opsx:verify add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/bulk-archive.md
+++ b/.claude/commands/opsx/bulk-archive.md
@@ -1,0 +1,242 @@
+---
+name: "OPSX: Bulk Archive"
+description: Archive multiple completed changes at once
+category: Workflow
+tags: [workflow, archive, experimental, bulk]
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.claude/commands/opsx/continue.md
+++ b/.claude/commands/opsx/continue.md
@@ -1,0 +1,114 @@
+---
+name: "OPSX: Continue"
+description: Continue working on a change - create the next artifact (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name after `/opsx:continue` (e.g., `/opsx:continue add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change with `/opsx:apply` or archive it with `/opsx:archive`."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Run `/opsx:continue` to create the next artifact"
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/ff.md
+++ b/.claude/commands/opsx/ff.md
@@ -1,0 +1,97 @@
+---
+name: "OPSX: Fast Forward"
+description: Create a change and generate all artifacts needed for implementation in one go
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation.
+
+**Input**: The argument after `/opsx:ff` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/new.md
+++ b/.claude/commands/opsx/new.md
@@ -1,0 +1,69 @@
+---
+name: "OPSX: New"
+description: Start a new change using the experimental artifact workflow (OPSX)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The argument after `/opsx:new` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Run `/opsx:continue` or just describe what this change is about and I'll draft it."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest using `/opsx:continue` instead
+- Pass --schema if using a non-default workflow

--- a/.claude/commands/opsx/onboard.md
+++ b/.claude/commands/opsx/onboard.md
@@ -1,0 +1,550 @@
+---
+name: "OPSX: Onboard"
+description: Guided onboarding - walk through a complete OpenSpec workflow cycle with narration
+category: Workflow
+tags: [workflow, onboarding, tutorial, learning]
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,134 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/commands/opsx/verify.md
+++ b/.claude/commands/opsx/verify.md
@@ -1,0 +1,164 @@
+---
+name: "OPSX: Verify"
+description: Verify implementation matches change artifacts before archiving
+category: Workflow
+tags: [workflow, verify, experimental]
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name after `/opsx:verify` (e.g., `/opsx:verify add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.claude/skills/openspec-bulk-archive-change/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: openspec-bulk-archive-change
+description: Archive multiple completed changes at once. Use when archiving several parallel changes.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.claude/skills/openspec-continue-change/SKILL.md
+++ b/.claude/skills/openspec-continue-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-continue-change
+description: Continue working on an OpenSpec change by creating the next artifact. Use when the user wants to progress their change, create the next artifact, or continue their workflow.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change or archive it."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Want to continue? Just ask me to continue or tell me what to do next."
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-ff-change/SKILL.md
+++ b/.claude/skills/openspec-ff-change/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: openspec-ff-change
+description: Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation in one go.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, suggest continuing that change instead
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: openspec-new-change
+description: Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema (e.g., `proposal` for spec-driven).
+   Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Just describe what this change is about and I'll draft it, or ask me to continue."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest continuing that change instead
+- Pass --schema if using a non-default workflow

--- a/.claude/skills/openspec-onboard/SKILL.md
+++ b/.claude/skills/openspec-onboard/SKILL.md
@@ -1,0 +1,554 @@
+---
+name: openspec-onboard
+description: Guided onboarding for OpenSpec - walk through a complete workflow cycle with narration and real codebase work.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: openspec-verify-change
+description: Verify implementation matches change artifacts. Use when the user wants to validate that implementation is complete, correct, and coherent before archiving.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.gemini/commands/opsx/apply.toml
+++ b/.gemini/commands/opsx/apply.toml
@@ -1,0 +1,149 @@
+description = "Implement tasks from an OpenSpec change (Experimental)"
+
+prompt = """
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly
+"""

--- a/.gemini/commands/opsx/archive.toml
+++ b/.gemini/commands/opsx/archive.toml
@@ -1,0 +1,154 @@
+description = "Archive a completed change in the experimental workflow"
+
+prompt = """
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+"""

--- a/.gemini/commands/opsx/bulk-archive.toml
+++ b/.gemini/commands/opsx/bulk-archive.toml
@@ -1,0 +1,239 @@
+description = "Archive multiple completed changes at once"
+
+prompt = """
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others
+"""

--- a/.gemini/commands/opsx/continue.toml
+++ b/.gemini/commands/opsx/continue.toml
@@ -1,0 +1,111 @@
+description = "Continue working on a change - create the next artifact (Experimental)"
+
+prompt = """
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name after `/opsx:continue` (e.g., `/opsx:continue add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change with `/opsx:apply` or archive it with `/opsx:archive`."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Run `/opsx:continue` to create the next artifact"
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+"""

--- a/.gemini/commands/opsx/explore.toml
+++ b/.gemini/commands/opsx/explore.toml
@@ -1,0 +1,170 @@
+description = "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+
+prompt = """
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own
+"""

--- a/.gemini/commands/opsx/ff.toml
+++ b/.gemini/commands/opsx/ff.toml
@@ -1,0 +1,94 @@
+description = "Create a change and generate all artifacts needed for implementation in one go"
+
+prompt = """
+Fast-forward through artifact creation - generate everything needed to start implementation.
+
+**Input**: The argument after `/opsx:ff` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next
+"""

--- a/.gemini/commands/opsx/new.toml
+++ b/.gemini/commands/opsx/new.toml
@@ -1,0 +1,66 @@
+description = "Start a new change using the experimental artifact workflow (OPSX)"
+
+prompt = """
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The argument after `/opsx:new` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Run `/opsx:continue` or just describe what this change is about and I'll draft it."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest using `/opsx:continue` instead
+- Pass --schema if using a non-default workflow
+"""

--- a/.gemini/commands/opsx/onboard.toml
+++ b/.gemini/commands/opsx/onboard.toml
@@ -1,0 +1,547 @@
+description = "Guided onboarding - walk through a complete OpenSpec workflow cycle with narration"
+
+prompt = """
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice
+"""

--- a/.gemini/commands/opsx/propose.toml
+++ b/.gemini/commands/opsx/propose.toml
@@ -1,0 +1,103 @@
+description = "Propose a new change - create it and generate all artifacts in one step"
+
+prompt = """
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next
+"""

--- a/.gemini/commands/opsx/sync.toml
+++ b/.gemini/commands/opsx/sync.toml
@@ -1,0 +1,131 @@
+description = "Sync delta specs from a change to main specs"
+
+prompt = """
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result
+"""

--- a/.gemini/commands/opsx/verify.toml
+++ b/.gemini/commands/opsx/verify.toml
@@ -1,0 +1,161 @@
+description = "Verify implementation matches change artifacts before archiving"
+
+prompt = """
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name after `/opsx:verify` (e.g., `/opsx:verify add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"
+"""

--- a/.gemini/skills/openspec-apply-change/SKILL.md
+++ b/.gemini/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.gemini/skills/openspec-archive-change/SKILL.md
+++ b/.gemini/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.gemini/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.gemini/skills/openspec-bulk-archive-change/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: openspec-bulk-archive-change
+description: Archive multiple completed changes at once. Use when archiving several parallel changes.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.gemini/skills/openspec-continue-change/SKILL.md
+++ b/.gemini/skills/openspec-continue-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-continue-change
+description: Continue working on an OpenSpec change by creating the next artifact. Use when the user wants to progress their change, create the next artifact, or continue their workflow.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change or archive it."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Want to continue? Just ask me to continue or tell me what to do next."
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.gemini/skills/openspec-explore/SKILL.md
+++ b/.gemini/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.gemini/skills/openspec-ff-change/SKILL.md
+++ b/.gemini/skills/openspec-ff-change/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: openspec-ff-change
+description: Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation in one go.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, suggest continuing that change instead
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gemini/skills/openspec-new-change/SKILL.md
+++ b/.gemini/skills/openspec-new-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: openspec-new-change
+description: Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema (e.g., `proposal` for spec-driven).
+   Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Just describe what this change is about and I'll draft it, or ask me to continue."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest continuing that change instead
+- Pass --schema if using a non-default workflow

--- a/.gemini/skills/openspec-onboard/SKILL.md
+++ b/.gemini/skills/openspec-onboard/SKILL.md
@@ -1,0 +1,554 @@
+---
+name: openspec-onboard
+description: Guided onboarding for OpenSpec - walk through a complete workflow cycle with narration and real codebase work.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+# Unix/macOS
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.gemini/skills/openspec-propose/SKILL.md
+++ b/.gemini/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gemini/skills/openspec-sync-specs/SKILL.md
+++ b/.gemini/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.gemini/skills/openspec-verify-change/SKILL.md
+++ b/.gemini/skills/openspec-verify-change/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: openspec-verify-change
+description: Verify implementation matches change artifacts. Use when the user wants to validate that implementation is complete, correct, and coherent before archiving.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
+            <!-- zmninja:// deep links from notification actions, widgets, tray -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="zmninja" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/ios/App/App/Info.plist
+++ b/app/ios/App/App/Info.plist
@@ -20,6 +20,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.zoneminder.zmNinjaNG</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zmninja</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -39,6 +39,7 @@ const Settings = lazy(() => import('./pages/Settings'));
 const Server = lazy(() => import('./pages/Server'));
 const NotificationSettings = lazy(() => import('./pages/NotificationSettings'));
 const NotificationHistory = lazy(() => import('./pages/NotificationHistory'));
+const TriageCenter = lazy(() => import('./pages/TriageCenter'));
 const Logs = lazy(() => import('./pages/Logs'));
 
 // Loading fallback component
@@ -249,6 +250,14 @@ function AppRoutes() {
             element={
               <RouteErrorBoundary routePath="/notifications/history">
                 <NotificationHistory />
+              </RouteErrorBoundary>
+            }
+          />
+          <Route
+            path="/notifications/triage"
+            element={
+              <RouteErrorBoundary routePath="/notifications/triage">
+                <TriageCenter />
               </RouteErrorBoundary>
             }
           />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,7 @@ import { ThemeProvider } from './components/theme-provider';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { useTokenRefresh } from './hooks/useTokenRefresh';
+import { useDeepLinkHandler } from './hooks/useDeepLinkHandler';
 import AppLayout from './components/layout/AppLayout';
 import { NotificationHandler } from './components/NotificationHandler';
 import { Button } from './components/ui/button';
@@ -73,6 +74,9 @@ function AppRoutes() {
 
   // Enable automatic token refresh
   useTokenRefresh();
+
+  // Handle zmninja:// deep links (notification action 'Live', widgets, tray)
+  useDeepLinkHandler();
 
   // Always apply compact mode
   useEffect(() => {

--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -13,13 +13,14 @@ import { Card } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { EventThumbnail } from './EventThumbnail';
 import { EventThumbnailHoverPreview } from './EventThumbnailHoverPreview';
-import { Video, Calendar, Clock, Star } from 'lucide-react';
+import { Video, Calendar, Clock, Star, CheckCircle2 } from 'lucide-react';
 import { getEventCauseIcon } from '../../lib/event-icons';
 import { getObjectClassIconFromList } from '../../lib/object-class-icons';
 import type { EventCardProps } from '../../api/types';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
 import { useEventFavoritesStore } from '../../stores/eventFavorites';
+import { useEventReviewStateStore } from '../../stores/eventReviewState';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { TagChipList } from './TagChip';
 
@@ -39,11 +40,16 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
   const { currentProfile, settings } = useCurrentProfile();
   const showHover = settings.hoverPreview.eventsList;
   const toggleFavorite = useEventFavoritesStore((state) => state.toggleFavorite);
+  const toggleReviewed = useEventReviewStateStore((state) => state.toggleReviewed);
 
   // Subscribe to the specific favorite state for this event
   // This ensures re-renders when favorite status changes
   const isFav = useEventFavoritesStore((state) =>
     currentProfile ? state.isFavorited(currentProfile.id, event.Id) : false
+  );
+
+  const isReviewed = useEventReviewStateStore((state) =>
+    currentProfile ? state.isReviewed(currentProfile.id, event.Id) : false
   );
 
   const startTime = new Date(event.StartDateTime.replace(' ', 'T'));
@@ -59,9 +65,20 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
     }
   };
 
+  const handleReviewedClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (currentProfile) {
+      toggleReviewed(currentProfile.id, event.Id);
+    }
+  };
+
   return (
     <Card
-      className="group overflow-hidden cursor-pointer hover:shadow-lg transition-all duration-200 hover:ring-2 hover:ring-primary/50 focus:outline-none focus:ring-2 focus:ring-primary"
+      className={cn(
+        "group overflow-hidden cursor-pointer hover:shadow-lg transition-all duration-200 hover:ring-2 hover:ring-primary/50 focus:outline-none focus:ring-2 focus:ring-primary",
+        isReviewed && "opacity-50"
+      )}
+      data-reviewed={isReviewed ? 'true' : 'false'}
       onClick={() => navigate(`/events/${event.Id}`, { state: { from: '/events', eventFilters } })}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -128,6 +145,24 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
                 {event.Name}
               </h3>
               <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+                <button
+                  onClick={handleReviewedClick}
+                  className={cn(
+                    "p-1 rounded-full hover:bg-accent transition-colors",
+                    "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  )}
+                  aria-label={isReviewed ? t('events.review.unmark') : t('events.review.mark')}
+                  data-testid="event-reviewed-button"
+                >
+                  <CheckCircle2
+                    className={cn(
+                      "h-4 w-4 sm:h-5 sm:w-5 transition-colors",
+                      isReviewed
+                        ? "fill-emerald-500 stroke-white"
+                        : "stroke-muted-foreground hover:stroke-emerald-500"
+                    )}
+                  />
+                </button>
                 <button
                   onClick={handleFavoriteClick}
                   className={cn(

--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -13,7 +13,7 @@ import { Card } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { EventThumbnail } from './EventThumbnail';
 import { EventThumbnailHoverPreview } from './EventThumbnailHoverPreview';
-import { Video, Calendar, Clock, Star, CheckCircle2 } from 'lucide-react';
+import { Video, Calendar, Clock, Star, CheckCircle2, Filter } from 'lucide-react';
 import { getEventCauseIcon } from '../../lib/event-icons';
 import { getObjectClassIconFromList } from '../../lib/object-class-icons';
 import type { EventCardProps } from '../../api/types';
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
 import { useEventFavoritesStore } from '../../stores/eventFavorites';
 import { useEventReviewStateStore } from '../../stores/eventReviewState';
+import { useSuppressionEntries, matchesAnyNoiseFilter } from '../../plugins/suppression-store';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { TagChipList } from './TagChip';
 
@@ -52,6 +53,23 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
     currentProfile ? state.isReviewed(currentProfile.id, event.Id) : false
   );
 
+  // Noise-filter dim treatment — any matching rule (hide OR dim) marks the
+  // card. Hide-mode rules also remove the event from the list upstream
+  // (Events.tsx); when "Show filtered" is on, hide-mode events still arrive
+  // here and should still render dimmed.
+  const suppressionEntries = useSuppressionEntries(currentProfile?.id);
+  const noiseDimmed = currentProfile
+    ? matchesAnyNoiseFilter(
+        {
+          profile_id: currentProfile.id,
+          monitor_id: event.MonitorId,
+          alarm_score: Number(event.AvgScore) || 0,
+          cause_text: event.Cause,
+        },
+        suppressionEntries
+      ) !== null
+    : false;
+
   const startTime = new Date(event.StartDateTime.replace(' ', 'T'));
 
   // Calculate aspect ratio from thumbnail dimensions
@@ -76,9 +94,11 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
     <Card
       className={cn(
         "group overflow-hidden cursor-pointer hover:shadow-lg transition-all duration-200 hover:ring-2 hover:ring-primary/50 focus:outline-none focus:ring-2 focus:ring-primary",
-        isReviewed && "opacity-50"
+        // 50% opacity when reviewed OR noise-dimmed; capped (no 25%) when both apply
+        (isReviewed || noiseDimmed) && "opacity-50"
       )}
       data-reviewed={isReviewed ? 'true' : 'false'}
+      data-noise-dimmed={noiseDimmed ? 'true' : 'false'}
       onClick={() => navigate(`/events/${event.Id}`, { state: { from: '/events', eventFilters } })}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -145,6 +165,13 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
                 {event.Name}
               </h3>
               <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+                {noiseDimmed && (
+                  <Filter
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-label={t('events.review.noise_filtered')}
+                    data-testid="event-noise-filtered-icon"
+                  />
+                )}
                 <button
                   onClick={handleReviewedClick}
                   className={cn(

--- a/app/src/components/events/EventsFilterPopover.tsx
+++ b/app/src/components/events/EventsFilterPopover.tsx
@@ -5,7 +5,7 @@
  * Provides filtering UI for events by monitors, favorites, tags, and date range.
  */
 
-import { Star, Tag, X, Loader2, ScanSearch, CheckCircle2 } from 'lucide-react';
+import { Star, Tag, X, Loader2, ScanSearch, CheckCircle2, Filter } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { MonitorData, Tag as TagType } from '../../api/types';
 import { ALL_TAGS_FILTER_ID } from '../../hooks/useEventFilters';
@@ -44,6 +44,9 @@ interface EventsFilterPopoverProps {
   // Reviewed filter
   showReviewed?: boolean;
   onShowReviewedChange?: (value: boolean) => void;
+  // Noise-filter "Show filtered" — session-scoped, surfaces hide-mode events.
+  showFiltered?: boolean;
+  onShowFilteredChange?: (value: boolean) => void;
 }
 
 export function EventsFilterPopover({
@@ -68,6 +71,8 @@ export function EventsFilterPopover({
   onOnlyDetectedObjectsChange,
   showReviewed = false,
   onShowReviewedChange,
+  showFiltered = false,
+  onShowFilteredChange,
 }: EventsFilterPopoverProps) {
   const { t } = useTranslation();
 
@@ -172,6 +177,24 @@ export function EventsFilterPopover({
               checked={showReviewed}
               onCheckedChange={onShowReviewedChange}
               data-testid="events-show-reviewed-toggle"
+            />
+          </div>
+        )}
+
+        {/* Show noise-filtered events (session-scoped) */}
+        {onShowFilteredChange && (
+          <div className="flex items-center justify-between p-3 rounded-md border bg-card">
+            <div className="flex items-center gap-2">
+              <Filter className="h-4 w-4 text-muted-foreground" />
+              <Label htmlFor="show-filtered" className="cursor-pointer">
+                {t('events.review.show_filtered')}
+              </Label>
+            </div>
+            <Switch
+              id="show-filtered"
+              checked={showFiltered}
+              onCheckedChange={onShowFilteredChange}
+              data-testid="events-show-filtered-toggle"
             />
           </div>
         )}

--- a/app/src/components/events/EventsFilterPopover.tsx
+++ b/app/src/components/events/EventsFilterPopover.tsx
@@ -5,7 +5,7 @@
  * Provides filtering UI for events by monitors, favorites, tags, and date range.
  */
 
-import { Star, Tag, X, Loader2, ScanSearch } from 'lucide-react';
+import { Star, Tag, X, Loader2, ScanSearch, CheckCircle2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { MonitorData, Tag as TagType } from '../../api/types';
 import { ALL_TAGS_FILTER_ID } from '../../hooks/useEventFilters';
@@ -41,6 +41,9 @@ interface EventsFilterPopoverProps {
   // Object detection filter
   onlyDetectedObjects?: boolean;
   onOnlyDetectedObjectsChange?: (value: boolean) => void;
+  // Reviewed filter
+  showReviewed?: boolean;
+  onShowReviewedChange?: (value: boolean) => void;
 }
 
 export function EventsFilterPopover({
@@ -63,6 +66,8 @@ export function EventsFilterPopover({
   isLoadingTags = false,
   onlyDetectedObjects = false,
   onOnlyDetectedObjectsChange,
+  showReviewed = false,
+  onShowReviewedChange,
 }: EventsFilterPopoverProps) {
   const { t } = useTranslation();
 
@@ -152,6 +157,24 @@ export function EventsFilterPopover({
             data-testid="events-detected-objects-toggle"
           />
         </div>
+
+        {/* Show reviewed events */}
+        {onShowReviewedChange && (
+          <div className="flex items-center justify-between p-3 rounded-md border bg-card">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+              <Label htmlFor="show-reviewed" className="cursor-pointer">
+                {t('events.review.show_reviewed')}
+              </Label>
+            </div>
+            <Switch
+              id="show-reviewed"
+              checked={showReviewed}
+              onCheckedChange={onShowReviewedChange}
+              data-testid="events-show-reviewed-toggle"
+            />
+          </div>
+        )}
 
         {/* Tags filter - only show if tags are supported */}
         {tagsSupported && (

--- a/app/src/components/events/QuickSearchFilterBar.tsx
+++ b/app/src/components/events/QuickSearchFilterBar.tsx
@@ -1,0 +1,109 @@
+/**
+ * Quick-Search Filter Bar
+ *
+ * Sticky bar above the events list exposing the highest-traffic filters
+ * inline so users don't have to crack open the popover. Session-scoped
+ * state (resets on profile switch / app restart). Coexists with the
+ * existing EventsFilterPopover — popover filters AND with bar filters.
+ *
+ * Phase-A MVP surfaces three new client-side filters:
+ *   - cause / notes / monitor-name "contains" text
+ *   - alarm-score minimum slider
+ *   - "Today's high-score events" one-tap preset
+ *
+ * Class-chip multiselect and the full date-range bar are deferred to a
+ * follow-up; the existing QuickDateRangeButtons live just below.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Search, X, Star } from 'lucide-react';
+import { Input } from '../ui/input';
+import { Slider } from '../ui/slider';
+import { Button } from '../ui/button';
+import { cn } from '../../lib/utils';
+
+export interface QuickSearchFilterBarProps {
+  causeContains: string;
+  onCauseContainsChange: (value: string) => void;
+  scoreMin: number;
+  onScoreMinChange: (value: number) => void;
+  /** Apply the "today's high-score" preset (date range = today, score >= 50). */
+  onApplyTodaysHighScore: () => void;
+  /** Clear inline filter state (cause + score). Does NOT touch popover filters. */
+  onClearInline: () => void;
+  className?: string;
+}
+
+export function QuickSearchFilterBar({
+  causeContains,
+  onCauseContainsChange,
+  scoreMin,
+  onScoreMinChange,
+  onApplyTodaysHighScore,
+  onClearInline,
+  className,
+}: QuickSearchFilterBarProps) {
+  const { t } = useTranslation();
+  const hasInline = causeContains.length > 0 || scoreMin > 0;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col sm:flex-row sm:items-center gap-2 py-2',
+        className
+      )}
+      data-testid="quick-search-bar"
+    >
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+          <Input
+            value={causeContains}
+            onChange={(e) => onCauseContainsChange(e.target.value)}
+            placeholder={t('events.quick_search.cause_placeholder')}
+            className="pl-7 h-8 text-sm"
+            data-testid="quick-search-cause-input"
+          />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onApplyTodaysHighScore}
+          className="shrink-0 h-8"
+          data-testid="quick-search-todays-hs"
+        >
+          <Star className="h-3.5 w-3.5 mr-1 fill-yellow-500 stroke-yellow-500" />
+          <span className="hidden sm:inline">{t('events.quick_search.todays_hs')}</span>
+          <span className="sm:hidden">{t('events.quick_search.todays_hs_short')}</span>
+        </Button>
+        {hasInline && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClearInline}
+            aria-label={t('events.quick_search.clear')}
+            className="shrink-0 h-8 w-8"
+            data-testid="quick-search-clear"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center gap-2 sm:w-56" data-testid="quick-search-score-row">
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {t('events.quick_search.score_min', { value: scoreMin })}
+        </span>
+        <Slider
+          value={[scoreMin]}
+          onValueChange={(v) => onScoreMinChange(v[0] ?? 0)}
+          min={0}
+          max={100}
+          step={5}
+          className="flex-1"
+          data-testid="quick-search-score-slider"
+          aria-label={t('events.quick_search.score_min_label')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -32,6 +32,7 @@ import { useKioskStore } from '../../stores/kioskStore';
 import { KioskOverlay } from '../kiosk/KioskOverlay';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { SidebarContent } from './SidebarContent';
+import { QuickLookDock } from './QuickLookDock';
 
 
 /**
@@ -253,6 +254,8 @@ export default function AppLayout() {
       />
 
       <KioskOverlay onUnlock={handleKioskUnlock} />
+
+      <QuickLookDock />
     </div>
   );
 }

--- a/app/src/components/layout/QuickLookDock.tsx
+++ b/app/src/components/layout/QuickLookDock.tsx
@@ -1,0 +1,134 @@
+/**
+ * Quick-Look Dock (web).
+ *
+ * Persistent strip at the bottom of the viewport showing the most recent
+ * notification events for the active profile, present on every route. Each
+ * row deep-links to the corresponding event. Dismissable per session via
+ * sessionStorage. Hidden on phone-portrait viewports < 480px wide so the
+ * dock never fights with the thumb-zone of the bottom toolbar.
+ *
+ * The functional-equivalent on native is the home-screen widget; on Tauri
+ * it's the system-tray popover. See specs/quick-look-surfaces/spec.md.
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { Capacitor } from '@capacitor/core';
+import { useNotificationStore } from '../../stores/notifications';
+import { useCurrentProfile } from '../../hooks/useCurrentProfile';
+import { useDateTimeFormat } from '../../hooks/useDateTimeFormat';
+import { Button } from '../ui/button';
+import { cn } from '../../lib/utils';
+
+const DISMISS_KEY = 'zmng-quicklook-dock-dismissed';
+const MAX_VISIBLE = 5;
+const HIDE_BELOW_PX = 480;
+
+export function QuickLookDock() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { fmtTimeShort } = useDateTimeFormat();
+  const { currentProfile } = useCurrentProfile();
+
+  const events = useNotificationStore(
+    useShallow((state) =>
+      currentProfile ? state.profileEvents[currentProfile.id] ?? [] : []
+    )
+  );
+
+  // Per-session dismiss
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof sessionStorage === 'undefined') return false;
+    return sessionStorage.getItem(DISMISS_KEY) === '1';
+  });
+
+  // Track narrow viewports so the dock disappears under 480px wide
+  const [tooNarrow, setTooNarrow] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < HIDE_BELOW_PX;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onResize = () => setTooNarrow(window.innerWidth < HIDE_BELOW_PX);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // Dock is web-only; on native, the home-screen widget is the equivalent surface.
+  if (Capacitor.isNativePlatform()) return null;
+  if (dismissed) return null;
+  if (tooNarrow) return null;
+
+  const recent = [...events]
+    .sort((a, b) => b.receivedAt - a.receivedAt)
+    .slice(0, MAX_VISIBLE);
+
+  const dismiss = () => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(DISMISS_KEY, '1');
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-0 left-0 right-0 z-30',
+        'bg-card/95 backdrop-blur border-t border-border',
+        'pb-[env(safe-area-inset-bottom)]'
+      )}
+      role="region"
+      aria-label={t('quicklook.region_label')}
+      data-testid="quicklook-dock"
+    >
+      <div className="flex items-stretch gap-2 px-3 py-1.5 max-w-screen-xl mx-auto">
+        <div className="flex-1 flex items-center gap-2 overflow-x-auto">
+          {recent.length === 0 ? (
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="quicklook-empty"
+            >
+              {t('quicklook.empty')}
+            </span>
+          ) : (
+            recent.map((event) => (
+              <button
+                key={`${event.MonitorId}-${event.EventId}-${event.receivedAt}`}
+                type="button"
+                onClick={() => navigate(`/events/${event.EventId}`)}
+                className={cn(
+                  'flex items-center gap-2 px-2 py-1 rounded-md',
+                  'text-xs hover:bg-accent transition-colors min-w-0 shrink-0',
+                  'focus:outline-none focus:ring-2 focus:ring-ring'
+                )}
+                data-testid={`quicklook-event-${event.EventId}`}
+              >
+                <span className="font-medium truncate max-w-[120px]" title={event.MonitorName}>
+                  {event.MonitorName}
+                </span>
+                <span className="text-muted-foreground">
+                  {fmtTimeShort(new Date(event.receivedAt))}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={dismiss}
+          aria-label={t('quicklook.dismiss')}
+          title={t('quicklook.dismiss')}
+          data-testid="quicklook-dismiss"
+          className="h-7 w-7 shrink-0"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/layout/__tests__/QuickLookDock.test.tsx
+++ b/app/src/components/layout/__tests__/QuickLookDock.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QuickLookDock } from '../QuickLookDock';
+import type { NotificationEvent } from '../../../stores/notifications';
+
+let mockEvents: NotificationEvent[] = [];
+
+vi.mock('../../../stores/notifications', () => ({
+  useNotificationStore: (selector: (state: { profileEvents: Record<string, NotificationEvent[]> }) => unknown) =>
+    selector({ profileEvents: { 'p1': mockEvents } }),
+}));
+
+vi.mock('../../../hooks/useCurrentProfile', () => ({
+  useCurrentProfile: () => ({
+    currentProfile: { id: 'p1', name: 'Home' },
+    settings: {},
+  }),
+}));
+
+vi.mock('../../../hooks/useDateTimeFormat', () => ({
+  useDateTimeFormat: () => ({
+    fmtTimeShort: (d: Date) => d.toISOString().slice(11, 16),
+  }),
+}));
+
+const event = (overrides: Partial<NotificationEvent>): NotificationEvent => ({
+  MonitorId: 1,
+  MonitorName: 'Driveway',
+  EventId: 100,
+  Cause: 'Motion',
+  Name: 'Event 100',
+  receivedAt: Date.now(),
+  read: false,
+  source: 'websocket',
+  ...overrides,
+});
+
+const renderDock = () =>
+  render(
+    <MemoryRouter>
+      <QuickLookDock />
+    </MemoryRouter>
+  );
+
+describe('QuickLookDock', () => {
+  beforeEach(() => {
+    mockEvents = [];
+    if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
+    Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true, writable: true });
+  });
+
+  afterEach(() => {
+    if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
+  });
+
+  it('renders the dock with empty state when no events exist', () => {
+    renderDock();
+    expect(screen.getByTestId('quicklook-dock')).toBeInTheDocument();
+    expect(screen.getByTestId('quicklook-empty')).toBeInTheDocument();
+  });
+
+  it('renders up to 5 events sorted by receivedAt descending', () => {
+    mockEvents = [
+      event({ EventId: 1, MonitorName: 'Front', receivedAt: 1000 }),
+      event({ EventId: 2, MonitorName: 'Side', receivedAt: 5000 }),
+      event({ EventId: 3, MonitorName: 'Back', receivedAt: 3000 }),
+      event({ EventId: 4, MonitorName: 'Garage', receivedAt: 4000 }),
+      event({ EventId: 5, MonitorName: 'Porch', receivedAt: 2000 }),
+      event({ EventId: 6, MonitorName: 'Office', receivedAt: 6000 }),
+    ];
+    renderDock();
+    const buttons = screen.getAllByRole('button').filter((b) =>
+      b.getAttribute('data-testid')?.startsWith('quicklook-event-')
+    );
+    expect(buttons).toHaveLength(5);
+    expect(buttons[0].getAttribute('data-testid')).toBe('quicklook-event-6');
+    // Oldest of the 5 visible (event 1 with receivedAt=1000 is sliced off).
+    expect(buttons[4].getAttribute('data-testid')).toBe('quicklook-event-5');
+  });
+
+  it('hides the dock after dismiss for the session', () => {
+    renderDock();
+    fireEvent.click(screen.getByTestId('quicklook-dismiss'));
+    expect(screen.queryByTestId('quicklook-dock')).not.toBeInTheDocument();
+    expect(sessionStorage.getItem('zmng-quicklook-dock-dismissed')).toBe('1');
+  });
+
+  it('stays hidden on subsequent mount within the same session', () => {
+    sessionStorage.setItem('zmng-quicklook-dock-dismissed', '1');
+    renderDock();
+    expect(screen.queryByTestId('quicklook-dock')).not.toBeInTheDocument();
+  });
+
+  it('hides on viewports narrower than 480px', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 360, configurable: true, writable: true });
+    renderDock();
+    expect(screen.queryByTestId('quicklook-dock')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/hooks/useDeepLinkHandler.ts
+++ b/app/src/hooks/useDeepLinkHandler.ts
@@ -1,0 +1,97 @@
+/**
+ * useDeepLinkHandler
+ *
+ * Listens for `zmninja://` URL opens delivered by Capacitor's `App` plugin
+ * and routes the running app to the matching screen. Switches the active
+ * profile first when the deep link references a different one.
+ *
+ * Web platforms also receive deep links when the URL bar contains an
+ * `app_url=zmninja://...` query (used by widget / tray previews).
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Capacitor } from '@capacitor/core';
+import { useProfileStore } from '../stores/profile';
+import { parseDeepLink, deepLinkToRoute } from '../lib/deep-link';
+import { log, LogLevel } from '../lib/logger';
+
+export function useDeepLinkHandler() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let cleanup: (() => void) | null = null;
+    let mounted = true;
+
+    async function handleUrl(url: string) {
+      const parsed = parseDeepLink(url);
+      if (!parsed) {
+        log.notifications('Deep link could not be parsed', LogLevel.WARN, { url });
+        return;
+      }
+
+      const { currentProfileId, profiles, switchProfile } = useProfileStore.getState();
+      if (parsed.profileId && parsed.profileId !== currentProfileId) {
+        const target = profiles.find((p) => p.id === parsed.profileId);
+        if (!target) {
+          log.notifications('Deep link references unknown profile; routing under current', LogLevel.WARN, {
+            url,
+            profileId: parsed.profileId,
+          });
+        } else {
+          try {
+            await switchProfile(parsed.profileId);
+          } catch (err) {
+            log.notifications('Profile switch failed; aborting deep link', LogLevel.ERROR, {
+              url,
+              profileId: parsed.profileId,
+              error: (err as Error)?.message,
+            });
+            return;
+          }
+        }
+      }
+
+      const route = deepLinkToRoute(parsed);
+      log.notifications('Routing deep link', LogLevel.INFO, { url, route });
+      navigate(route);
+    }
+
+    async function setup() {
+      if (Capacitor.isNativePlatform()) {
+        try {
+          const { App } = await import('@capacitor/app');
+          const handle = await App.addListener('appUrlOpen', (event) => {
+            if (mounted) void handleUrl(event.url);
+          });
+          if (!mounted) {
+            handle.remove();
+            return;
+          }
+          cleanup = () => {
+            handle.remove();
+          };
+        } catch (err) {
+          log.notifications('Could not register appUrlOpen listener', LogLevel.WARN, {
+            error: (err as Error)?.message,
+          });
+        }
+        return;
+      }
+
+      // Web: support `?app_url=...` once on mount, useful for previews.
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        const initial = params.get('app_url');
+        if (initial) void handleUrl(initial);
+      }
+    }
+
+    void setup();
+
+    return () => {
+      mounted = false;
+      if (cleanup) cleanup();
+    };
+  }, [navigate]);
+}

--- a/app/src/lib/__tests__/deep-link.test.ts
+++ b/app/src/lib/__tests__/deep-link.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeepLink, deepLinkToRoute } from '../deep-link';
+
+describe('parseDeepLink', () => {
+  it('returns null for empty input', () => {
+    expect(parseDeepLink('')).toBeNull();
+    expect(parseDeepLink(null)).toBeNull();
+    expect(parseDeepLink(undefined)).toBeNull();
+  });
+
+  it('returns null for non-zmninja schemes', () => {
+    expect(parseDeepLink('https://example.test/event/1')).toBeNull();
+    expect(parseDeepLink('mailto:foo@bar')).toBeNull();
+  });
+
+  it('parses zmninja://event/<id>', () => {
+    const result = parseDeepLink('zmninja://event/42');
+    expect(result).toEqual(
+      expect.objectContaining({ kind: 'event', eventId: '42', pipAuto: false })
+    );
+    expect(result?.profileId).toBeUndefined();
+  });
+
+  it('parses zmninja://monitor/<id>?pip=auto&profile_id=p1', () => {
+    const result = parseDeepLink('zmninja://monitor/m1?pip=auto&profile_id=p1');
+    expect(result).toMatchObject({
+      kind: 'monitor',
+      monitorId: 'm1',
+      profileId: 'p1',
+      pipAuto: true,
+    });
+  });
+
+  it('treats pip without =auto as false', () => {
+    const result = parseDeepLink('zmninja://monitor/m1?pip=on');
+    expect(result?.pipAuto).toBe(false);
+  });
+
+  it('tolerates the host-empty encoding (zmninja:event/123)', () => {
+    const result = parseDeepLink('zmninja:event/99');
+    expect(result).toMatchObject({ kind: 'event', eventId: '99' });
+  });
+
+  it('tolerates trailing slash', () => {
+    const result = parseDeepLink('zmninja://event/7/');
+    expect(result).toMatchObject({ kind: 'event', eventId: '7' });
+  });
+
+  it('decodes URL-encoded ids', () => {
+    const result = parseDeepLink('zmninja://event/abc%20def');
+    expect(result).toMatchObject({ kind: 'event', eventId: 'abc def' });
+  });
+
+  it('returns null when host is unknown', () => {
+    expect(parseDeepLink('zmninja://other/123')).toBeNull();
+  });
+
+  it('returns null when id is missing', () => {
+    expect(parseDeepLink('zmninja://event/')).toBeNull();
+    expect(parseDeepLink('zmninja://monitor')).toBeNull();
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(parseDeepLink('ZMNINJA://event/1')).toMatchObject({ kind: 'event', eventId: '1' });
+  });
+
+  it('exposes the raw query for callers that need extra params', () => {
+    const result = parseDeepLink('zmninja://monitor/m1?profile_id=p1&extra=foo');
+    expect(result?.query.get('extra')).toBe('foo');
+  });
+});
+
+describe('deepLinkToRoute', () => {
+  it('routes events to /events/<id>', () => {
+    const parsed = parseDeepLink('zmninja://event/42')!;
+    expect(deepLinkToRoute(parsed)).toBe('/events/42');
+  });
+
+  it('routes monitors with pip=auto preserved', () => {
+    const parsed = parseDeepLink('zmninja://monitor/m1?pip=auto&profile_id=p1')!;
+    expect(deepLinkToRoute(parsed)).toBe('/monitors/m1?pip=auto');
+  });
+
+  it('omits pip query when pipAuto is false', () => {
+    const parsed = parseDeepLink('zmninja://monitor/m1?profile_id=p1')!;
+    expect(deepLinkToRoute(parsed)).toBe('/monitors/m1');
+  });
+
+  it('encodes ids with reserved characters', () => {
+    const parsed = parseDeepLink('zmninja://event/abc%20def')!;
+    expect(deepLinkToRoute(parsed)).toBe('/events/abc%20def');
+  });
+});

--- a/app/src/lib/deep-link.ts
+++ b/app/src/lib/deep-link.ts
@@ -1,0 +1,83 @@
+/**
+ * zmninja:// deep-link parser.
+ *
+ * Supported shapes:
+ *   zmninja://event/<event_id>?profile_id=<id>
+ *   zmninja://monitor/<monitor_id>?profile_id=<id>&pip=auto
+ *
+ * Accepts both URL-style (zmninja://event/123) and host-empty (zmninja:event/123)
+ * encodings. Trailing slashes and arbitrary query params are tolerated.
+ */
+
+export type ParsedDeepLink =
+  | {
+      kind: 'event';
+      eventId: string;
+      profileId?: string;
+      pipAuto: boolean;
+      query: URLSearchParams;
+    }
+  | {
+      kind: 'monitor';
+      monitorId: string;
+      profileId?: string;
+      pipAuto: boolean;
+      query: URLSearchParams;
+    };
+
+const SCHEME = 'zmninja:';
+
+export function parseDeepLink(raw: string | null | undefined): ParsedDeepLink | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith(SCHEME)) return null;
+
+  // Normalize zmninja:event/123 → zmninja://event/123 so URL can parse it.
+  let normalized = trimmed;
+  if (!normalized.toLowerCase().startsWith('zmninja://')) {
+    normalized = 'zmninja://' + normalized.slice(SCHEME.length);
+  }
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return null;
+  }
+
+  const host = url.host;
+  // Path may be empty or "/<id>" or "/<id>/" etc.
+  const segments = url.pathname.split('/').filter(Boolean);
+  const id = segments[0];
+
+  if (!id) return null;
+
+  const query = url.searchParams;
+  const profileId = query.get('profile_id') ?? undefined;
+  const pipAuto = query.get('pip') === 'auto';
+
+  if (host === 'event') {
+    return { kind: 'event', eventId: decodeURIComponent(id), profileId, pipAuto, query };
+  }
+  if (host === 'monitor') {
+    return { kind: 'monitor', monitorId: decodeURIComponent(id), profileId, pipAuto, query };
+  }
+  return null;
+}
+
+/**
+ * Render the matching in-app route for a parsed deep link. The returned path
+ * is suitable for HashRouter `navigate()` (no leading slash hash).
+ */
+export function deepLinkToRoute(parsed: ParsedDeepLink): string {
+  switch (parsed.kind) {
+    case 'event':
+      return `/events/${encodeURIComponent(parsed.eventId)}`;
+    case 'monitor': {
+      const params = new URLSearchParams();
+      if (parsed.pipAuto) params.set('pip', 'auto');
+      const query = params.toString();
+      return `/monitors/${encodeURIComponent(parsed.monitorId)}${query ? `?${query}` : ''}`;
+    }
+  }
+}

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -209,7 +209,8 @@
       "reviewed": "Geprüft",
       "bulk_mark_all": "Alle als geprüft markieren",
       "bulk_marked": "{{count}} Ereignisse als geprüft markiert",
-      "bulk_capped": "Erste {{count}} Ereignisse als geprüft markiert"
+      "bulk_capped": "Erste {{count}} Ereignisse als geprüft markiert",
+      "show_reviewed": "Geprüfte anzeigen"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -210,7 +210,9 @@
       "bulk_mark_all": "Alle als geprüft markieren",
       "bulk_marked": "{{count}} Ereignisse als geprüft markiert",
       "bulk_capped": "Erste {{count}} Ereignisse als geprüft markiert",
-      "show_reviewed": "Geprüfte anzeigen"
+      "show_reviewed": "Geprüfte anzeigen",
+      "show_filtered": "Gefilterte anzeigen",
+      "noise_filtered": "Durch Filterregeln ausgeblendet"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -224,6 +224,14 @@
       "show_filtered": "Gefilterte anzeigen",
       "noise_filtered": "Durch Filterregeln ausgeblendet"
     },
+    "quick_search": {
+      "cause_placeholder": "Ursache, Notizen oder Monitor suchen",
+      "todays_hs": "Heute Top",
+      "todays_hs_short": "Heute Top",
+      "score_min": "Score ≥ {{value}}",
+      "score_min_label": "Mindest-Alarm-Score",
+      "clear": "Inline-Filter löschen"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Tags auswählen...",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -203,6 +203,11 @@
     "favorites_only": "Nur Favoriten",
     "added_to_favorites": "Ereignis zu Favoriten hinzugefügt",
     "removed_from_favorites": "Ereignis aus Favoriten entfernt",
+    "review": {
+      "mark": "Als geprüft markieren",
+      "unmark": "Als ungeprüft markieren",
+      "reviewed": "Geprüft"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Tags auswählen...",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1174,5 +1174,10 @@
     "priority": {
       "placeholder": "Pro-Monitor-Priorität kommt mit der nativen Version."
     }
+  },
+  "quicklook": {
+    "region_label": "Aktuelle Ereignisse",
+    "empty": "Keine aktuellen Ereignisse.",
+    "dismiss": "Ausblenden"
   }
 }

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -206,7 +206,10 @@
     "review": {
       "mark": "Als geprüft markieren",
       "unmark": "Als ungeprüft markieren",
-      "reviewed": "Geprüft"
+      "reviewed": "Geprüft",
+      "bulk_mark_all": "Alle als geprüft markieren",
+      "bulk_marked": "{{count}} Ereignisse als geprüft markiert",
+      "bulk_capped": "Erste {{count}} Ereignisse als geprüft markiert"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1,6 +1,16 @@
 {
   "common": {
     "go_back": "Zurück",
+    "back": "Zurück",
+    "weekday": {
+      "sun": "So",
+      "mon": "Mo",
+      "tue": "Di",
+      "wed": "Mi",
+      "thu": "Do",
+      "fri": "Fr",
+      "sat": "Sa"
+    },
     "previous": "Zurück",
     "next": "Weiter",
     "refresh": "Aktualisieren",
@@ -723,6 +733,7 @@
     "show_advanced": "Erweitert anzeigen",
     "unread_count": "{{count}} ungelesene Benachrichtigungen",
     "view_history": "Verlauf",
+    "triage_center": "Triage-Center",
     "function": "Funktion",
     "disconnected": "Getrennt",
     "notifications_enabled": "Benachrichtigungen aktiviert",
@@ -1118,5 +1129,50 @@
     "pin_cleared": "Kiosk-PIN entfernt",
     "pin_setting_label": "Kiosk-PIN",
     "pin_setting_desc": "PIN zum Sperren und Entsperren des Kiosk-Modus"
+  },
+  "triage": {
+    "title": "Triage-Center",
+    "subtitle": "Stummschaltungen und Filter für Benachrichtigungen verwalten.",
+    "tab": {
+      "mutes": "Stumm",
+      "quiet_hours": "Ruhezeiten",
+      "noise": "Filter",
+      "priority": "Priorität"
+    },
+    "mutes": {
+      "empty": "Keine aktiven Stummschaltungen. Stumm-Aktion in einer Benachrichtigung verwenden.",
+      "monitor": "Monitor {{id}}",
+      "until": "Bis {{time}}",
+      "extend_1h": "+1 Std."
+    },
+    "quiet_hours": {
+      "empty": "Noch keine Ruhezeit-Fenster.",
+      "add": "Ruhezeit hinzufügen",
+      "label_field": "Bezeichnung",
+      "label_placeholder": "z. B. Schlaf",
+      "start": "Start",
+      "end": "Ende",
+      "weekdays": "Wochentage",
+      "every_day": "Jeden Tag",
+      "unnamed": "Ruhezeit",
+      "error_no_weekdays": "Mindestens einen Wochentag wählen.",
+      "error_time_format": "Zeitformat muss HH:MM sein."
+    },
+    "noise": {
+      "empty": "Noch keine Filterregeln.",
+      "add": "Regel hinzufügen",
+      "min_score": "Mindest-Alarm-Score",
+      "mode": "Modus",
+      "mode_dim": "In Liste abblenden",
+      "mode_hide": "Aus Liste und Pushes ausblenden",
+      "exclude_label": "Ausschließen wenn Ursache enthält (kommagetrennt)",
+      "exclude_placeholder": "z. B. Continuous, Test",
+      "row_summary": "Score < {{score}} · {{mode}}",
+      "exclude_summary": "Ausschluss: {{patterns}}",
+      "error_score_range": "Score muss 0-100 sein."
+    },
+    "priority": {
+      "placeholder": "Pro-Monitor-Priorität kommt mit der nativen Version."
+    }
   }
 }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -210,7 +210,9 @@
       "bulk_mark_all": "Mark all reviewed",
       "bulk_marked": "Marked {{count}} events reviewed",
       "bulk_capped": "Marked first {{count}} events reviewed",
-      "show_reviewed": "Show reviewed"
+      "show_reviewed": "Show reviewed",
+      "show_filtered": "Show filtered",
+      "noise_filtered": "Filtered by noise rules"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -203,6 +203,11 @@
     "favorites_only": "Favorites Only",
     "added_to_favorites": "Event added to favorites",
     "removed_from_favorites": "Event removed from favorites",
+    "review": {
+      "mark": "Mark reviewed",
+      "unmark": "Unmark reviewed",
+      "reviewed": "Reviewed"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Select tags...",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1174,5 +1174,10 @@
     "priority": {
       "placeholder": "Per-monitor priority arrives with the native release."
     }
+  },
+  "quicklook": {
+    "region_label": "Recent events",
+    "empty": "No recent events.",
+    "dismiss": "Dismiss"
   }
 }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -29,6 +29,16 @@
     "filter": "Filter",
     "clear": "Clear",
     "go_back": "Go Back",
+    "back": "Back",
+    "weekday": {
+      "sun": "Sun",
+      "mon": "Mon",
+      "tue": "Tue",
+      "wed": "Wed",
+      "thu": "Thu",
+      "fri": "Fri",
+      "sat": "Sat"
+    },
     "previous": "Previous",
     "next": "Next",
     "apply": "Apply",
@@ -724,6 +734,7 @@
     "show_advanced": "Show Advanced",
     "unread_count": "{{count}} unread notifications",
     "view_history": "History",
+    "triage_center": "Triage Center",
     "function": "Function",
     "disconnected": "Disconnected",
     "select_profile_first": "Please select a profile first",
@@ -1118,5 +1129,50 @@
     "pin_cleared": "Kiosk PIN removed",
     "pin_setting_label": "Kiosk PIN",
     "pin_setting_desc": "PIN used to lock and unlock kiosk mode"
+  },
+  "triage": {
+    "title": "Triage Center",
+    "subtitle": "Manage how notifications are silenced and filtered.",
+    "tab": {
+      "mutes": "Mutes",
+      "quiet_hours": "Quiet Hours",
+      "noise": "Noise",
+      "priority": "Priority"
+    },
+    "mutes": {
+      "empty": "No active mutes. Mute a monitor from a notification to see it here.",
+      "monitor": "Monitor {{id}}",
+      "until": "Until {{time}}",
+      "extend_1h": "+1h"
+    },
+    "quiet_hours": {
+      "empty": "No quiet-hours windows yet.",
+      "add": "Add quiet hours",
+      "label_field": "Label",
+      "label_placeholder": "e.g. Sleep",
+      "start": "Start",
+      "end": "End",
+      "weekdays": "Weekdays",
+      "every_day": "Every day",
+      "unnamed": "Quiet hours",
+      "error_no_weekdays": "Pick at least one weekday.",
+      "error_time_format": "Time must be HH:MM."
+    },
+    "noise": {
+      "empty": "No noise-filter rules yet.",
+      "add": "Add filter rule",
+      "min_score": "Minimum alarm score",
+      "mode": "Mode",
+      "mode_dim": "Dim in list",
+      "mode_hide": "Hide from list and notifications",
+      "exclude_label": "Exclude when cause contains (comma-separated)",
+      "exclude_placeholder": "e.g. Continuous, Test",
+      "row_summary": "Score < {{score}} · {{mode}}",
+      "exclude_summary": "Excludes: {{patterns}}",
+      "error_score_range": "Score must be 0-100."
+    },
+    "priority": {
+      "placeholder": "Per-monitor priority arrives with the native release."
+    }
   }
 }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -209,7 +209,8 @@
       "reviewed": "Reviewed",
       "bulk_mark_all": "Mark all reviewed",
       "bulk_marked": "Marked {{count}} events reviewed",
-      "bulk_capped": "Marked first {{count}} events reviewed"
+      "bulk_capped": "Marked first {{count}} events reviewed",
+      "show_reviewed": "Show reviewed"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -206,7 +206,10 @@
     "review": {
       "mark": "Mark reviewed",
       "unmark": "Unmark reviewed",
-      "reviewed": "Reviewed"
+      "reviewed": "Reviewed",
+      "bulk_mark_all": "Mark all reviewed",
+      "bulk_marked": "Marked {{count}} events reviewed",
+      "bulk_capped": "Marked first {{count}} events reviewed"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -224,6 +224,14 @@
       "show_filtered": "Show filtered",
       "noise_filtered": "Filtered by noise rules"
     },
+    "quick_search": {
+      "cause_placeholder": "Search cause, notes, or monitor",
+      "todays_hs": "Today's high-score",
+      "todays_hs_short": "Today HS",
+      "score_min": "Score ≥ {{value}}",
+      "score_min_label": "Minimum alarm score",
+      "clear": "Clear inline filters"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Select tags...",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -210,7 +210,9 @@
       "bulk_mark_all": "Marcar todos revisados",
       "bulk_marked": "{{count}} eventos marcados revisados",
       "bulk_capped": "Primeros {{count}} eventos marcados revisados",
-      "show_reviewed": "Mostrar revisados"
+      "show_reviewed": "Mostrar revisados",
+      "show_filtered": "Mostrar filtrados",
+      "noise_filtered": "Filtrado por reglas de ruido"
     },
     "filter": {
       "tags": "Etiquetas",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -224,6 +224,14 @@
       "show_filtered": "Mostrar filtrados",
       "noise_filtered": "Filtrado por reglas de ruido"
     },
+    "quick_search": {
+      "cause_placeholder": "Buscar causa, notas o monitor",
+      "todays_hs": "Hoy alta puntuación",
+      "todays_hs_short": "Hoy HP",
+      "score_min": "Score ≥ {{value}}",
+      "score_min_label": "Puntuación mínima",
+      "clear": "Borrar filtros en línea"
+    },
     "filter": {
       "tags": "Etiquetas",
       "selectTags": "Seleccionar etiquetas...",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -206,7 +206,10 @@
     "review": {
       "mark": "Marcar revisado",
       "unmark": "Desmarcar revisado",
-      "reviewed": "Revisado"
+      "reviewed": "Revisado",
+      "bulk_mark_all": "Marcar todos revisados",
+      "bulk_marked": "{{count}} eventos marcados revisados",
+      "bulk_capped": "Primeros {{count}} eventos marcados revisados"
     },
     "filter": {
       "tags": "Etiquetas",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -209,7 +209,8 @@
       "reviewed": "Revisado",
       "bulk_mark_all": "Marcar todos revisados",
       "bulk_marked": "{{count}} eventos marcados revisados",
-      "bulk_capped": "Primeros {{count}} eventos marcados revisados"
+      "bulk_capped": "Primeros {{count}} eventos marcados revisados",
+      "show_reviewed": "Mostrar revisados"
     },
     "filter": {
       "tags": "Etiquetas",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1174,5 +1174,10 @@
     "priority": {
       "placeholder": "La prioridad por monitor llega con la versión nativa."
     }
+  },
+  "quicklook": {
+    "region_label": "Eventos recientes",
+    "empty": "Sin eventos recientes.",
+    "dismiss": "Ocultar"
   }
 }

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1,6 +1,16 @@
 {
   "common": {
     "go_back": "Volver",
+    "back": "Atrás",
+    "weekday": {
+      "sun": "Dom",
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mié",
+      "thu": "Jue",
+      "fri": "Vie",
+      "sat": "Sáb"
+    },
     "previous": "Anterior",
     "next": "Siguiente",
     "refresh": "Actualizar",
@@ -723,6 +733,7 @@
     "show_advanced": "Mostrar Avanzado",
     "unread_count": "{{count}} notificaciones sin leer",
     "view_history": "Historial",
+    "triage_center": "Centro de triaje",
     "function": "Función",
     "disconnected": "Desconectado",
     "notifications_enabled": "Notificaciones habilitadas",
@@ -1118,5 +1129,50 @@
     "pin_cleared": "PIN de kiosco eliminado",
     "pin_setting_label": "PIN de kiosco",
     "pin_setting_desc": "PIN para bloquear y desbloquear el modo kiosco"
+  },
+  "triage": {
+    "title": "Centro de triaje",
+    "subtitle": "Gestiona el silenciado y filtrado de notificaciones.",
+    "tab": {
+      "mutes": "Silenciados",
+      "quiet_hours": "Horas tranquilas",
+      "noise": "Ruido",
+      "priority": "Prioridad"
+    },
+    "mutes": {
+      "empty": "Sin silencios activos. Silencia un monitor desde una notificación para verlo aquí.",
+      "monitor": "Monitor {{id}}",
+      "until": "Hasta {{time}}",
+      "extend_1h": "+1 h"
+    },
+    "quiet_hours": {
+      "empty": "Aún no hay franjas de horas tranquilas.",
+      "add": "Añadir horas tranquilas",
+      "label_field": "Etiqueta",
+      "label_placeholder": "Ej. Sueño",
+      "start": "Inicio",
+      "end": "Fin",
+      "weekdays": "Días",
+      "every_day": "Cada día",
+      "unnamed": "Horas tranquilas",
+      "error_no_weekdays": "Elige al menos un día.",
+      "error_time_format": "El formato debe ser HH:MM."
+    },
+    "noise": {
+      "empty": "Aún no hay reglas de filtro.",
+      "add": "Añadir regla",
+      "min_score": "Puntuación mínima",
+      "mode": "Modo",
+      "mode_dim": "Atenuar en la lista",
+      "mode_hide": "Ocultar de lista y notificaciones",
+      "exclude_label": "Excluir si la causa contiene (separadas por coma)",
+      "exclude_placeholder": "Ej. Continuous, Test",
+      "row_summary": "Score < {{score}} · {{mode}}",
+      "exclude_summary": "Excluye: {{patterns}}",
+      "error_score_range": "La puntuación debe ser 0-100."
+    },
+    "priority": {
+      "placeholder": "La prioridad por monitor llega con la versión nativa."
+    }
   }
 }

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -203,6 +203,11 @@
     "favorites_only": "Solo Favoritos",
     "added_to_favorites": "Evento añadido a favoritos",
     "removed_from_favorites": "Evento eliminado de favoritos",
+    "review": {
+      "mark": "Marcar revisado",
+      "unmark": "Desmarcar revisado",
+      "reviewed": "Revisado"
+    },
     "filter": {
       "tags": "Etiquetas",
       "selectTags": "Seleccionar etiquetas...",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1,6 +1,16 @@
 {
   "common": {
     "go_back": "Retour",
+    "back": "Retour",
+    "weekday": {
+      "sun": "Dim",
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mer",
+      "thu": "Jeu",
+      "fri": "Ven",
+      "sat": "Sam"
+    },
     "previous": "Précédent",
     "next": "Suivant",
     "refresh": "Actualiser",
@@ -723,6 +733,7 @@
     "show_advanced": "Afficher avancé",
     "unread_count": "{{count}} notifications non lues",
     "view_history": "Historique",
+    "triage_center": "Centre de triage",
     "function": "Fonction",
     "disconnected": "Déconnecté",
     "notifications_enabled": "Notifications activées",
@@ -1118,5 +1129,50 @@
     "pin_cleared": "PIN kiosque supprimé",
     "pin_setting_label": "PIN kiosque",
     "pin_setting_desc": "PIN pour verrouiller et déverrouiller le mode kiosque"
+  },
+  "triage": {
+    "title": "Centre de triage",
+    "subtitle": "Gérer la mise en sourdine et le filtrage des notifications.",
+    "tab": {
+      "mutes": "Sourdines",
+      "quiet_hours": "Heures calmes",
+      "noise": "Bruit",
+      "priority": "Priorité"
+    },
+    "mutes": {
+      "empty": "Aucune sourdine active. Utilisez l'action Sourdine d'une notification.",
+      "monitor": "Moniteur {{id}}",
+      "until": "Jusqu'à {{time}}",
+      "extend_1h": "+1 h"
+    },
+    "quiet_hours": {
+      "empty": "Aucune plage d'heures calmes.",
+      "add": "Ajouter heures calmes",
+      "label_field": "Libellé",
+      "label_placeholder": "Ex. Sommeil",
+      "start": "Début",
+      "end": "Fin",
+      "weekdays": "Jours",
+      "every_day": "Tous les jours",
+      "unnamed": "Heures calmes",
+      "error_no_weekdays": "Choisissez au moins un jour.",
+      "error_time_format": "Le format doit être HH:MM."
+    },
+    "noise": {
+      "empty": "Aucune règle de filtre.",
+      "add": "Ajouter une règle",
+      "min_score": "Score d'alarme minimum",
+      "mode": "Mode",
+      "mode_dim": "Atténuer dans la liste",
+      "mode_hide": "Masquer de la liste et des notifications",
+      "exclude_label": "Exclure si la cause contient (séparées par virgule)",
+      "exclude_placeholder": "Ex. Continuous, Test",
+      "row_summary": "Score < {{score}} · {{mode}}",
+      "exclude_summary": "Exclut: {{patterns}}",
+      "error_score_range": "Le score doit être 0-100."
+    },
+    "priority": {
+      "placeholder": "La priorité par moniteur arrive avec la version native."
+    }
   }
 }

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1174,5 +1174,10 @@
     "priority": {
       "placeholder": "La priorité par moniteur arrive avec la version native."
     }
+  },
+  "quicklook": {
+    "region_label": "Événements récents",
+    "empty": "Aucun événement récent.",
+    "dismiss": "Masquer"
   }
 }

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -209,7 +209,8 @@
       "reviewed": "Vu",
       "bulk_mark_all": "Tout marquer vu",
       "bulk_marked": "{{count}} événements marqués vus",
-      "bulk_capped": "Premiers {{count}} événements marqués vus"
+      "bulk_capped": "Premiers {{count}} événements marqués vus",
+      "show_reviewed": "Afficher les vus"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -203,6 +203,11 @@
     "favorites_only": "Favoris Uniquement",
     "added_to_favorites": "Événement ajouté aux favoris",
     "removed_from_favorites": "Événement retiré des favoris",
+    "review": {
+      "mark": "Marquer vu",
+      "unmark": "Démarquer vu",
+      "reviewed": "Vu"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Sélectionner des tags...",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -224,6 +224,14 @@
       "show_filtered": "Afficher les filtrés",
       "noise_filtered": "Filtré par les règles de bruit"
     },
+    "quick_search": {
+      "cause_placeholder": "Rechercher cause, notes ou moniteur",
+      "todays_hs": "Score élevé du jour",
+      "todays_hs_short": "Top du jour",
+      "score_min": "Score ≥ {{value}}",
+      "score_min_label": "Score d'alarme minimum",
+      "clear": "Effacer les filtres en ligne"
+    },
     "filter": {
       "tags": "Tags",
       "selectTags": "Sélectionner des tags...",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -210,7 +210,9 @@
       "bulk_mark_all": "Tout marquer vu",
       "bulk_marked": "{{count}} événements marqués vus",
       "bulk_capped": "Premiers {{count}} événements marqués vus",
-      "show_reviewed": "Afficher les vus"
+      "show_reviewed": "Afficher les vus",
+      "show_filtered": "Afficher les filtrés",
+      "noise_filtered": "Filtré par les règles de bruit"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -206,7 +206,10 @@
     "review": {
       "mark": "Marquer vu",
       "unmark": "Démarquer vu",
-      "reviewed": "Vu"
+      "reviewed": "Vu",
+      "bulk_mark_all": "Tout marquer vu",
+      "bulk_marked": "{{count}} événements marqués vus",
+      "bulk_capped": "Premiers {{count}} événements marqués vus"
     },
     "filter": {
       "tags": "Tags",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1,6 +1,16 @@
 {
   "common": {
     "go_back": "返回",
+    "back": "返回",
+    "weekday": {
+      "sun": "周日",
+      "mon": "周一",
+      "tue": "周二",
+      "wed": "周三",
+      "thu": "周四",
+      "fri": "周五",
+      "sat": "周六"
+    },
     "previous": "上一个",
     "next": "下一个",
     "refresh": "刷新",
@@ -723,6 +733,7 @@
     "show_advanced": "显示高级",
     "unread_count": "{{count}} 条未读通知",
     "view_history": "历史",
+    "triage_center": "分诊中心",
     "function": "功能",
     "disconnected": "已断开",
     "notifications_enabled": "通知已启用",
@@ -1118,5 +1129,50 @@
     "pin_cleared": "展台PIN已移除",
     "pin_setting_label": "展台PIN",
     "pin_setting_desc": "用于锁定和解锁展台模式的PIN"
+  },
+  "triage": {
+    "title": "分诊中心",
+    "subtitle": "管理通知的静音与过滤。",
+    "tab": {
+      "mutes": "静音",
+      "quiet_hours": "免打扰",
+      "noise": "过滤",
+      "priority": "优先级"
+    },
+    "mutes": {
+      "empty": "暂无静音。请通过通知操作进行静音后查看。",
+      "monitor": "监视器 {{id}}",
+      "until": "直到 {{time}}",
+      "extend_1h": "+1 小时"
+    },
+    "quiet_hours": {
+      "empty": "尚未设置免打扰时段。",
+      "add": "添加免打扰",
+      "label_field": "名称",
+      "label_placeholder": "例如：睡眠",
+      "start": "开始",
+      "end": "结束",
+      "weekdays": "工作日",
+      "every_day": "每天",
+      "unnamed": "免打扰",
+      "error_no_weekdays": "请至少选择一天。",
+      "error_time_format": "时间格式必须为 HH:MM。"
+    },
+    "noise": {
+      "empty": "尚无过滤规则。",
+      "add": "添加规则",
+      "min_score": "最低告警分数",
+      "mode": "模式",
+      "mode_dim": "在列表中变暗",
+      "mode_hide": "从列表和通知中隐藏",
+      "exclude_label": "当原因包含以下内容时排除（逗号分隔）",
+      "exclude_placeholder": "例如：Continuous, Test",
+      "row_summary": "分数 < {{score}} · {{mode}}",
+      "exclude_summary": "排除: {{patterns}}",
+      "error_score_range": "分数必须为 0-100。"
+    },
+    "priority": {
+      "placeholder": "按监视器的优先级将随原生版本一起推出。"
+    }
   }
 }

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -210,7 +210,9 @@
       "bulk_mark_all": "全部标记已查看",
       "bulk_marked": "已标记 {{count}} 个事件",
       "bulk_capped": "已标记前 {{count}} 个事件",
-      "show_reviewed": "显示已查看"
+      "show_reviewed": "显示已查看",
+      "show_filtered": "显示已过滤",
+      "noise_filtered": "已被噪声规则过滤"
     },
     "filter": {
       "tags": "标签",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1174,5 +1174,10 @@
     "priority": {
       "placeholder": "按监视器的优先级将随原生版本一起推出。"
     }
+  },
+  "quicklook": {
+    "region_label": "最近事件",
+    "empty": "暂无最近事件。",
+    "dismiss": "隐藏"
   }
 }

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -203,6 +203,11 @@
     "favorites_only": "仅显示收藏",
     "added_to_favorites": "事件已添加到收藏",
     "removed_from_favorites": "事件已从收藏中移除",
+    "review": {
+      "mark": "标记已查看",
+      "unmark": "取消已查看",
+      "reviewed": "已查看"
+    },
     "filter": {
       "tags": "标签",
       "selectTags": "选择标签...",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -209,7 +209,8 @@
       "reviewed": "已查看",
       "bulk_mark_all": "全部标记已查看",
       "bulk_marked": "已标记 {{count}} 个事件",
-      "bulk_capped": "已标记前 {{count}} 个事件"
+      "bulk_capped": "已标记前 {{count}} 个事件",
+      "show_reviewed": "显示已查看"
     },
     "filter": {
       "tags": "标签",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -206,7 +206,10 @@
     "review": {
       "mark": "标记已查看",
       "unmark": "取消已查看",
-      "reviewed": "已查看"
+      "reviewed": "已查看",
+      "bulk_mark_all": "全部标记已查看",
+      "bulk_marked": "已标记 {{count}} 个事件",
+      "bulk_capped": "已标记前 {{count}} 个事件"
     },
     "filter": {
       "tags": "标签",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -224,6 +224,14 @@
       "show_filtered": "显示已过滤",
       "noise_filtered": "已被噪声规则过滤"
     },
+    "quick_search": {
+      "cause_placeholder": "搜索原因、备注或监视器",
+      "todays_hs": "今日高分",
+      "todays_hs_short": "今日高分",
+      "score_min": "分数 ≥ {{value}}",
+      "score_min_label": "最低告警分数",
+      "clear": "清除内联过滤"
+    },
     "filter": {
       "tags": "标签",
       "selectTags": "选择标签...",

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -64,6 +64,15 @@ export default function Events() {
     )
   );
 
+  // Reviewed-state subscription. Toggle is session-only per spec; reviewed
+  // events are hidden by default and rendered dimmed when "Show reviewed" is on.
+  const reviewedIds = useEventReviewStateStore(
+    useShallow((state) =>
+      currentProfile ? state.getReviewed(currentProfile.id) : []
+    )
+  );
+  const [showReviewed, setShowReviewed] = useState(false);
+
   const parentRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -217,6 +226,12 @@ export default function Events() {
       filtered = filtered.filter(({ Event }: EventData) => favoriteIds.includes(Event.Id));
     }
 
+    // Hide reviewed events unless the session toggle says otherwise.
+    if (!showReviewed && reviewedIds.length > 0) {
+      const reviewedSet = new Set(reviewedIds);
+      filtered = filtered.filter(({ Event }: EventData) => !reviewedSet.has(Event.Id));
+    }
+
     // Apply tag filter if tags are selected (client-side)
     if (selectedTagIds.length > 0 && eventTagMap.size > 0) {
       const isAllTagsFilter = selectedTagIds.includes(ALL_TAGS_FILTER_ID);
@@ -232,7 +247,7 @@ export default function Events() {
     }
 
     return filtered;
-  }, [eventsData?.events, favoritesOnly, favoriteIds, selectedTagIds, eventTagMap]);
+  }, [eventsData?.events, favoritesOnly, favoriteIds, showReviewed, reviewedIds, selectedTagIds, eventTagMap]);
 
   // Use grid management hook (only active when in montage mode)
   const gridControls = useEventMontageGrid({
@@ -424,6 +439,8 @@ export default function Events() {
                   isLoadingTags={isLoadingTags}
                   onlyDetectedObjects={onlyDetectedObjects}
                   onOnlyDetectedObjectsChange={setOnlyDetectedObjects}
+                  showReviewed={showReviewed}
+                  onShowReviewedChange={setShowReviewed}
                 />
               </Popover>
 

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -41,6 +41,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { useEventFavoritesStore } from '../stores/eventFavorites';
 import { useEventReviewStateStore } from '../stores/eventReviewState';
 import { toast } from 'sonner';
+import {
+  useSuppressionEntries,
+  evaluateSuppression,
+} from '../plugins/suppression-store';
 import { NotificationBadge } from '../components/NotificationBadge';
 
 export default function Events() {
@@ -72,6 +76,11 @@ export default function Events() {
     )
   );
   const [showReviewed, setShowReviewed] = useState(false);
+  const [showFiltered, setShowFiltered] = useState(false);
+
+  // Suppression-store entries drive both notification suppression (when
+  // implemented natively) and the Events list noise filter (here).
+  const suppressionEntries = useSuppressionEntries(currentProfile?.id);
 
   const parentRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
@@ -232,6 +241,24 @@ export default function Events() {
       filtered = filtered.filter(({ Event }: EventData) => !reviewedSet.has(Event.Id));
     }
 
+    // Apply noise-filter rules (mode: hide drops, mode: dim is rendered by
+    // the EventCard via a per-event "noise-dimmed" flag below). The "Show
+    // filtered" session toggle un-hides hide-mode matches for the session.
+    if (!showFiltered && currentProfile && suppressionEntries.length > 0) {
+      filtered = filtered.filter(({ Event }: EventData) => {
+        const reason = evaluateSuppression(
+          {
+            profile_id: currentProfile.id,
+            monitor_id: Event.MonitorId,
+            alarm_score: Number(Event.AvgScore) || 0,
+            cause_text: Event.Cause,
+          },
+          suppressionEntries
+        );
+        return reason?.kind !== 'noise_filter';
+      });
+    }
+
     // Apply tag filter if tags are selected (client-side)
     if (selectedTagIds.length > 0 && eventTagMap.size > 0) {
       const isAllTagsFilter = selectedTagIds.includes(ALL_TAGS_FILTER_ID);
@@ -247,7 +274,18 @@ export default function Events() {
     }
 
     return filtered;
-  }, [eventsData?.events, favoritesOnly, favoriteIds, showReviewed, reviewedIds, selectedTagIds, eventTagMap]);
+  }, [
+    eventsData?.events,
+    favoritesOnly,
+    favoriteIds,
+    showReviewed,
+    reviewedIds,
+    showFiltered,
+    suppressionEntries,
+    currentProfile,
+    selectedTagIds,
+    eventTagMap,
+  ]);
 
   // Use grid management hook (only active when in montage mode)
   const gridControls = useEventMontageGrid({
@@ -441,6 +479,8 @@ export default function Events() {
                   onOnlyDetectedObjectsChange={setOnlyDetectedObjects}
                   showReviewed={showReviewed}
                   onShowReviewedChange={setShowReviewed}
+                  showFiltered={showFiltered}
+                  onShowFilteredChange={setShowFiltered}
                 />
               </Popover>
 

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -23,7 +23,7 @@ import { useEventMontageGrid } from '../hooks/useEventMontageGrid';
 import { useEventTags, useEventTagMapping } from '../hooks/useEventTags';
 import { PullToRefreshIndicator } from '../components/ui/pull-to-refresh-indicator';
 import { Button } from '../components/ui/button';
-import { RefreshCw, Filter, AlertCircle, ArrowLeft, LayoutGrid, List, Clock, X } from 'lucide-react';
+import { RefreshCw, Filter, AlertCircle, ArrowLeft, LayoutGrid, List, Clock, X, CheckCheck } from 'lucide-react';
 import { filterMonitorsByGroup } from '../lib/filters';
 import { useGroupFilter } from '../hooks/useGroupFilter';
 import { GroupFilterSelect } from '../components/filters/GroupFilterSelect';
@@ -39,6 +39,8 @@ import { formatForServer, formatLocalDateTime } from '../lib/time';
 import { EmptyState } from '../components/ui/empty-state';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { useEventFavoritesStore } from '../stores/eventFavorites';
+import { useEventReviewStateStore } from '../stores/eventReviewState';
+import { toast } from 'sonner';
 import { NotificationBadge } from '../components/NotificationBadge';
 
 export default function Events() {
@@ -425,6 +427,27 @@ export default function Events() {
                 />
               </Popover>
 
+              <Button
+                onClick={() => {
+                  if (!currentProfile || allEvents.length === 0) return;
+                  const BULK_CAP = 500;
+                  const ids = allEvents.slice(0, BULK_CAP).map(({ Event }) => Event.Id);
+                  useEventReviewStateStore.getState().markManyReviewed(currentProfile.id, ids);
+                  if (allEvents.length > BULK_CAP) {
+                    toast.info(t('events.review.bulk_capped', { count: BULK_CAP }));
+                  } else {
+                    toast.success(t('events.review.bulk_marked', { count: ids.length }));
+                  }
+                }}
+                variant="outline"
+                size="icon"
+                aria-label={t('events.review.bulk_mark_all')}
+                title={t('events.review.bulk_mark_all')}
+                disabled={allEvents.length === 0}
+                data-testid="events-bulk-mark-reviewed"
+              >
+                <CheckCheck className="h-4 w-4" />
+              </Button>
               <Button
                 onClick={() => refetch()}
                 variant="outline"

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -33,6 +33,7 @@ import { EventMontageView } from '../components/events/EventMontageView';
 import { EventListView } from '../components/events/EventListView';
 import { EventMontageGridControls } from '../components/events/EventMontageGridControls';
 import { EventsFilterPopover } from '../components/events/EventsFilterPopover';
+import { QuickSearchFilterBar } from '../components/events/QuickSearchFilterBar';
 import { QuickDateRangeButtons } from '../components/ui/quick-date-range-buttons';
 import { useTranslation } from 'react-i18next';
 import { formatForServer, formatLocalDateTime } from '../lib/time';
@@ -77,6 +78,16 @@ export default function Events() {
   );
   const [showReviewed, setShowReviewed] = useState(false);
   const [showFiltered, setShowFiltered] = useState(false);
+  // Inline quick-search filters — session-scoped, reset on profile switch via the
+  // dependency on currentProfile?.id below.
+  const [causeContains, setCauseContains] = useState('');
+  const [scoreMin, setScoreMin] = useState(0);
+  useEffect(() => {
+    setCauseContains('');
+    setScoreMin(0);
+    setShowReviewed(false);
+    setShowFiltered(false);
+  }, [currentProfile?.id]);
 
   // Suppression-store entries drive both notification suppression (when
   // implemented natively) and the Events list noise filter (here).
@@ -241,6 +252,22 @@ export default function Events() {
       filtered = filtered.filter(({ Event }: EventData) => !reviewedSet.has(Event.Id));
     }
 
+    // Quick-search bar: cause/notes/monitor "contains" + score-min. Both
+    // session-scoped, applied client-side.
+    const trimmedCause = causeContains.trim().toLowerCase();
+    if (trimmedCause) {
+      filtered = filtered.filter(({ Event }: EventData) => {
+        const haystack = `${Event.Cause ?? ''} ${Event.Notes ?? ''} ${Event.Name ?? ''}`.toLowerCase();
+        return haystack.includes(trimmedCause);
+      });
+    }
+    if (scoreMin > 0) {
+      filtered = filtered.filter(({ Event }: EventData) => {
+        const score = Number(Event.AvgScore) || 0;
+        return score >= scoreMin;
+      });
+    }
+
     // Apply noise-filter rules (mode: hide drops, mode: dim is rendered by
     // the EventCard via a per-event "noise-dimmed" flag below). The "Show
     // filtered" session toggle un-hides hide-mode matches for the session.
@@ -285,6 +312,8 @@ export default function Events() {
     currentProfile,
     selectedTagIds,
     eventTagMap,
+    causeContains,
+    scoreMin,
   ]);
 
   // Use grid management hook (only active when in montage mode)
@@ -547,6 +576,28 @@ export default function Events() {
               </Button>
             )}
           </div>
+
+          <QuickSearchFilterBar
+            causeContains={causeContains}
+            onCauseContainsChange={setCauseContains}
+            scoreMin={scoreMin}
+            onScoreMinChange={setScoreMin}
+            onApplyTodaysHighScore={() => {
+              const end = new Date();
+              const start = new Date(end);
+              start.setHours(0, 0, 0, 0);
+              setStartDateInput(formatLocalDateTime(start));
+              setEndDateInput(formatLocalDateTime(end));
+              setActiveQuickRange(0);
+              setScoreMin(50);
+              setCauseContains('');
+              applyFilters();
+            }}
+            onClearInline={() => {
+              setCauseContains('');
+              setScoreMin(0);
+            }}
+          />
         </div>
 
         {/* Event Heatmap */}

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -18,7 +18,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Switch } from '../components/ui/switch';
 import { Label } from '../components/ui/label';
 import { ArrowLeft, Settings, Maximize2, Minimize2, Clock, AlertTriangle, Download, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Layers, Video, Eye, Disc } from 'lucide-react';
-import { useState, useRef, useMemo, useCallback } from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { cn } from '../lib/utils';
 import { toast } from 'sonner';
 import { downloadSnapshotFromElement } from '../lib/download';
@@ -33,6 +33,7 @@ import { isZmVersionAtLeast } from '../lib/zm-version';
 import { getMonitorRunState, monitorDotColor } from '../lib/monitor-status';
 import { useZoomPan } from '../hooks/useZoomPan';
 import { useServerUrls } from '../hooks/useServerUrls';
+import { engageOnReady } from '../plugins/pip';
 
 // Extracted hooks and components
 import { usePTZControl, useAlarmControl, useModeControl, useMonitorNavigation } from './hooks';
@@ -60,6 +61,37 @@ export default function MonitorDetail() {
   const referrer = location.state?.from as string | undefined;
   const canGoBack = referrer || window.history.length > 1;
   const goBack = () => referrer ? navigate(referrer) : canGoBack ? navigate(-1) : navigate('/monitors');
+
+  // pip=auto deep-link entry point — engage PiP once the video element is ready.
+  // No-op when the active media is an MJPEG <img>, when PiP is unsupported, or
+  // when the param is absent. See specs/monitor-live-deeplink/spec.md.
+  const pipAutoRequested = useMemo(
+    () => new URLSearchParams(location.search).get('pip') === 'auto',
+    [location.search]
+  );
+  const pipEngagedRef = useRef(false);
+  useEffect(() => {
+    if (!pipAutoRequested) return;
+    pipEngagedRef.current = false;
+  }, [pipAutoRequested, id]);
+  useEffect(() => {
+    if (!pipAutoRequested || pipEngagedRef.current) return;
+    const el = mediaRef.current;
+    if (!(el instanceof HTMLVideoElement)) return;
+
+    const tryEngage = () => {
+      if (pipEngagedRef.current) return;
+      pipEngagedRef.current = true;
+      void engageOnReady(el, { eventId: id });
+    };
+
+    if (el.readyState >= 2) {
+      tryEngage();
+      return;
+    }
+    el.addEventListener('loadedmetadata', tryEngage, { once: true });
+    return () => el.removeEventListener('loadedmetadata', tryEngage);
+  }, [pipAutoRequested, id, protocol]);
 
   // Profile and settings
   const { currentProfile, settings } = useCurrentProfile();

--- a/app/src/pages/NotificationSettings.tsx
+++ b/app/src/pages/NotificationSettings.tsx
@@ -26,6 +26,7 @@ import {
   XCircle,
   AlertCircle,
   Loader2,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -323,14 +324,24 @@ export default function NotificationSettings() {
             {t('notification_settings.subtitle')}
           </p>
         </div>
-        <Button
-          variant="outline"
-          onClick={() => navigate('/notifications/history')}
-          data-testid="notification-history-button"
-        >
-          <History className="h-4 w-4 mr-2" />
-          {t('notification_settings.view_history')}
-        </Button>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Button
+            variant="outline"
+            onClick={() => navigate('/notifications/triage')}
+            data-testid="notification-triage-button"
+          >
+            <SlidersHorizontal className="h-4 w-4 mr-2" />
+            {t('notification_settings.triage_center')}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => navigate('/notifications/history')}
+            data-testid="notification-history-button"
+          >
+            <History className="h-4 w-4 mr-2" />
+            {t('notification_settings.view_history')}
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-4">

--- a/app/src/pages/TriageCenter.tsx
+++ b/app/src/pages/TriageCenter.tsx
@@ -1,0 +1,512 @@
+/**
+ * Triage Center
+ *
+ * Single in-app screen to manage all suppression-store entries: ad-hoc
+ * mutes, recurring quiet-hours, per-monitor priority (native-only — shown
+ * as a placeholder for now), and noise-filter rules. See
+ * specs/snooze-management-screen/spec.md for the full contract.
+ */
+
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, BellOff, Moon, ShieldAlert, Filter, Plus, Trash2 } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import { Card } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { useCurrentProfile } from '../hooks/useCurrentProfile';
+import {
+  type MuteEntry,
+  type QuietHoursEntry,
+  type NoiseFilterEntry,
+  MONITOR_ALL,
+  useSuppressionEntries,
+  addSuppressionEntry,
+  updateSuppressionEntry,
+  removeSuppressionEntry,
+} from '../plugins/suppression-store';
+import { useDateTimeFormat } from '../hooks/useDateTimeFormat';
+
+const WEEKDAY_BITS = [
+  { bit: 0, key: 'common.weekday.sun' },
+  { bit: 1, key: 'common.weekday.mon' },
+  { bit: 2, key: 'common.weekday.tue' },
+  { bit: 3, key: 'common.weekday.wed' },
+  { bit: 4, key: 'common.weekday.thu' },
+  { bit: 5, key: 'common.weekday.fri' },
+  { bit: 6, key: 'common.weekday.sat' },
+] as const;
+
+export default function TriageCenter() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { currentProfile } = useCurrentProfile();
+  const entries = useSuppressionEntries(currentProfile?.id);
+
+  const mutes = useMemo(
+    () => entries.filter((e): e is MuteEntry => e.kind === 'mute'),
+    [entries]
+  );
+  const quietHours = useMemo(
+    () => entries.filter((e): e is QuietHoursEntry => e.kind === 'quiet_hours'),
+    [entries]
+  );
+  const noiseRules = useMemo(
+    () => entries.filter((e): e is NoiseFilterEntry => e.kind === 'noise_filter'),
+    [entries]
+  );
+
+  return (
+    <div className="container mx-auto p-4 max-w-3xl" data-testid="triage-center">
+      <div className="flex items-center gap-3 mb-4">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate('/notifications')}
+          aria-label={t('common.back')}
+          data-testid="triage-back"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-xl font-semibold">{t('triage.title')}</h1>
+          <p className="text-xs text-muted-foreground">{t('triage.subtitle')}</p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="mutes">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="mutes" data-testid="triage-tab-mutes">
+            <BellOff className="h-4 w-4 mr-1" />
+            {t('triage.tab.mutes')}
+          </TabsTrigger>
+          <TabsTrigger value="quiet" data-testid="triage-tab-quiet">
+            <Moon className="h-4 w-4 mr-1" />
+            {t('triage.tab.quiet_hours')}
+          </TabsTrigger>
+          <TabsTrigger value="noise" data-testid="triage-tab-noise">
+            <Filter className="h-4 w-4 mr-1" />
+            {t('triage.tab.noise')}
+          </TabsTrigger>
+          <TabsTrigger value="priority" data-testid="triage-tab-priority">
+            <ShieldAlert className="h-4 w-4 mr-1" />
+            {t('triage.tab.priority')}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="mutes">
+          <MutesSection mutes={mutes} />
+        </TabsContent>
+        <TabsContent value="quiet">
+          <QuietHoursSection
+            entries={quietHours}
+            profileId={currentProfile?.id}
+          />
+        </TabsContent>
+        <TabsContent value="noise">
+          <NoiseFilterSection
+            entries={noiseRules}
+            profileId={currentProfile?.id}
+          />
+        </TabsContent>
+        <TabsContent value="priority">
+          <PriorityPlaceholder />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function MutesSection({ mutes }: { mutes: MuteEntry[] }) {
+  const { t } = useTranslation();
+  const { fmtDateTimeShort } = useDateTimeFormat();
+
+  if (mutes.length === 0) {
+    return (
+      <Card className="p-6 text-center text-sm text-muted-foreground" data-testid="triage-mutes-empty">
+        {t('triage.mutes.empty')}
+      </Card>
+    );
+  }
+
+  const sorted = [...mutes].sort((a, b) => Date.parse(a.until) - Date.parse(b.until));
+
+  return (
+    <div className="space-y-2" data-testid="triage-mutes-list">
+      {sorted.map((m) => {
+        const until = new Date(m.until);
+        return (
+          <Card key={m.id} className="p-3 flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="font-medium truncate">{t('triage.mutes.monitor', { id: m.monitor_id })}</div>
+              <div className="text-xs text-muted-foreground">
+                {t('triage.mutes.until', { time: fmtDateTimeShort(until) })}
+              </div>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  updateSuppressionEntry(m.id, {
+                    until: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+                  })
+                }
+                data-testid={`triage-mute-extend-${m.id}`}
+              >
+                {t('triage.mutes.extend_1h')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => removeSuppressionEntry(m.id)}
+                aria-label={t('common.clear')}
+                data-testid={`triage-mute-clear-${m.id}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function QuietHoursSection({
+  entries,
+  profileId,
+}: {
+  entries: QuietHoursEntry[];
+  profileId: string | undefined;
+}) {
+  const { t } = useTranslation();
+  const [showAdd, setShowAdd] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      {entries.length === 0 && !showAdd && (
+        <Card className="p-6 text-center text-sm text-muted-foreground" data-testid="triage-quiet-empty">
+          {t('triage.quiet_hours.empty')}
+        </Card>
+      )}
+
+      {entries.map((e) => (
+        <Card key={e.id} className="p-3 flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{e.label || t('triage.quiet_hours.unnamed')}</div>
+            <div className="text-xs text-muted-foreground">
+              {e.start_local_time}–{e.end_local_time} · {weekdayLabel(e.weekday_mask, t)}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removeSuppressionEntry(e.id)}
+            aria-label={t('common.clear')}
+            data-testid={`triage-quiet-delete-${e.id}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </Card>
+      ))}
+
+      {showAdd ? (
+        <QuietHoursAddForm
+          profileId={profileId}
+          onCancel={() => setShowAdd(false)}
+          onSaved={() => setShowAdd(false)}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          onClick={() => setShowAdd(true)}
+          disabled={!profileId}
+          data-testid="triage-quiet-add"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          {t('triage.quiet_hours.add')}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function QuietHoursAddForm({
+  profileId,
+  onCancel,
+  onSaved,
+}: {
+  profileId: string | undefined;
+  onCancel: () => void;
+  onSaved: () => void;
+}) {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState('');
+  const [start, setStart] = useState('22:00');
+  const [end, setEnd] = useState('07:00');
+  const [mask, setMask] = useState(0b1111111);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = () => {
+    if (!profileId) return;
+    if (mask === 0) {
+      setError(t('triage.quiet_hours.error_no_weekdays'));
+      return;
+    }
+    if (!/^\d{1,2}:\d{2}$/.test(start) || !/^\d{1,2}:\d{2}$/.test(end)) {
+      setError(t('triage.quiet_hours.error_time_format'));
+      return;
+    }
+    addSuppressionEntry({
+      kind: 'quiet_hours',
+      profile_id: profileId,
+      monitor_id_or_all: MONITOR_ALL,
+      start_local_time: start,
+      end_local_time: end,
+      weekday_mask: mask,
+      label: label.trim(),
+    } as Omit<QuietHoursEntry, 'id' | 'created_at'>);
+    onSaved();
+  };
+
+  return (
+    <Card className="p-3 space-y-3" data-testid="triage-quiet-form">
+      <div>
+        <Label htmlFor="qh-label">{t('triage.quiet_hours.label_field')}</Label>
+        <Input
+          id="qh-label"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder={t('triage.quiet_hours.label_placeholder')}
+          data-testid="triage-quiet-label"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label htmlFor="qh-start">{t('triage.quiet_hours.start')}</Label>
+          <Input
+            id="qh-start"
+            type="time"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            data-testid="triage-quiet-start"
+          />
+        </div>
+        <div>
+          <Label htmlFor="qh-end">{t('triage.quiet_hours.end')}</Label>
+          <Input
+            id="qh-end"
+            type="time"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            data-testid="triage-quiet-end"
+          />
+        </div>
+      </div>
+      <div>
+        <Label className="block mb-1">{t('triage.quiet_hours.weekdays')}</Label>
+        <div className="flex gap-1 flex-wrap">
+          {WEEKDAY_BITS.map(({ bit, key }) => {
+            const active = (mask & (1 << bit)) !== 0;
+            return (
+              <Button
+                key={bit}
+                type="button"
+                variant={active ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setMask(mask ^ (1 << bit))}
+                data-testid={`triage-quiet-weekday-${bit}`}
+              >
+                {t(key)}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" onClick={onCancel} data-testid="triage-quiet-cancel">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={save} disabled={!profileId} data-testid="triage-quiet-save">
+          {t('common.save')}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function NoiseFilterSection({
+  entries,
+  profileId,
+}: {
+  entries: NoiseFilterEntry[];
+  profileId: string | undefined;
+}) {
+  const { t } = useTranslation();
+  const [showAdd, setShowAdd] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      {entries.length === 0 && !showAdd && (
+        <Card className="p-6 text-center text-sm text-muted-foreground" data-testid="triage-noise-empty">
+          {t('triage.noise.empty')}
+        </Card>
+      )}
+
+      {entries.map((e) => (
+        <Card key={e.id} className="p-3 flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="font-medium">
+              {t('triage.noise.row_summary', {
+                score: e.min_alarm_score,
+                mode: t(`triage.noise.mode_${e.mode}`),
+              })}
+            </div>
+            {e.exclude_cause_patterns.length > 0 && (
+              <div className="text-xs text-muted-foreground truncate">
+                {t('triage.noise.exclude_summary', {
+                  patterns: e.exclude_cause_patterns.join(', '),
+                })}
+              </div>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removeSuppressionEntry(e.id)}
+            aria-label={t('common.clear')}
+            data-testid={`triage-noise-delete-${e.id}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </Card>
+      ))}
+
+      {showAdd ? (
+        <NoiseFilterAddForm
+          profileId={profileId}
+          onCancel={() => setShowAdd(false)}
+          onSaved={() => setShowAdd(false)}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          onClick={() => setShowAdd(true)}
+          disabled={!profileId}
+          data-testid="triage-noise-add"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          {t('triage.noise.add')}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function NoiseFilterAddForm({
+  profileId,
+  onCancel,
+  onSaved,
+}: {
+  profileId: string | undefined;
+  onCancel: () => void;
+  onSaved: () => void;
+}) {
+  const { t } = useTranslation();
+  const [score, setScore] = useState('30');
+  const [mode, setMode] = useState<'hide' | 'dim'>('dim');
+  const [excludeText, setExcludeText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const save = () => {
+    if (!profileId) return;
+    const parsedScore = Number(score);
+    if (Number.isNaN(parsedScore) || parsedScore < 0 || parsedScore > 100) {
+      setError(t('triage.noise.error_score_range'));
+      return;
+    }
+    const patterns = excludeText
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+
+    addSuppressionEntry({
+      kind: 'noise_filter',
+      profile_id: profileId,
+      monitor_id_or_all: MONITOR_ALL,
+      min_alarm_score: parsedScore,
+      exclude_cause_patterns: patterns,
+      mode,
+    } as Omit<NoiseFilterEntry, 'id' | 'created_at'>);
+    onSaved();
+  };
+
+  return (
+    <Card className="p-3 space-y-3" data-testid="triage-noise-form">
+      <div>
+        <Label htmlFor="nf-score">{t('triage.noise.min_score')}</Label>
+        <Input
+          id="nf-score"
+          type="number"
+          min={0}
+          max={100}
+          value={score}
+          onChange={(e) => setScore(e.target.value)}
+          data-testid="triage-noise-score"
+        />
+      </div>
+      <div>
+        <Label htmlFor="nf-mode">{t('triage.noise.mode')}</Label>
+        <Select value={mode} onValueChange={(v) => setMode(v as 'hide' | 'dim')}>
+          <SelectTrigger id="nf-mode" data-testid="triage-noise-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="dim">{t('triage.noise.mode_dim')}</SelectItem>
+            <SelectItem value="hide">{t('triage.noise.mode_hide')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div>
+        <Label htmlFor="nf-exclude">{t('triage.noise.exclude_label')}</Label>
+        <Input
+          id="nf-exclude"
+          value={excludeText}
+          onChange={(e) => setExcludeText(e.target.value)}
+          placeholder={t('triage.noise.exclude_placeholder')}
+          data-testid="triage-noise-exclude"
+        />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" onClick={onCancel} data-testid="triage-noise-cancel">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={save} disabled={!profileId} data-testid="triage-noise-save">
+          {t('common.save')}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function PriorityPlaceholder() {
+  const { t } = useTranslation();
+  return (
+    <Card className="p-6 text-sm text-muted-foreground" data-testid="triage-priority-placeholder">
+      {t('triage.priority.placeholder')}
+    </Card>
+  );
+}
+
+function weekdayLabel(mask: number, t: (k: string) => string): string {
+  if (mask === 0b1111111) return t('triage.quiet_hours.every_day');
+  return WEEKDAY_BITS.filter(({ bit }) => mask & (1 << bit))
+    .map(({ key }) => t(key))
+    .join(' · ');
+}

--- a/app/src/plugins/pip/__tests__/engageOnReady.test.ts
+++ b/app/src/plugins/pip/__tests__/engageOnReady.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const { isPipSupportedMock, enterPipMock } = vi.hoisted(() => ({
+  isPipSupportedMock: vi.fn(),
+  enterPipMock: vi.fn(),
+}));
+
+vi.mock('@capacitor/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@capacitor/core')>();
+  return {
+    ...actual,
+    Capacitor: {
+      isNativePlatform: () => false,
+      getPlatform: () => 'web',
+    },
+    registerPlugin: () => ({
+      isPipSupported: isPipSupportedMock,
+      enterPip: enterPipMock,
+    }),
+  };
+});
+
+import { engageOnReady } from '../index';
+
+function setBrowserPipEnabled(enabled: boolean) {
+  Object.defineProperty(document, 'pictureInPictureEnabled', {
+    value: enabled,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('engageOnReady', () => {
+  beforeEach(() => {
+    isPipSupportedMock.mockReset();
+    enterPipMock.mockReset();
+    setBrowserPipEnabled(false);
+  });
+
+  afterEach(() => {
+    setBrowserPipEnabled(false);
+  });
+
+  it('returns without throwing when called with a null video element', async () => {
+    await expect(engageOnReady(null)).resolves.toBeUndefined();
+    expect(isPipSupportedMock).not.toHaveBeenCalled();
+    expect(enterPipMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to browser PiP when native plugin reports unsupported', async () => {
+    isPipSupportedMock.mockResolvedValue({ supported: false });
+    setBrowserPipEnabled(true);
+
+    const requestPiP = vi.fn().mockResolvedValue(undefined);
+    const videoEl = {
+      currentSrc: 'https://example.test/stream.m3u8',
+      currentTime: 12,
+      videoWidth: 1280,
+      videoHeight: 720,
+      requestPictureInPicture: requestPiP,
+    } as unknown as HTMLVideoElement;
+
+    await engageOnReady(videoEl);
+
+    expect(isPipSupportedMock).toHaveBeenCalledOnce();
+    expect(enterPipMock).not.toHaveBeenCalled();
+    expect(requestPiP).toHaveBeenCalledOnce();
+  });
+
+  it('uses native PiP when supported and a stream URL is present', async () => {
+    isPipSupportedMock.mockResolvedValue({ supported: true });
+    enterPipMock.mockResolvedValue({ position: 0 });
+
+    const videoEl = {
+      currentSrc: 'https://example.test/stream.m3u8',
+      currentTime: 7,
+      videoWidth: 1920,
+      videoHeight: 1080,
+    } as unknown as HTMLVideoElement;
+
+    await engageOnReady(videoEl, { eventId: 'evt-42' });
+
+    expect(enterPipMock).toHaveBeenCalledWith({
+      url: 'https://example.test/stream.m3u8',
+      position: 7,
+      aspectRatio: '1920:1080',
+    });
+  });
+
+  it('does not throw when no PiP path is available', async () => {
+    isPipSupportedMock.mockResolvedValue({ supported: false });
+    // pictureInPictureEnabled left undefined; element has no requestPictureInPicture
+
+    const videoEl = {
+      currentSrc: '',
+      currentTime: 0,
+      videoWidth: 0,
+      videoHeight: 0,
+    } as unknown as HTMLVideoElement;
+
+    await expect(engageOnReady(videoEl)).resolves.toBeUndefined();
+  });
+
+  it('swallows errors from native enterPip and continues to browser fallback', async () => {
+    isPipSupportedMock.mockResolvedValue({ supported: true });
+    enterPipMock.mockRejectedValue(new Error('boom'));
+    setBrowserPipEnabled(true);
+
+    const requestPiP = vi.fn().mockResolvedValue(undefined);
+    const videoEl = {
+      currentSrc: 'https://example.test/stream.m3u8',
+      currentTime: 0,
+      videoWidth: 640,
+      videoHeight: 480,
+      requestPictureInPicture: requestPiP,
+    } as unknown as HTMLVideoElement;
+
+    await expect(engageOnReady(videoEl)).resolves.toBeUndefined();
+    expect(requestPiP).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/plugins/pip/index.ts
+++ b/app/src/plugins/pip/index.ts
@@ -1,9 +1,76 @@
 import { registerPlugin } from '@capacitor/core';
 import type { PipPlugin } from './definitions';
+import { log, LogLevel } from '../../lib/logger';
 
 const Pip = registerPlugin<PipPlugin>('Pip', {
   web: () => import('./web').then((m) => new m.PipWeb()),
 });
+
+function browserPipEnabled(): boolean {
+  if (typeof document === 'undefined') return false;
+  return Boolean((document as { pictureInPictureEnabled?: boolean }).pictureInPictureEnabled);
+}
+
+/**
+ * Engage Picture-in-Picture for a `<video>` element on the first platform
+ * path that supports it. Safe to call when PiP is unsupported — logs and
+ * returns without throwing. Used by deep links (e.g. `?pip=auto`) and
+ * future glanceable surfaces.
+ */
+export async function engageOnReady(
+  videoEl: HTMLVideoElement | null | undefined,
+  opts?: { eventId?: string }
+): Promise<void> {
+  if (!videoEl) {
+    log.notifications('engageOnReady called with no video element', LogLevel.DEBUG);
+    return;
+  }
+
+  // 1. Native plugin (Android stream-URL PiP today).
+  try {
+    const { supported } = await Pip.isPipSupported();
+    if (supported && videoEl.currentSrc) {
+      const aspectRatio =
+        videoEl.videoWidth && videoEl.videoHeight
+          ? `${videoEl.videoWidth}:${videoEl.videoHeight}`
+          : undefined;
+      await Pip.enterPip({
+        url: videoEl.currentSrc,
+        position: videoEl.currentTime || 0,
+        aspectRatio,
+      });
+      log.notifications('engageOnReady: native PiP engaged', LogLevel.INFO, {
+        eventId: opts?.eventId,
+      });
+      return;
+    }
+  } catch (err) {
+    log.notifications('engageOnReady: native PiP failed, falling back', LogLevel.WARN, {
+      eventId: opts?.eventId,
+      error: (err as Error)?.message,
+    });
+  }
+
+  // 2. Browser-native PiP (web + Tauri WebView when available).
+  try {
+    if (browserPipEnabled() && typeof videoEl.requestPictureInPicture === 'function') {
+      await videoEl.requestPictureInPicture();
+      log.notifications('engageOnReady: browser PiP engaged', LogLevel.INFO, {
+        eventId: opts?.eventId,
+      });
+      return;
+    }
+  } catch (err) {
+    log.notifications('engageOnReady: browser PiP failed', LogLevel.WARN, {
+      eventId: opts?.eventId,
+      error: (err as Error)?.message,
+    });
+  }
+
+  log.notifications('engageOnReady: PiP not supported on this platform', LogLevel.INFO, {
+    eventId: opts?.eventId,
+  });
+}
 
 export * from './definitions';
 export { Pip };

--- a/app/src/plugins/suppression-store/__tests__/evaluators.test.ts
+++ b/app/src/plugins/suppression-store/__tests__/evaluators.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMuteActive,
+  isQuietHoursActive,
+  matchesNoiseFilter,
+  evaluateSuppression,
+  matchesAnyNoiseFilter,
+  entryAppliesToMonitor,
+} from '../evaluators';
+import {
+  type MuteEntry,
+  type QuietHoursEntry,
+  type NoiseFilterEntry,
+  type SuppressionEntry,
+  MONITOR_ALL,
+} from '../types';
+
+const baseMute = (overrides: Partial<MuteEntry> = {}): MuteEntry => ({
+  id: 'm1',
+  kind: 'mute',
+  profile_id: 'p1',
+  monitor_id: 'mon-1',
+  until: new Date(Date.now() + 60_000).toISOString(),
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+const baseQuiet = (overrides: Partial<QuietHoursEntry> = {}): QuietHoursEntry => ({
+  id: 'q1',
+  kind: 'quiet_hours',
+  profile_id: 'p1',
+  monitor_id_or_all: MONITOR_ALL,
+  start_local_time: '22:00',
+  end_local_time: '07:00',
+  weekday_mask: 0b1111111, // every day
+  label: 'Night',
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+const baseNoise = (overrides: Partial<NoiseFilterEntry> = {}): NoiseFilterEntry => ({
+  id: 'n1',
+  kind: 'noise_filter',
+  profile_id: 'p1',
+  monitor_id_or_all: MONITOR_ALL,
+  min_alarm_score: 30,
+  exclude_cause_patterns: [],
+  mode: 'hide',
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('isMuteActive', () => {
+  it('returns true when until is in the future', () => {
+    expect(isMuteActive(baseMute({ until: new Date(Date.now() + 5000).toISOString() }))).toBe(true);
+  });
+
+  it('returns false when until has passed', () => {
+    expect(isMuteActive(baseMute({ until: new Date(Date.now() - 5000).toISOString() }))).toBe(false);
+  });
+
+  it('returns false for malformed until', () => {
+    expect(isMuteActive(baseMute({ until: 'not-a-date' }))).toBe(false);
+  });
+});
+
+describe('isQuietHoursActive', () => {
+  // A Tuesday at 23:30
+  const tueNight = new Date('2026-04-28T23:30:00');
+  // A Saturday at 03:00 (Friday's window crossing midnight)
+  const satEarly = new Date('2026-05-02T03:00:00');
+  // A Wednesday at 09:00 — outside any 22:00-07:00 window
+  const wedMorning = new Date('2026-04-29T09:00:00');
+
+  it('matches a same-day window on a covered weekday', () => {
+    const entry = baseQuiet({
+      start_local_time: '21:00',
+      end_local_time: '23:59',
+      weekday_mask: 0b0000100, // Tuesday only (bit 2)
+    });
+    expect(isQuietHoursActive(entry, tueNight)).toBe(true);
+  });
+
+  it('does not match a same-day window outside its weekdays', () => {
+    const entry = baseQuiet({
+      start_local_time: '21:00',
+      end_local_time: '23:59',
+      weekday_mask: 0b0000010, // Monday only
+    });
+    expect(isQuietHoursActive(entry, tueNight)).toBe(false);
+  });
+
+  it('matches a midnight-crossing window — past start on the start day', () => {
+    // 22:00-07:00, Mon-Fri. Tue 23:30 is within window starting Tue.
+    const entry = baseQuiet({
+      start_local_time: '22:00',
+      end_local_time: '07:00',
+      weekday_mask: 0b0111110, // Mon-Fri (bits 1..5)
+    });
+    expect(isQuietHoursActive(entry, tueNight)).toBe(true);
+  });
+
+  it('matches a midnight-crossing window — before end, weekday based on yesterday', () => {
+    // 22:00-07:00 Mon-Fri. Saturday 03:00 belongs to Friday's window.
+    const entry = baseQuiet({
+      start_local_time: '22:00',
+      end_local_time: '07:00',
+      weekday_mask: 0b0111110, // Mon-Fri
+    });
+    expect(isQuietHoursActive(entry, satEarly)).toBe(true);
+  });
+
+  it('does not match a midnight-crossing window when yesterday is excluded', () => {
+    // 22:00-07:00 Sat only. Saturday 03:00 — start day is Friday (excluded).
+    const entry = baseQuiet({
+      start_local_time: '22:00',
+      end_local_time: '07:00',
+      weekday_mask: 0b1000000, // Saturday only
+    });
+    expect(isQuietHoursActive(entry, satEarly)).toBe(false);
+  });
+
+  it('does not match outside the time range', () => {
+    const entry = baseQuiet({
+      start_local_time: '22:00',
+      end_local_time: '07:00',
+      weekday_mask: 0b1111111,
+    });
+    expect(isQuietHoursActive(entry, wedMorning)).toBe(false);
+  });
+
+  it('returns false for empty weekday mask', () => {
+    expect(isQuietHoursActive(baseQuiet({ weekday_mask: 0 }), tueNight)).toBe(false);
+  });
+
+  it('returns false for malformed time', () => {
+    expect(isQuietHoursActive(baseQuiet({ start_local_time: '99:99' }), tueNight)).toBe(false);
+  });
+
+  it('returns false for zero-length window', () => {
+    expect(
+      isQuietHoursActive(baseQuiet({ start_local_time: '06:00', end_local_time: '06:00' }), tueNight)
+    ).toBe(false);
+  });
+});
+
+describe('matchesNoiseFilter', () => {
+  it('matches when score is below threshold', () => {
+    expect(matchesNoiseFilter(baseNoise({ min_alarm_score: 30 }), { alarm_score: 12 })).toBe(true);
+  });
+
+  it('does not match when score equals threshold', () => {
+    // strict inequality: 30 > 30 is false
+    expect(matchesNoiseFilter(baseNoise({ min_alarm_score: 30 }), { alarm_score: 30 })).toBe(false);
+  });
+
+  it('does not match when score is above threshold', () => {
+    expect(matchesNoiseFilter(baseNoise({ min_alarm_score: 30 }), { alarm_score: 80 })).toBe(false);
+  });
+
+  it('matches a cause-exclude pattern (case-insensitive)', () => {
+    expect(
+      matchesNoiseFilter(
+        baseNoise({ min_alarm_score: 0, exclude_cause_patterns: ['Continuous'] }),
+        { alarm_score: 100, cause_text: 'continuous recording' }
+      )
+    ).toBe(true);
+  });
+
+  it('does not match when cause_text is missing', () => {
+    expect(
+      matchesNoiseFilter(
+        baseNoise({ min_alarm_score: 0, exclude_cause_patterns: ['Continuous'] }),
+        { alarm_score: 100 }
+      )
+    ).toBe(false);
+  });
+
+  it('skips empty pattern strings', () => {
+    expect(
+      matchesNoiseFilter(
+        baseNoise({ min_alarm_score: 0, exclude_cause_patterns: [''] }),
+        { alarm_score: 100, cause_text: 'anything' }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when no input provided', () => {
+    expect(matchesNoiseFilter(baseNoise({ min_alarm_score: 30 }), {})).toBe(false);
+  });
+});
+
+describe('entryAppliesToMonitor', () => {
+  it('matches the wildcard', () => {
+    expect(entryAppliesToMonitor(MONITOR_ALL, 'mon-1')).toBe(true);
+  });
+  it('matches a specific id', () => {
+    expect(entryAppliesToMonitor('mon-1', 'mon-1')).toBe(true);
+  });
+  it('does not match a different id', () => {
+    expect(entryAppliesToMonitor('mon-1', 'mon-2')).toBe(false);
+  });
+});
+
+describe('evaluateSuppression', () => {
+  const ctx = {
+    profile_id: 'p1',
+    monitor_id: 'mon-1',
+    now: new Date('2026-04-28T23:30:00'),
+    alarm_score: 12,
+    cause_text: 'continuous',
+  };
+
+  it('returns null when no entries match', () => {
+    expect(evaluateSuppression(ctx, [])).toBeNull();
+  });
+
+  it('returns mute reason first (priority order)', () => {
+    const entries: SuppressionEntry[] = [
+      baseMute({ until: new Date(ctx.now.getTime() + 60_000).toISOString() }),
+      baseQuiet({ start_local_time: '00:00', end_local_time: '23:59', weekday_mask: 0b1111111 }),
+    ];
+    expect(evaluateSuppression(ctx, entries)?.kind).toBe('mute');
+  });
+
+  it('returns quiet_hours when no mute matches', () => {
+    const entries: SuppressionEntry[] = [
+      baseQuiet({
+        start_local_time: '22:00',
+        end_local_time: '07:00',
+        weekday_mask: 0b0111110, // Mon-Fri
+      }),
+    ];
+    expect(evaluateSuppression(ctx, entries)?.kind).toBe('quiet_hours');
+  });
+
+  it('returns noise_filter only when mode is hide', () => {
+    const dimEntries: SuppressionEntry[] = [
+      baseNoise({ min_alarm_score: 30, mode: 'dim' }),
+    ];
+    expect(evaluateSuppression(ctx, dimEntries)).toBeNull();
+
+    const hideEntries: SuppressionEntry[] = [
+      baseNoise({ min_alarm_score: 30, mode: 'hide' }),
+    ];
+    expect(evaluateSuppression(ctx, hideEntries)?.kind).toBe('noise_filter');
+  });
+
+  it('respects profile boundary', () => {
+    const entries: SuppressionEntry[] = [
+      baseMute({
+        profile_id: 'p2',
+        until: new Date(ctx.now.getTime() + 60_000).toISOString(),
+      }),
+    ];
+    expect(evaluateSuppression(ctx, entries)).toBeNull();
+  });
+
+  it('respects monitor boundary on monitor-specific entries', () => {
+    const entries: SuppressionEntry[] = [
+      baseQuiet({
+        monitor_id_or_all: 'mon-7',
+        start_local_time: '00:00',
+        end_local_time: '23:59',
+        weekday_mask: 0b1111111,
+      }),
+    ];
+    expect(evaluateSuppression(ctx, entries)).toBeNull();
+  });
+});
+
+describe('matchesAnyNoiseFilter', () => {
+  it('matches dim-mode rules too', () => {
+    const ctx = {
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      alarm_score: 5,
+    };
+    const entries: SuppressionEntry[] = [
+      baseNoise({ min_alarm_score: 10, mode: 'dim' }),
+    ];
+    expect(matchesAnyNoiseFilter(ctx, entries)).not.toBeNull();
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(
+      matchesAnyNoiseFilter(
+        { profile_id: 'p1', monitor_id: 'mon-1', alarm_score: 90 },
+        [baseNoise({ min_alarm_score: 10, mode: 'dim' })]
+      )
+    ).toBeNull();
+  });
+});

--- a/app/src/plugins/suppression-store/__tests__/web.test.ts
+++ b/app/src/plugins/suppression-store/__tests__/web.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { WebSuppressionStore } from '../web';
+import type { MuteEntry, QuietHoursEntry, NoiseFilterEntry } from '../types';
+
+function makeStore() {
+  let counter = 0;
+  const memory: Record<string, string> = {};
+  const storage = {
+    getItem: (k: string) => memory[k] ?? null,
+    setItem: (k: string, v: string) => {
+      memory[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete memory[k];
+    },
+  };
+  const store = new WebSuppressionStore({
+    storage,
+    newId: () => `id-${++counter}`,
+    now: () => '2026-04-28T12:00:00.000Z',
+  });
+  return { store, storage, raw: () => memory };
+}
+
+describe('WebSuppressionStore', () => {
+  let helpers = makeStore();
+
+  beforeEach(() => {
+    helpers = makeStore();
+  });
+
+  it('returns empty list when nothing stored', () => {
+    expect(helpers.store.list()).toEqual([]);
+  });
+
+  it('adds and lists entries with assigned id + created_at', () => {
+    const entry = helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+
+    expect(entry.id).toBe('id-1');
+    expect(entry.created_at).toBe('2026-04-28T12:00:00.000Z');
+    expect(helpers.store.list()).toEqual([entry]);
+  });
+
+  it('filters by profile_id and kind', () => {
+    helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+    helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p2',
+      monitor_id: 'mon-9',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+    helpers.store.add({
+      kind: 'noise_filter',
+      profile_id: 'p1',
+      monitor_id_or_all: '*',
+      min_alarm_score: 30,
+      exclude_cause_patterns: [],
+      mode: 'hide',
+    } as Omit<NoiseFilterEntry, 'id' | 'created_at'>);
+
+    expect(helpers.store.list({ profile_id: 'p1' })).toHaveLength(2);
+    expect(helpers.store.list({ kind: 'mute' })).toHaveLength(2);
+    expect(helpers.store.list({ profile_id: 'p2', kind: 'mute' })).toHaveLength(1);
+  });
+
+  it('updates an entry', () => {
+    const entry = helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+
+    const updated = helpers.store.update(entry.id, { until: '2026-04-30T00:00:00Z' } as Partial<MuteEntry>);
+    expect(updated && (updated as MuteEntry).until).toBe('2026-04-30T00:00:00Z');
+    expect(updated?.created_at).toBe(entry.created_at);
+  });
+
+  it('rejects cross-kind updates and returns the unchanged entry', () => {
+    const entry = helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+
+    const result = helpers.store.update(entry.id, {
+      kind: 'noise_filter' as 'mute',
+    });
+    expect(result?.kind).toBe('mute');
+    expect(helpers.store.list()).toHaveLength(1);
+  });
+
+  it('returns null when updating an unknown id', () => {
+    expect(helpers.store.update('does-not-exist', { until: '2026-01-01T00:00:00Z' })).toBeNull();
+  });
+
+  it('removes an entry by id', () => {
+    const entry = helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+
+    expect(helpers.store.remove(entry.id)).toBe(true);
+    expect(helpers.store.list()).toEqual([]);
+  });
+
+  it('returns false when removing an unknown id', () => {
+    expect(helpers.store.remove('nope')).toBe(false);
+  });
+
+  it('clears entries for a single profile only', () => {
+    helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p1',
+      monitor_id: 'mon-1',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+    helpers.store.add({
+      kind: 'mute',
+      profile_id: 'p2',
+      monitor_id: 'mon-9',
+      until: '2026-04-29T00:00:00Z',
+    } as Omit<MuteEntry, 'id' | 'created_at'>);
+
+    helpers.store.clearProfile('p1');
+    expect(helpers.store.list().map((e) => e.profile_id)).toEqual(['p2']);
+  });
+
+  it('survives malformed JSON in storage by resetting', () => {
+    const corrupted = makeStore();
+    corrupted.storage.setItem('zmng-suppression-store-v1', '{not json');
+    expect(corrupted.store.list()).toEqual([]);
+  });
+
+  it('round-trips entries via raw storage (persistence)', () => {
+    helpers.store.add({
+      kind: 'quiet_hours',
+      profile_id: 'p1',
+      monitor_id_or_all: '*',
+      start_local_time: '22:00',
+      end_local_time: '07:00',
+      weekday_mask: 0b1111111,
+      label: 'Night',
+    } as Omit<QuietHoursEntry, 'id' | 'created_at'>);
+
+    const serialized = helpers.raw()['zmng-suppression-store-v1'];
+    expect(serialized).toBeTruthy();
+    const reread = JSON.parse(serialized);
+    expect(reread).toHaveLength(1);
+    expect(reread[0].kind).toBe('quiet_hours');
+  });
+});

--- a/app/src/plugins/suppression-store/evaluators.ts
+++ b/app/src/plugins/suppression-store/evaluators.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure suppression-rule evaluators.
+ *
+ * No I/O, no state — given an entry and a context, return a verdict. Used
+ * by the push pipeline (native side will mirror this logic) and the
+ * Events list filter.
+ */
+
+import {
+  type MuteEntry,
+  type QuietHoursEntry,
+  type NoiseFilterEntry,
+  type SuppressionContext,
+  type SuppressionEntry,
+  type SuppressionReason,
+  MONITOR_ALL,
+} from './types';
+
+export function isMuteActive(entry: MuteEntry, now: Date = new Date()): boolean {
+  const expiry = Date.parse(entry.until);
+  if (Number.isNaN(expiry)) return false;
+  return expiry > now.getTime();
+}
+
+/**
+ * True when the current local time falls inside the window AND today's
+ * weekday is set in `weekday_mask`. Windows that cross midnight are active
+ * when current >= start OR current < end, with the weekday check applied to
+ * whichever date the start belongs to.
+ */
+export function isQuietHoursActive(entry: QuietHoursEntry, now: Date = new Date()): boolean {
+  const start = parseHHMM(entry.start_local_time);
+  const end = parseHHMM(entry.end_local_time);
+  if (start === null || end === null) return false;
+  if (entry.weekday_mask === 0) return false;
+
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const todayBit = 1 << now.getDay();
+
+  if (start === end) return false; // zero-length window
+
+  if (start < end) {
+    // Same-day window
+    if (!(entry.weekday_mask & todayBit)) return false;
+    return currentMinutes >= start && currentMinutes < end;
+  }
+
+  // Midnight-crossing window: active either after start today (if today is set)
+  // or before end today (if yesterday — the start day — is set).
+  if (currentMinutes >= start) {
+    return Boolean(entry.weekday_mask & todayBit);
+  }
+  if (currentMinutes < end) {
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const yesterdayBit = 1 << yesterday.getDay();
+    return Boolean(entry.weekday_mask & yesterdayBit);
+  }
+  return false;
+}
+
+interface NoiseFilterTarget {
+  alarm_score?: number;
+  cause_text?: string;
+}
+
+export function matchesNoiseFilter(entry: NoiseFilterEntry, target: NoiseFilterTarget): boolean {
+  if (typeof target.alarm_score === 'number' && entry.min_alarm_score > target.alarm_score) {
+    return true;
+  }
+  if (target.cause_text && entry.exclude_cause_patterns.length > 0) {
+    const haystack = target.cause_text.toLowerCase();
+    for (const pattern of entry.exclude_cause_patterns) {
+      if (!pattern) continue;
+      if (haystack.includes(pattern.toLowerCase())) return true;
+    }
+  }
+  return false;
+}
+
+export function entryAppliesToMonitor(
+  scope: string,
+  monitorId: string
+): boolean {
+  return scope === MONITOR_ALL || scope === monitorId;
+}
+
+/**
+ * End-to-end decision for a single push or rendered event. Returns the
+ * first matching reason in priority order: mute → quiet_hours → noise_filter (hide).
+ * Noise-filter rules in `mode: dim` never suppress here — callers handle dim
+ * separately (Events list rendering).
+ */
+export function evaluateSuppression(
+  ctx: SuppressionContext,
+  entries: SuppressionEntry[]
+): SuppressionReason | null {
+  const now = ctx.now ?? new Date();
+
+  for (const entry of entries) {
+    if (entry.kind !== 'mute') continue;
+    if (entry.profile_id !== ctx.profile_id) continue;
+    if (entry.monitor_id !== ctx.monitor_id) continue;
+    if (isMuteActive(entry, now)) {
+      return { kind: 'mute', entry };
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.kind !== 'quiet_hours') continue;
+    if (entry.profile_id !== ctx.profile_id) continue;
+    if (!entryAppliesToMonitor(entry.monitor_id_or_all, ctx.monitor_id)) continue;
+    if (isQuietHoursActive(entry, now)) {
+      return { kind: 'quiet_hours', entry };
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.kind !== 'noise_filter') continue;
+    if (entry.mode !== 'hide') continue;
+    if (entry.profile_id !== ctx.profile_id) continue;
+    if (!entryAppliesToMonitor(entry.monitor_id_or_all, ctx.monitor_id)) continue;
+    if (matchesNoiseFilter(entry, { alarm_score: ctx.alarm_score, cause_text: ctx.cause_text })) {
+      return { kind: 'noise_filter', entry };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns `true` when any noise-filter rule (hide OR dim) matches the
+ * event for the active profile/monitor — used by the Events list to apply
+ * the dim treatment regardless of mode.
+ */
+export function matchesAnyNoiseFilter(
+  ctx: SuppressionContext,
+  entries: SuppressionEntry[]
+): NoiseFilterEntry | null {
+  for (const entry of entries) {
+    if (entry.kind !== 'noise_filter') continue;
+    if (entry.profile_id !== ctx.profile_id) continue;
+    if (!entryAppliesToMonitor(entry.monitor_id_or_all, ctx.monitor_id)) continue;
+    if (matchesNoiseFilter(entry, { alarm_score: ctx.alarm_score, cause_text: ctx.cause_text })) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function parseHHMM(value: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}

--- a/app/src/plugins/suppression-store/index.ts
+++ b/app/src/plugins/suppression-store/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './evaluators';
+export { WebSuppressionStore } from './web';

--- a/app/src/plugins/suppression-store/index.ts
+++ b/app/src/plugins/suppression-store/index.ts
@@ -1,3 +1,11 @@
 export * from './types';
 export * from './evaluators';
 export { WebSuppressionStore } from './web';
+export {
+  listSuppressionEntries,
+  addSuppressionEntry,
+  updateSuppressionEntry,
+  removeSuppressionEntry,
+  clearProfileSuppression,
+  useSuppressionEntries,
+} from './singleton';

--- a/app/src/plugins/suppression-store/singleton.ts
+++ b/app/src/plugins/suppression-store/singleton.ts
@@ -1,0 +1,76 @@
+/**
+ * App-wide singleton wrapper around `WebSuppressionStore`.
+ *
+ * Adds a tiny pub/sub layer so React components can subscribe via
+ * `useSyncExternalStore`. Mutations are wrapped to notify subscribers.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { WebSuppressionStore } from './web';
+import type { SuppressionEntry } from './types';
+
+const store = new WebSuppressionStore();
+const listeners = new Set<() => void>();
+
+let snapshot: SuppressionEntry[] = store.list();
+function refreshSnapshot() {
+  snapshot = store.list();
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): SuppressionEntry[] {
+  return snapshot;
+}
+
+/** Read all entries (synchronous; reflects last mutation). */
+export function listSuppressionEntries(filter?: {
+  profile_id?: string;
+  kind?: SuppressionEntry['kind'];
+}): SuppressionEntry[] {
+  return store.list(filter);
+}
+
+export function addSuppressionEntry(
+  entry: Parameters<WebSuppressionStore['add']>[0]
+): SuppressionEntry {
+  const result = store.add(entry);
+  refreshSnapshot();
+  return result;
+}
+
+export function updateSuppressionEntry(
+  id: string,
+  patch: Parameters<WebSuppressionStore['update']>[1]
+): SuppressionEntry | null {
+  const result = store.update(id, patch);
+  refreshSnapshot();
+  return result;
+}
+
+export function removeSuppressionEntry(id: string): boolean {
+  const result = store.remove(id);
+  refreshSnapshot();
+  return result;
+}
+
+export function clearProfileSuppression(profile_id: string): void {
+  store.clearProfile(profile_id);
+  refreshSnapshot();
+}
+
+/**
+ * React hook returning all suppression entries for the current profile,
+ * subscribed to the singleton — re-renders on any mutation.
+ */
+export function useSuppressionEntries(profileId: string | undefined): SuppressionEntry[] {
+  const all = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (!profileId) return [];
+  return all.filter((e) => e.profile_id === profileId);
+}

--- a/app/src/plugins/suppression-store/types.ts
+++ b/app/src/plugins/suppression-store/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Suppression-store entry types.
+ *
+ * The store is the single source of truth consumed by:
+ *   - the iOS Service Extension and Android FCM service before display
+ *   - the in-app Events list filter
+ *   - the Triage Center management UI
+ *
+ * Entries are profile-scoped and persisted across app kill / reboot.
+ * See specs/notification-mute-store/spec.md for the full contract.
+ */
+
+export const MONITOR_ALL = '*' as const;
+
+export interface MuteEntry {
+  id: string;
+  kind: 'mute';
+  profile_id: string;
+  monitor_id: string;
+  /** Absolute ISO 8601 timestamp at which the mute expires. */
+  until: string;
+  created_at: string;
+}
+
+export interface QuietHoursEntry {
+  id: string;
+  kind: 'quiet_hours';
+  profile_id: string;
+  /** Specific monitor_id or `"*"` for "all monitors in this profile". */
+  monitor_id_or_all: string;
+  /** Local-time start, format `"HH:MM"` (24h). */
+  start_local_time: string;
+  /** Local-time end, format `"HH:MM"` (24h). End may be earlier than start (midnight crossing). */
+  end_local_time: string;
+  /** Bitfield. Bit 0 = Sunday … bit 6 = Saturday. */
+  weekday_mask: number;
+  label: string;
+  created_at: string;
+}
+
+export interface NoiseFilterEntry {
+  id: string;
+  kind: 'noise_filter';
+  profile_id: string;
+  monitor_id_or_all: string;
+  /** Strict threshold: rule matches when `min_alarm_score > event.alarm_score`. */
+  min_alarm_score: number;
+  /** Substrings (case-insensitive) tested against `event.cause_text`. */
+  exclude_cause_patterns: string[];
+  mode: 'hide' | 'dim';
+  created_at: string;
+}
+
+export type SuppressionEntry = MuteEntry | QuietHoursEntry | NoiseFilterEntry;
+export type SuppressionEntryKind = SuppressionEntry['kind'];
+
+export type SuppressionReason =
+  | { kind: 'mute'; entry: MuteEntry }
+  | { kind: 'quiet_hours'; entry: QuietHoursEntry }
+  | { kind: 'noise_filter'; entry: NoiseFilterEntry };
+
+/** Inputs to an end-to-end suppression decision. */
+export interface SuppressionContext {
+  profile_id: string;
+  monitor_id: string;
+  /** Optional — quiet-hours evaluation needs a clock. */
+  now?: Date;
+  /** Optional — noise-filter evaluation needs the event's score. */
+  alarm_score?: number;
+  cause_text?: string;
+}

--- a/app/src/plugins/suppression-store/web.ts
+++ b/app/src/plugins/suppression-store/web.ts
@@ -1,0 +1,124 @@
+/**
+ * Web/foreground implementation of the suppression store.
+ *
+ * Backed by `localStorage` under a versioned key. The Capacitor WebView on
+ * iOS/Android also reads this storage during foreground operation, but the
+ * native iOS Service Extension and Android FCM service must read from
+ * App Group / SharedPreferences instead — those bridges live in §4.2 / §4.3
+ * (deferred).
+ */
+
+import type { SuppressionEntry } from './types';
+import { log, LogLevel } from '../../lib/logger';
+
+const STORAGE_KEY = 'zmng-suppression-store-v1';
+
+type Storage = Pick<typeof localStorage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export interface WebSuppressionStoreOptions {
+  /** Override for tests. Defaults to `globalThis.localStorage`. */
+  storage?: Storage;
+  /** Override for tests / determinism. Defaults to `crypto.randomUUID()`. */
+  newId?: () => string;
+  /** Override for tests / determinism. Defaults to `() => new Date().toISOString()`. */
+  now?: () => string;
+}
+
+export class WebSuppressionStore {
+  private readonly storage: Storage;
+  private readonly newId: () => string;
+  private readonly now: () => string;
+
+  constructor(opts: WebSuppressionStoreOptions = {}) {
+    this.storage = opts.storage ?? globalThis.localStorage;
+    this.newId = opts.newId ?? defaultNewId;
+    this.now = opts.now ?? (() => new Date().toISOString());
+  }
+
+  list(filter?: {
+    profile_id?: string;
+    kind?: SuppressionEntry['kind'];
+  }): SuppressionEntry[] {
+    const all = this.readAll();
+    if (!filter) return all;
+    return all.filter((e) => {
+      if (filter.profile_id && e.profile_id !== filter.profile_id) return false;
+      if (filter.kind && e.kind !== filter.kind) return false;
+      return true;
+    });
+  }
+
+  add(
+    entry: Omit<SuppressionEntry, 'id' | 'created_at'>
+  ): SuppressionEntry {
+    const created: SuppressionEntry = {
+      ...entry,
+      id: this.newId(),
+      created_at: this.now(),
+    } as SuppressionEntry;
+    const all = this.readAll();
+    all.push(created);
+    this.writeAll(all);
+    return created;
+  }
+
+  update(id: string, patch: Partial<SuppressionEntry>): SuppressionEntry | null {
+    const all = this.readAll();
+    const idx = all.findIndex((e) => e.id === id);
+    if (idx === -1) return null;
+    const existing = all[idx];
+    if (patch.kind && patch.kind !== existing.kind) {
+      log.notifications('suppression-store: rejected cross-kind update', LogLevel.WARN, {
+        id,
+        from: existing.kind,
+        to: patch.kind,
+      });
+      return existing;
+    }
+    const merged = { ...existing, ...patch, id: existing.id, kind: existing.kind } as SuppressionEntry;
+    all[idx] = merged;
+    this.writeAll(all);
+    return merged;
+  }
+
+  remove(id: string): boolean {
+    const all = this.readAll();
+    const next = all.filter((e) => e.id !== id);
+    if (next.length === all.length) return false;
+    this.writeAll(next);
+    return true;
+  }
+
+  clearProfile(profile_id: string): void {
+    const next = this.readAll().filter((e) => e.profile_id !== profile_id);
+    this.writeAll(next);
+  }
+
+  private readAll(): SuppressionEntry[] {
+    const raw = this.storage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed as SuppressionEntry[];
+    } catch (err) {
+      log.notifications('suppression-store: parse failed; resetting', LogLevel.ERROR, {
+        error: (err as Error)?.message,
+      });
+      this.storage.removeItem(STORAGE_KEY);
+      return [];
+    }
+  }
+
+  private writeAll(entries: SuppressionEntry[]): void {
+    this.storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  }
+}
+
+function defaultNewId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // RFC4122-ish fallback for environments without crypto.randomUUID
+  return 'sup-' + Math.random().toString(36).slice(2, 12) + Date.now().toString(36);
+}

--- a/app/src/stores/__tests__/eventReviewState.test.ts
+++ b/app/src/stores/__tests__/eventReviewState.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { useEventReviewStateStore } from '../eventReviewState';
+
+describe('EventReviewState Store', () => {
+  beforeEach(() => {
+    useEventReviewStateStore.setState({ profileReviewed: {} });
+    localStorage.clear();
+  });
+
+  describe('isReviewed', () => {
+    it('returns false for unreviewed event', () => {
+      const { isReviewed } = useEventReviewStateStore.getState();
+      expect(isReviewed('profile-1', 'event-123')).toBe(false);
+    });
+
+    it('returns true for reviewed event', () => {
+      const { markReviewed, isReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      expect(isReviewed('profile-1', 'event-123')).toBe(true);
+    });
+
+    it('returns false for event reviewed in different profile', () => {
+      const { markReviewed, isReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      expect(isReviewed('profile-2', 'event-123')).toBe(false);
+    });
+  });
+
+  describe('markReviewed', () => {
+    it('marks event reviewed', () => {
+      const { markReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      expect(getReviewed('profile-1')).toEqual(['event-123']);
+    });
+
+    it('does not duplicate if event already reviewed', () => {
+      const { markReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      markReviewed('profile-1', 'event-123');
+      expect(getReviewed('profile-1')).toEqual(['event-123']);
+    });
+
+    it('keeps reviewed sets isolated per profile', () => {
+      const { markReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      markReviewed('profile-2', 'event-456');
+
+      expect(getReviewed('profile-1')).toEqual(['event-123']);
+      expect(getReviewed('profile-2')).toEqual(['event-456']);
+    });
+  });
+
+  describe('markManyReviewed', () => {
+    it('marks all provided events reviewed in a single batched write', () => {
+      const { markManyReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', ['e1', 'e2', 'e3']);
+      expect(getReviewed('profile-1')).toEqual(['e1', 'e2', 'e3']);
+    });
+
+    it('skips already-reviewed events without duplicating', () => {
+      const { markReviewed, markManyReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'e2');
+      markManyReviewed('profile-1', ['e1', 'e2', 'e3']);
+      expect(getReviewed('profile-1')).toEqual(['e2', 'e1', 'e3']);
+    });
+
+    it('handles empty input as a no-op', () => {
+      const { markManyReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', []);
+      expect(getReviewed('profile-1')).toEqual([]);
+    });
+
+    it('does not affect other profiles', () => {
+      const { markReviewed, markManyReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-2', 'e9');
+      markManyReviewed('profile-1', ['e1', 'e2']);
+
+      expect(getReviewed('profile-1')).toEqual(['e1', 'e2']);
+      expect(getReviewed('profile-2')).toEqual(['e9']);
+    });
+
+    it('completes a 500-item batch quickly', () => {
+      const { markManyReviewed, getReviewedCount } = useEventReviewStateStore.getState();
+      const ids = Array.from({ length: 500 }, (_, i) => `e${i}`);
+      const start = performance.now();
+      markManyReviewed('profile-1', ids);
+      const elapsedMs = performance.now() - start;
+      expect(getReviewedCount('profile-1')).toBe(500);
+      // The bulk action SHALL not block the UI for more than 100ms (spec)
+      expect(elapsedMs).toBeLessThan(100);
+    });
+  });
+
+  describe('unmarkReviewed', () => {
+    it('removes event from reviewed set', () => {
+      const { markReviewed, unmarkReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'event-123');
+      unmarkReviewed('profile-1', 'event-123');
+      expect(getReviewed('profile-1')).toEqual([]);
+    });
+
+    it('does not error if unmarking unreviewed event', () => {
+      const { unmarkReviewed, getReviewed } = useEventReviewStateStore.getState();
+      unmarkReviewed('profile-1', 'event-123');
+      expect(getReviewed('profile-1')).toEqual([]);
+    });
+
+    it('only removes the specified event', () => {
+      const { markManyReviewed, unmarkReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', ['a', 'b', 'c']);
+      unmarkReviewed('profile-1', 'b');
+      expect(getReviewed('profile-1')).toEqual(['a', 'c']);
+    });
+
+    it('does not affect other profiles', () => {
+      const { markReviewed, unmarkReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'e1');
+      markReviewed('profile-2', 'e1');
+
+      unmarkReviewed('profile-1', 'e1');
+
+      expect(getReviewed('profile-1')).toEqual([]);
+      expect(getReviewed('profile-2')).toEqual(['e1']);
+    });
+  });
+
+  describe('toggleReviewed', () => {
+    it('marks if not reviewed', () => {
+      const { toggleReviewed, isReviewed } = useEventReviewStateStore.getState();
+      toggleReviewed('profile-1', 'e1');
+      expect(isReviewed('profile-1', 'e1')).toBe(true);
+    });
+
+    it('unmarks if already reviewed', () => {
+      const { markReviewed, toggleReviewed, isReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'e1');
+      toggleReviewed('profile-1', 'e1');
+      expect(isReviewed('profile-1', 'e1')).toBe(false);
+    });
+  });
+
+  describe('clearReviewed', () => {
+    it('clears all reviewed events for a profile', () => {
+      const { markManyReviewed, clearReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', ['a', 'b', 'c']);
+      clearReviewed('profile-1');
+      expect(getReviewed('profile-1')).toEqual([]);
+    });
+
+    it('does not affect other profiles', () => {
+      const { markReviewed, clearReviewed, getReviewed } = useEventReviewStateStore.getState();
+      markReviewed('profile-1', 'e1');
+      markReviewed('profile-2', 'e2');
+
+      clearReviewed('profile-1');
+
+      expect(getReviewed('profile-1')).toEqual([]);
+      expect(getReviewed('profile-2')).toEqual(['e2']);
+    });
+
+    it('does not error if clearing empty set', () => {
+      const { clearReviewed, getReviewed } = useEventReviewStateStore.getState();
+      clearReviewed('profile-1');
+      expect(getReviewed('profile-1')).toEqual([]);
+    });
+  });
+
+  describe('getReviewedCount', () => {
+    it('returns 0 for profile with nothing reviewed', () => {
+      const { getReviewedCount } = useEventReviewStateStore.getState();
+      expect(getReviewedCount('profile-1')).toBe(0);
+    });
+
+    it('returns the size of the reviewed set', () => {
+      const { markManyReviewed, getReviewedCount } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', ['a', 'b', 'c']);
+      expect(getReviewedCount('profile-1')).toBe(3);
+    });
+
+    it('updates after unmark', () => {
+      const { markManyReviewed, unmarkReviewed, getReviewedCount } = useEventReviewStateStore.getState();
+      markManyReviewed('profile-1', ['a', 'b']);
+      unmarkReviewed('profile-1', 'a');
+      expect(getReviewedCount('profile-1')).toBe(1);
+    });
+  });
+});

--- a/app/src/stores/eventReviewState.ts
+++ b/app/src/stores/eventReviewState.ts
@@ -1,0 +1,139 @@
+/**
+ * Event Review-State Store
+ *
+ * Tracks which events the user has marked reviewed, per profile.
+ * Reviewed-state is a primitive consumed by the Events list (visual dim,
+ * "Show reviewed" toggle), the dashboard recent-events widget, and the
+ * notification "Reviewed" action drain path.
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { log, LogLevel } from '../lib/logger';
+
+interface EventReviewState {
+  // event-id sets per profile
+  profileReviewed: Record<string, string[]>;
+
+  isReviewed: (profileId: string, eventId: string) => boolean;
+  markReviewed: (profileId: string, eventId: string) => void;
+  markManyReviewed: (profileId: string, eventIds: string[]) => void;
+  unmarkReviewed: (profileId: string, eventId: string) => void;
+  toggleReviewed: (profileId: string, eventId: string) => void;
+  getReviewed: (profileId: string) => string[];
+  getReviewedCount: (profileId: string) => number;
+  clearReviewed: (profileId: string) => void;
+}
+
+export const useEventReviewStateStore = create<EventReviewState>()(
+  persist(
+    (set, get) => ({
+      profileReviewed: {},
+
+      isReviewed: (profileId, eventId) => {
+        const reviewed = get().profileReviewed[profileId] || [];
+        return reviewed.includes(eventId);
+      },
+
+      markReviewed: (profileId, eventId) => {
+        set((state) => {
+          const reviewed = state.profileReviewed[profileId] || [];
+          if (reviewed.includes(eventId)) return state;
+
+          log.profile(`Event ${eventId} marked reviewed`, LogLevel.INFO, {
+            profileId,
+            eventId,
+          });
+
+          return {
+            profileReviewed: {
+              ...state.profileReviewed,
+              [profileId]: [...reviewed, eventId],
+            },
+          };
+        });
+      },
+
+      markManyReviewed: (profileId, eventIds) => {
+        if (eventIds.length === 0) return;
+
+        set((state) => {
+          const existing = state.profileReviewed[profileId] || [];
+          const existingSet = new Set(existing);
+          const additions: string[] = [];
+          for (const id of eventIds) {
+            if (!existingSet.has(id)) {
+              existingSet.add(id);
+              additions.push(id);
+            }
+          }
+          if (additions.length === 0) return state;
+
+          log.profile(`Bulk marked reviewed`, LogLevel.INFO, {
+            profileId,
+            added: additions.length,
+            requested: eventIds.length,
+          });
+
+          return {
+            profileReviewed: {
+              ...state.profileReviewed,
+              [profileId]: [...existing, ...additions],
+            },
+          };
+        });
+      },
+
+      unmarkReviewed: (profileId, eventId) => {
+        set((state) => {
+          const reviewed = state.profileReviewed[profileId] || [];
+          if (!reviewed.includes(eventId)) return state;
+
+          log.profile(`Event ${eventId} unmarked`, LogLevel.INFO, {
+            profileId,
+            eventId,
+          });
+
+          return {
+            profileReviewed: {
+              ...state.profileReviewed,
+              [profileId]: reviewed.filter((id) => id !== eventId),
+            },
+          };
+        });
+      },
+
+      toggleReviewed: (profileId, eventId) => {
+        const state = get();
+        if (state.isReviewed(profileId, eventId)) {
+          state.unmarkReviewed(profileId, eventId);
+        } else {
+          state.markReviewed(profileId, eventId);
+        }
+      },
+
+      getReviewed: (profileId) => get().profileReviewed[profileId] || [],
+
+      getReviewedCount: (profileId) =>
+        (get().profileReviewed[profileId] || []).length,
+
+      clearReviewed: (profileId) => {
+        set((state) => {
+          log.profile(`Cleared reviewed events`, LogLevel.INFO, {
+            profileId,
+            count: state.profileReviewed[profileId]?.length || 0,
+          });
+          return {
+            profileReviewed: {
+              ...state.profileReviewed,
+              [profileId]: [],
+            },
+          };
+        });
+      },
+    }),
+    {
+      name: 'zmng-event-review-state-v1',
+    }
+  )
+);

--- a/app/src/tests/setup.ts
+++ b/app/src/tests/setup.ts
@@ -80,6 +80,14 @@ class MockWebSocket {
 
 global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
 
+// Mock ResizeObserver (used by Radix Slider, Popover sizing, etc.)
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
 // Mock Audio for notification sounds
 global.AudioContext = vi.fn(() => ({
   createOscillator: vi.fn(() => ({

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -21,9 +21,31 @@ On desktop, hovering over a thumbnail for a moment shows a 400px-wide preview an
 
 Filter events using the controls at the top:
 
-- **Date range** - Select a start and end date
+- **Date range** - Select a start and end date, or use the quick-range buttons (Today, 24h, 7d, etc.)
 - **Monitor** - Show events from a specific camera only
 - **Groups** - Filter by monitor group
+- **Cause / notes search** - Type any term to find matching events (the inline bar searches across cause text, notes, and monitor name)
+- **Minimum alarm score** - Drag the score slider to filter out low-score noise
+- **Today's high-score** - One-tap preset that sets the date range to today and the minimum score to 50
+
+### Reviewed events
+
+Each event card has a green checkmark button. Tap it to mark the event reviewed; tap again to unmark.
+
+- **Reviewed events are hidden by default**, so the list stays focused on what still needs your attention.
+- A **Show reviewed** toggle in the filter popover brings them back into view, rendered at 50% opacity with the checkmark icon so they're easy to distinguish.
+- The **Mark all reviewed** button (next to Refresh) acts on every event currently visible in the filtered list, capped at 500 per click. A toast confirms how many were marked.
+
+Reviewed state is profile-scoped and persists across app restarts.
+
+### Noise filter rules
+
+Noise-filter rules let you suppress low-value events at the source. Configure them in **Triage Center** (see {doc}`notifications`). Rules can either:
+
+- **Hide** matching events from the list and notifications, or
+- **Dim** them in the list while still letting notifications through.
+
+Hide-mode events can be temporarily revealed by enabling **Show filtered** in the filter popover; they appear with a small filter icon so you know why they were normally suppressed.
 
 ## Event Playback
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -66,6 +66,50 @@ Each history entry shows:
 
 Tap a notification entry to jump to the corresponding event.
 
+## Triage Center
+
+The **Triage Center** (Notification Settings → "Triage Center") is the single place to manage how notifications are silenced and filtered for the active profile. It has four tabs:
+
+### Mutes
+
+Lists ad-hoc mutes — currently silenced monitors and when they expire. Use **+1h** to extend or the trash icon to clear. Mutes are typically created by tapping the "Mute monitor 1h" action on a notification (this action ships with the native release).
+
+### Quiet Hours
+
+Recurring time-of-day windows during which notifications are suppressed for the active profile.
+
+- Pick a label (e.g. "Sleep"), start and end time, and which weekdays the window applies to.
+- Windows that cross midnight (e.g. 22:00–07:00) are handled correctly — the active range belongs to the day the window starts.
+- Empty weekday selection is rejected at save time.
+
+### Noise Filter
+
+Rules that suppress events with a low alarm score or matching cause text. Each rule has:
+
+- A **minimum alarm score** — events below this are matched.
+- An optional **comma-separated list of cause patterns** — case-insensitive substring match against the event's cause text.
+- A **mode**: *Dim in list* (event still appears, dimmed) or *Hide from list and notifications*.
+
+The same rules apply to both the Events list (see {doc}`events`) and the notification pipeline once the native release lands — you only configure them once.
+
+### Priority
+
+Per-monitor priority (high / normal / low / silent) ships with the native release; the tab shows a placeholder for now.
+
+### How suppression works together
+
+When a push arrives, suppression is evaluated in this order:
+
+1. **Ad-hoc mute** wins first — silenced explicitly.
+2. **Quiet hours** wins next — silenced on schedule, even when priority is high.
+3. **Noise filter (hide mode)** wins last — silenced for being below threshold or matching cause-exclude.
+
+Anything that survives all three is presented at the priority configured for that monitor.
+
+## In-tab Quick-Look (web)
+
+On web, a slim strip at the bottom of the viewport shows the five most recent events with timestamps. Click any chip to jump to its detail page. The strip is hidden on phone-portrait viewports below 480px and can be dismissed for the session via the × button (it returns next time you open the tab). The functional equivalent on iOS and Android is a home-screen widget; on Tauri desktop it will be a system-tray popover (both ship with the native release).
+
 ## Troubleshooting
 
 **No in-app notifications (ES mode)**

--- a/openspec/changes/add-10s-notification-triage/.openspec.yaml
+++ b/openspec/changes/add-10s-notification-triage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-26

--- a/openspec/changes/add-10s-notification-triage/design.md
+++ b/openspec/changes/add-10s-notification-triage/design.md
@@ -1,0 +1,236 @@
+## Context
+
+zmNinjaNg currently delivers ZoneMinder events to users via FCM push (ES mode and Direct mode). The iOS side has a `NotificationServiceExtension` that downloads an image URL from the FCM payload and attaches it; on Android, Capacitor's default push plugin produces a plain title+body notification. The Events list shows a flat unfiltered stream with a hidden filter popover. There is no notion of "reviewed" — every alert keeps nagging until the user opens its detail.
+
+The user-facing flow on a fresh push is: glance → tap → cold start (3–8 s) → JS routing → event detail load → maybe play stream. Triage cannot happen on the lock screen because the notification carries almost no signal beyond "Motion detected on Monitor 1," and there is no way to act on a notification without launching the app. Inside the app, finding "the moment that mattered" requires hunting through a list dominated by false-alarm noise.
+
+The goal of this change is for the user to triage a push or browse recent events in under 10 seconds without opening the app for the common case. The decisions below put as much load as possible on Tier 1 (read at lock screen / glance at widget), Tier 2 (expand + action / list filter), and Tier 3 (probe via deep-link to existing PiP), and add an in-app review-state model so dismissals stick across surfaces.
+
+Stakeholders: zmNinjaNg client (iOS, Android, web, Tauri desktop), zmeventnotificationNg (ES) which controls the FCM payload, and ZoneMinder Direct mode (read-only for us — we accept whatever ZM sends).
+
+### Relationship to prior PROJECT.md
+
+The prior `.planning/PROJECT.md` (commit `4698007`) defined the same milestone with the same Core Value statement. This OpenSpec change is the realization of that milestone, with two deliberate divergences:
+
+1. **ES payload changes are in scope here**, where PROJECT.md framed the milestone as client-only with ES changes deferred. The user explicitly authorized this update during the explore-phase conversation that produced this change. The ES additions are strictly additive to keep the back-compat profile flat.
+2. **Single OpenSpec change covering all six milestone hypotheses**, rather than six sequential changes. The user authorized this consolidation. `tasks.md` phases the internal work to mitigate the resulting size.
+
+All other prior PROJECT.md positions are preserved: no Critical Alerts, no Live Activities, no Watch, no geofencing, no cloud, no ML, no Live-view redesign, functional-equivalent parity across platforms, milestone scope ~2–4 weeks (this proposal does not commit to that timeline; estimates are deferred to plan-phase).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A user receiving a push can decide "real / not real / mute / reviewed" within 10 seconds, primarily on the lock screen, secondarily in the expanded notification, without launching the app for the common case.
+- A user opening the Events list can locate any specific event in under 10 seconds via the quick-search filter bar.
+- A user glancing at a widget / tray / dock can answer "anything new and worth my time?" without launching the app.
+- The Reviewed state is consistent across surfaces (notification action, list bulk action, individual card action all converge).
+- Suppression — ad-hoc mute, recurring quiet-hours, noise-filter rules — is a single store consulted by both the push pipeline and the Events list filter.
+- Per-monitor priority maps cleanly to OS notification importance on both iOS and Android, with `silent` fully suppressing display.
+- iOS, Android, Tauri desktop, and web each expose a glanceable "latest events" surface — functional equivalents, not pixel parity.
+- All ES payload additions are optional and back-compatible.
+- All user-facing strings are localized in en, de, es, fr, zh, including extension-shipped strings and Android `strings.xml` accessed by the FCM service.
+
+**Non-Goals:**
+- Live Activities / Dynamic Island.
+- iOS Notification Content Extension (custom expanded UI).
+- iOS Critical Alerts entitlement — App Store rejects general home-security/surveillance use cases (per prior `.planning/research/PITFALLS.md`); standard `.timeSensitive` + Android `IMPORTANCE_HIGH` cover ~95% of the UX.
+- Apple Watch / Wear OS app.
+- Home-screen widget on Tauri (use system-tray instead) or a Progressive Web App push channel on web (use the in-tab dock instead).
+- Geofence-based arm/disarm.
+- Cloud / off-device storage / account sync.
+- Server-side mute or quiet-hours on ES.
+- New client-side ML / object-detection models.
+- Live-view or Montage redesign.
+- Any improvement for ZM Direct-mode users beyond what ZM core sends.
+- Replacing the existing in-app FCM toast/dedup pipeline — new native paths must coexist with it for foreground delivery.
+
+## Decisions
+
+### D1. Suppression is client-side, single store, evaluated before display
+
+A unified profile-scoped store holds three entry kinds: ad-hoc mutes, recurring quiet-hours, and noise-filter rules. Suppression evaluation runs in the iOS Service Extension and Android `FirebaseMessagingService` before the notification is shown. The same store is read by the Events list filter, so list and notification suppression always agree.
+
+**Alternatives considered:**
+- *Server-side suppression on ES.* Rejected: requires ES API changes, breaks offline semantics, adds round-trip in iOS extension action handlers (which have tight time/network budgets), and decouples list filter from notification filter.
+- *Two separate stores* (one for notifications, one for list). Rejected: drift inevitable; user surprised when a "muted" monitor still floods the list.
+
+### D2. Strong-default escape hatch via PiP-on-tap deep link
+
+The Live notification action does open the app, but routes directly to `MonitorDetail?pip=auto`. The existing PiP plugin engages on mount, so the user sees a small live overlay rather than the dashboard. This is technically an app launch but counts as the "strong default" because the user did not invoke the full UI.
+
+**Alternatives considered:**
+- *iOS Notification Content Extension.* Closer to ideal but is the heaviest piece of new native code on the table; deferred.
+- *Always launch into dashboard.* Defeats the goal.
+
+### D3. Locale duplication into extension/service bundles
+
+The iOS extension and Android `FirebaseMessagingService` run outside the React i18n context. Decision: ship a small set of templated strings (≤ ~12 keys) inside the extension bundle (`Localizable.strings`) and Android resources (`strings.xml`), per language. The extension/service reads the user's selected locale from App Group `UserDefaults` (iOS) / `SharedPreferences` (Android), which the React app writes whenever language changes. A build-time check asserts every extension key has values in all 5 locales.
+
+### D4. ES payload contract is additive only
+
+```
+required (for any new behavior):
+  monitor_id           string
+  monitor_name         string
+  event_id             string
+  started_at           ISO8601 string
+  profile_id           string
+
+strong (Tier-1 read benefit):
+  object_labels        [{label: string, confidence: number 0..1}]
+  image_url_jpg        string
+  alarm_score          number 0..100   // ZM-native; powers noise filter
+
+nice (Tier-1/2 polish):
+  image_urls_strip     [string]   // length 3
+  color_hex            string
+  category_id          string
+  cause_text           string     // ZM-native; powers cause-exclude patterns
+```
+
+All fields are optional on the wire. Older ES servers and ZM Direct mode produce notifications using whatever fields are present, falling back to today's "Motion detected on <monitor>" body.
+
+### D5. Android: wrap, don't replace, the Capacitor push plugin
+
+Install a custom `FirebaseMessagingService` in the Android manifest with priority above the Capacitor plugin's. It runs first on every push:
+1. Reads the suppression store; if matched, drops the push and returns.
+2. If app is in foreground, hands the message to the Capacitor pipeline so JS can render the in-app toast and dedup with the WebSocket. No system notification is shown.
+3. If app is in background, builds the rich `NotificationCompat` notification (BigPictureStyle + addAction) with the channel selected by per-monitor priority, and shows it.
+
+A spike (Open Question §1) confirms whether this wrapping is tractable. If not, the Android plan reroutes to "replace + rewrite the JS pipeline" with a re-estimate.
+
+### D6. Action handlers run natively without app launch (except Live)
+
+iOS: `UNNotificationCategory` registered at app launch with three actions (`mute1h`, `reviewed`, `live`). Mute and Reviewed run in the background extension (no `.foreground`); Live launches the app via `.foreground` and a deep link.
+
+Android: `addAction()` `PendingIntent`s target a `BroadcastReceiver` (mute, reviewed) or an `Activity` (live). Receivers run in the FCM service's process.
+
+The Reviewed action writes to a "review-pending" shared file/list that the React app drains on next foreground, merging into the new `eventReviewState` Zustand store.
+
+### D7. Multi-frame strip composition
+
+When `image_urls_strip` is present (length 3), iOS and Android extensions parallel-fetch all 3 URLs, composite horizontally, and attach as a single JPEG. Single-image fallback when absent. Partial composite (n<3) when one or two URLs fail.
+
+### D8. Profile scoping is mandatory at the payload boundary
+
+Every ES push for a multi-profile user must carry `profile_id`. The suppression store is keyed `(profile_id, monitor_id_or_all)`; the review-state store is keyed `(profile_id, event_id)`. Action handlers preserve `profile_id` from the originating notification. Without `profile_id`, no new behavior triggers — the system falls back to today's pipeline rather than risk incorrect suppression.
+
+### D9. Per-monitor priority maps directly to OS importance
+
+Priority is one of `high` / `normal` / `low` / `silent`, stored profile-scoped per monitor.
+
+| Priority | iOS `interruptionLevel` | Android channel | Effect |
+|---|---|---|---|
+| `high` | `.timeSensitive` | `zmn_high` (`IMPORTANCE_HIGH`) | Bypasses Focus on iOS where allowed; heads-up + sound on Android. |
+| `normal` (default) | `.active` | `zmn_normal` (`IMPORTANCE_DEFAULT`) | Today's behavior. |
+| `low` | `.passive` | `zmn_low` (`IMPORTANCE_LOW`) | Silent, no peek. |
+| `silent` | (suppressed) | `zmn_silent` (`IMPORTANCE_NONE`) | Never displayed; appears in history only. |
+
+Mapping happens after the suppression check passes; a `silent` monitor's push is recorded in history but never shown. The four channels are created at first launch; users with custom OS-level channel settings on the legacy single channel are migrated by writing the prior channel's preferences to `zmn_normal` and informing them via in-app notice on first run after upgrade.
+
+**Alternatives considered:**
+- *One channel per monitor.* Rejected: channel proliferation, unmanageable on prosumer setups with 30+ cameras.
+
+### D10. Reviewed state lives in a Zustand store, sourced from three places
+
+`eventReviewState` (Zustand, profile-scoped, persisted via `localStorage` adapter under a versioned key) holds `Set<event_id>`. Sources of truth:
+
+1. **In-app**: per-card "mark reviewed" affordance and bulk-mark-reviewed action on the Events page.
+2. **Notification action**: the Reviewed action writes the event to a shared "review-pending" file/list (App Group on iOS, shared `SharedPreferences` on Android); the app drains it on next foreground.
+3. **Triage Center**: not directly — Triage Center manages suppression, not review state.
+
+Visual treatment: reviewed events are dimmed (50% opacity on `EventCard`), the Reviewed state is shown as a small checkmark icon, and a per-list toggle ("Show reviewed") defaults to off in mobile portrait, on in desktop. Bulk-mark-reviewed acts on the current filtered set.
+
+### D11. Quick-search filter bar replaces the popover for the common case
+
+The hidden filter popover stays available for advanced filters; the common-case filters (date range, monitor multiselect, class, cause contains, alarm score min) appear inline as a sticky filter bar above the Events list. State is profile-scoped and persisted across navigations within a session; full reset on profile switch. The bar is collapsible on phone portrait (where space is constrained) and exposes a single-tap "today's high-score events" preset.
+
+### D12. Noise filter is a list of rules, not a single global threshold
+
+A noise-filter rule has `(profile_id, monitor_id_or_all, min_alarm_score, exclude_cause_patterns)`. Multiple rules per profile are supported; on evaluation, rules are OR'd (any match suppresses). The same rules apply to both notification suppression and Events list dimming/hiding (per-rule `mode: hide | dim`). A simple "score < 30 means below threshold" default rule is offered at first run.
+
+### D13. Quick-look surface is platform-specific by design
+
+Functional equivalents, not pixel parity:
+
+- **iOS**: WidgetKit widget, three sizes (small / medium / large). Driven by App Group event-snapshot file.
+- **Android**: AppWidget, three sizes via `AppWidgetProvider` minWidth/minHeight. Driven by `ContentProvider`-exposed event-snapshot.
+- **Tauri**: `tauri-plugin-systemtray` (or current equivalent compatible with Tauri 2). Tray icon + click-to-popover listing recent events.
+- **Web**: `QuickLookDock.tsx` — a small persistent strip mounted in the root layout. Dismissable per session via `sessionStorage`.
+
+A shared **event-snapshot writer** in `app/src/services/notifications.ts` writes the latest 5 events to the platform-specific source on every successful event delivery. Snapshot format is JSON: `{updated_at, events: [{event_id, monitor_id, monitor_name, started_at, image_url, top_label}]}`. Each surface decides how many to render given its size.
+
+**Alternatives considered:**
+- *PWA push for web.* Rejected: spotty cross-browser support; the in-tab dock is reachable by every user with the tab open.
+- *iOS / Android Live Activity for "in-progress" events.* Out of scope per prior PROJECT.md.
+
+### D14. ZM Direct mode degrades; widgets/tray/dock still work
+
+Direct-mode pushes lack `object_labels`, `category_id`, `cause_text`, etc. They still produce a basic system notification (no actions, no rich strip). They DO still update the event-snapshot, so widgets/tray/dock still surface them. The Events list quick-search and review-state work identically regardless of push origin.
+
+## Risks / Trade-offs
+
+**[R1: Capacitor + native FCM coexistence on Android may not be tractable]** → 1–2 day spike before implementation: write a stub `FirebaseMessagingService`, configure manifest priority, verify it runs first and that messages reach the Capacitor JS pipeline when handed off. If the spike fails, escalate to D5's rejected alternative (replace + rewrite JS handler) and re-estimate.
+
+**[R2: iOS App Group + shared Keychain + WidgetKit target provisioning]** → Standard but App Store Connect and provisioning-profile changes are required for App Group, Keychain Sharing, and the new Widget Extension target. Allow buffer for the maintainer's Apple side. No code workaround.
+
+**[R3: Extension localization drift]** → Mitigated by keeping the extension string set minimal (≤ ~12 keys), centralizing the key list in a shared constants file, and adding a build-time check that asserts every extension key has a translation in all 5 locales.
+
+**[R4: Profile scoping discipline]** → Mitigated by making `profile_id` required for any new behavior and falling back to today's pipeline when absent. Spec scenarios cover the missing-`profile_id` path.
+
+**[R5: FCM payload size near 4KB limit]** → Worst-case payload (3 strip URLs, 5 object labels, monitor name, all nice fields, `cause_text` to 200 chars) is under 2 KB. Headroom exists; truncate `cause_text` in ES if exceeded.
+
+**[R6: Notification action handlers have tight time and network budgets]** → Mitigated by D1 (no network in mute/reviewed handlers); both write to local shared store. Live action runs `.foreground` so launches the full app — no budget concern.
+
+**[R7: Suppression hidden from the user]** → Mitigated by the Triage Center listing all active mutes, quiet-hours, priority overrides, and noise-filter rules per profile; mutes naturally expire; quiet-hours show next-active time; priority overrides show on the monitor card in the existing Monitors page.
+
+**[R8: Older ES servers + new client]** → No new behavior triggers (no `profile_id` → fallback). User sees today's notification.
+
+**[R9: New ES server + older client]** → Client ignores unknown fields. User sees today's notification.
+
+**[R10: Android `NotificationChannel` migration]** → Existing single channel's settings preserved by writing them to `zmn_normal`; users informed via one-time in-app notice. Worst case: user re-enables sound on the new channel.
+
+**[R11: Tauri system-tray plugin compatibility]** → Confirm `tauri-plugin-systemtray` compatibility under Tauri 2 during plan-phase; if blocked, fall back to a foreground-window quick-look launched by a global keyboard shortcut. Rule #16 means JS and Rust packages must move together.
+
+**[R12: Widget data freshness]** → iOS / Android widgets refresh on OS schedule (typically 5–15 min). Mitigated by writing the snapshot on every push and showing a `formatRelative(updated_at)` "X ago" timestamp so staleness is explicit. Force-refresh via WidgetCenter / AppWidgetManager on push receipt where the OS allows it.
+
+**[R13: Scope size]** → This is a milestone-level change in one OpenSpec change. `tasks.md` phases the internal work and gates Android-side tasks behind R1's spike outcome. If plan-phase reveals the change is too large to land safely, this design supports a clean split: the existing 9 capabilities can become 3–5 follow-on changes (push pipeline, Events page improvements, Quick-look surfaces) without restructuring the spec content.
+
+**[R14: Bulk-mark-reviewed performance]** → Bulk acting on a large filtered set could write many entries at once. Mitigated by a single-write batch API on `eventReviewState` and by capping bulk operations at the currently-rendered window (e.g., 500 events).
+
+## Migration Plan
+
+This change ships as a single client release plus an additive ES update. Rollout:
+
+1. Land the additive ES payload changes in zmeventnotificationNg first; deploy to test environments.
+2. Land the client change behind a small set of profile-scoped feature flags (rule-#7 compatible) — `useNativeFcmService` (Android), `useTriageCenter` (in-app surfaces), `useQuickLookDock` (web), `useQuickLookWidget` (mobile widgets), `useQuickLookTray` (Tauri). Default on; rollback by toggling.
+3. Verify Tier-1 lock-screen behavior on real devices for both platforms with both old and new ES servers.
+4. Verify suppression entries (mute / quiet-hours / noise-filter) survive app kill / reboot.
+5. Verify Reviewed state converges across notification action, list action, and bulk action.
+6. Verify quick-look surface refreshes on each platform within its OS budget.
+7. Public release.
+
+**Rollback strategies**:
+- Android FCM service breaks foreground delivery → toggle `useNativeFcmService` off, fall back to today's Capacitor-only path.
+- Triage Center buggy → toggle `useTriageCenter` off, surface only basic Notification Settings.
+- Widget / tray / dock buggy → individual platform toggles off.
+- iOS extension changes are additive and roll back by shipping a previous extension build.
+
+**Data migration**:
+- New `eventReviewState` Zustand store: empty on first run; no migration needed.
+- New `notification-mute-store` entries: empty on first run.
+- Android `NotificationChannel`s: prior single channel's user-tweaked settings copied to `zmn_normal`; one-time in-app notice on first launch after upgrade.
+- Existing notification history: unchanged.
+
+## Open Questions
+
+1. **Spike outcome (R1).** Does Capacitor's push plugin tolerate a wrapping `FirebaseMessagingService`? Required answer before tasks dependent on §7 begin.
+2. **Mute durations.** 1h only as the action button, longer durations from the in-app Triage Center? (Lean: yes.)
+3. **Strip vs. single image when both sent.** Strip wins. (Settled.)
+4. **Object label localization.** Client-side via a fixed vocabulary `{person, vehicle, animal, package, unknown}`. (Lean: yes; requires extension `Localizable.strings` keys.)
+5. **Notification category set.** Single `zmEventStandard` category for now; add more if event kinds diverge.
+6. **Quiet-hours collision with priority.** If quiet-hours says suppress but priority is `high` (`.timeSensitive`), which wins? Lean: quiet-hours wins (user explicitly scheduled silence; `time-sensitive` is for OS-level Focus, not user-scheduled silence).
+7. **Web in-tab dock placement.** Top vs. bottom? Lean: bottom (matches mobile thumb-zone, doesn't fight with `Toolbar`); revisit in plan-phase with a UX sanity check.
+8. **Tauri tray plugin pin.** Confirm exact plugin name + version pair (JS + Rust) before tasks.
+9. **Bulk-mark-reviewed scope.** Filtered window only, or "all events through end of date X"? Lean: filtered window with a clear count badge; "all from X" can be added later.
+10. **Noise-filter default rule.** Should we ship with `score < 30 → dim` enabled by default, or off until the user opts in? Lean: off by default; surface as a one-tap "enable noise filter" prompt the first time the Events list shows >50 low-score events.

--- a/openspec/changes/add-10s-notification-triage/proposal.md
+++ b/openspec/changes/add-10s-notification-triage/proposal.md
@@ -1,0 +1,135 @@
+## Why
+
+When a push notification fires, the user has one question: *is this real, do I care?* Today the only way to answer it is to open the app, wait for cold start, route to event detail, and load a stream — well past 10 seconds. Most events are false alarms (pets, wind, headlights), so the app burns the user's attention on triage that the OS notification surfaces and a small set of in-app affordances could handle directly.
+
+This change is the full **10-second triage milestone**: it moves triage out of the React app shell and into (a) the OS notification layer, (b) targeted improvements in the Events list, and (c) a glanceable home-screen / tray / dock surface — so obvious cases resolve at the lock screen, less-obvious cases resolve in expanded notifications or via Events-list filters, and only ambiguous cases need to launch the full app. Cross-platform parity is achieved by *functional equivalents* (widget on mobile = system-tray on Tauri = in-tab dock on web), not pixel parity.
+
+This proposal is the OpenSpec realization of the milestone described in the prior `.planning/PROJECT.md`. The two divergences from that document are deliberate and recorded in `design.md` § "Relationship to prior PROJECT.md":
+
+1. ES (`zmeventnotificationNg`) payload changes are now in scope (the prior document had this client-only). The user explicitly authorized this trade.
+2. The same milestone but consolidated into a single OpenSpec change rather than 6 sequential ones.
+
+## What Changes
+
+### Push pipeline (lock-screen + expand triage)
+
+- ES FCM payload gains optional fields: `monitor_id`, `monitor_name`, `event_id`, `started_at`, `profile_id` (required for new behavior); `object_labels[{label,confidence}]`, `image_url_jpg`, `alarm_score` (strong); `image_urls_strip[3]`, `color_hex`, `category_id`, `cause_text` (nice). All additions are optional on the wire — older ES servers degrade to today's behavior, older clients ignore unknown fields.
+- iOS `NotificationServiceExtension` extended: locale-aware title formatted from `object_labels` + `monitor_name`; multi-frame strip composition; reads cross-process suppression store (mute / quiet-hours / noise-filter / priority-silent) and suppresses if matched; honours `category_id` and per-monitor priority.
+- iOS adds `UNNotificationCategory` and `UNNotificationAction` handlers for **Mute monitor 1h**, **Reviewed**, and **Live**. Mute and Reviewed run natively without app launch; Live deep-links into `MonitorDetail?pip=auto`.
+- iOS gains an App Group entitlement and shared Keychain so extension and main app share the suppression store and (optionally) credentials.
+- Android replaces / wraps the Capacitor default push handler with a custom `FirebaseMessagingService` that builds rich notifications (`BigPictureStyle`, `addAction` for the same three actions), formats the same locale-aware title, and runs the same suppression check before display. Coexists with the existing JS in-app FCM toast/dedup flow when the app is in the foreground.
+- iOS notification interruption level (`.passive` / `.active` / `.timeSensitive`) and Android `NotificationChannel` importance are mapped from the per-monitor priority setting.
+
+### Suppression model (mute, quiet-hours, noise-filter)
+
+- Profile-scoped, client-side **suppression store** (NOT server-side). Three entry kinds, all consulted before a notification is shown:
+  - **Ad-hoc mutes** — `(profile_id, monitor_id, until)`. Action-button writes; expires automatically.
+  - **Recurring quiet-hours windows** — `(profile_id, monitor_id_or_all, start_local_time, end_local_time, weekday_mask)`. User-configured.
+  - **Noise-filter rules** — `(profile_id, monitor_id_or_all, min_alarm_score, exclude_cause_patterns)`. Apply to both notification suppression *and* the Events list filter (single source of truth).
+- Suppression evaluation runs in the iOS Service Extension and Android FCM service before display. Survives app kill and reboot.
+
+### Per-monitor notification priority
+
+- Per-monitor priority field added to profile settings: `high` / `normal` / `low` / `silent`.
+- Maps at notification time to iOS `interruptionLevel` and Android `NotificationChannel` importance. `silent` suppresses display entirely. **BREAKING — Android channels:** four new channels (`zmn_high`, `zmn_normal`, `zmn_low`, `zmn_silent`) replace the single legacy channel; users may need to re-confirm channel preferences.
+
+### Events page improvements
+
+- **Reviewed state** per event: stored in a profile-scoped Zustand store, persisted; visual distinction in `EventCard` and list views; bulk-mark-reviewed action; integrates with the notification "Reviewed" action so dismissing from the lock screen marks the underlying event reviewed.
+- **Noise filter** UI: applies the suppression-store noise-filter rules to the Events list (hide / dim events below score or matching cause-exclude). Single source of truth shared with the notification suppression path.
+- **Quick-search filter bar** on the Events page: unified date range, monitor multiselect, object class, cause text contains, alarm score min — all visible at once, replacing today's hidden filter popover for the common case (popover stays available for advanced).
+
+### Triage Center screen
+
+- Renames the planned "Snooze Management" screen to **Triage Center** and consolidates: active mutes (with Clear / Extend), quiet-hours schedules (add / edit / delete), per-monitor priority (high/normal/low/silent), noise-filter rules (per-profile and per-monitor). Reachable from Notification Settings.
+
+### Quick-look surfaces (functional-equivalent parity)
+
+- **iOS** home-screen widget (WidgetKit, separate target): three sizes; shows latest event thumbnail, monitor name, time-ago, and object label per latest event; tap deep-links to that event or `MonitorDetail`.
+- **Android** home-screen widget (`AppWidgetProvider`): same data, three sizes (1x1, 2x2, 4x2).
+- **Tauri** desktop: system-tray / menu-bar quick-look with a popover listing the last N events, click-to-open. Uses `tauri-plugin-systemtray`.
+- **Web**: in-tab dock — a small persistent strip at the top or bottom of the app showing the last N events with thumbnail + monitor + time, present on every route, dismissable per-session.
+- Widget / tray / dock data source: a shared snapshot file written by the app (App Group on iOS, content provider on Android, app-data dir on Tauri, IndexedDB/localStorage on web). Updates whenever a new event is delivered.
+
+### Live action deep-link
+
+- Existing PiP plugin extended to auto-engage when `MonitorDetail` mounts with `?pip=auto`.
+
+### Localization & dedup
+
+- Extension/service-shipped `Localizable.strings` and Android `strings.xml` for all 5 supported languages (en, de, es, fr, zh) — extensions cannot use the React i18n bundle, so a small set of templated strings (≤ ~12 keys) is duplicated and read using locale from App Group `UserDefaults`.
+- ES/Direct deduplication for foreground delivery is preserved.
+
+### Documentation
+
+- `docs/user-guide/notifications.md` updated for the lock-screen behavior, action buttons, priority, quiet-hours, mute lifecycle, and graceful degradation against older servers.
+- `docs/user-guide/events.md` updated for reviewed state, quick-search filter bar, and noise filter.
+- `docs/user-guide/dashboard.md` (or new `quick-look.md`) updated for the widget / tray / dock surfaces.
+- `docs/developer-guide/` updated per rule #4 for new APIs, hooks, plugin shims, and deep-link contract.
+
+## Capabilities
+
+### New Capabilities
+- `push-notification-triage`: end-to-end behavior of the FCM push pipeline from ES payload through OS notification surface — payload contract, locale-aware title formatting, rich attachments, action set, suppression rules, priority mapping, and graceful degradation. iOS and Android.
+- `notification-mute-store`: profile-scoped, cross-process suppression store covering ad-hoc mutes, recurring quiet-hours, and noise-filter rules. Single source of truth consumed by the iOS extension, Android FCM service, and the in-app Events list filter.
+- `monitor-notification-priority`: per-monitor priority (high / normal / low / silent) mapped to iOS `interruptionLevel` and Android `NotificationChannel` importance at notification time.
+- `monitor-live-deeplink`: deep-link route into `MonitorDetail` with auto-PiP engagement on mount. Used by the Live action and reusable from any future deep link source (widget, tray, dock).
+- `snooze-management-screen`: in-app **Triage Center** screen — manages all suppression-store entries (mutes, quiet-hours, priority, noise-filter rules) per profile. Entry point from Notification Settings.
+- `event-review-state`: per-event reviewed/unreviewed state, bulk mark-reviewed, visual distinction in lists, and integration with the notification "Reviewed" action so cross-surface state stays consistent.
+- `event-noise-filter`: applies the suppression-store noise-filter rules to the Events list (alarm-score threshold, cause-text exclude patterns) — same data the push pipeline consumes.
+- `event-quick-search`: unified filter bar on the Events page (date range, monitor multiselect, class, cause contains, alarm score min) for sub-second event location.
+- `quick-look-surfaces`: home-screen widget on iOS and Android, system-tray quick-look on Tauri desktop, in-tab dock on web — functional equivalents driven from a shared event-snapshot source.
+
+### Modified Capabilities
+<!-- No existing OpenSpec specs in this repository. All work is new capabilities. The PROJECT.md / .planning/ artifacts are external context, not OpenSpec specs. -->
+
+## Impact
+
+**Code (large surface)**
+- `app/src/components/NotificationHandler.tsx`, `app/src/services/notifications.ts`, `app/src/services/pushNotifications.ts`: foreground dedup updated for new payload; integrate with suppression store; preserve ES/Direct dedup.
+- `app/src/pages/NotificationHistory.tsx`, `app/src/pages/NotificationSettings.tsx`: link to Triage Center, surface reviewed-state badges.
+- `app/src/pages/Events.tsx`, `app/src/components/events/EventCard.tsx`, `app/src/components/events/EventListView.tsx`, `app/src/components/events/EventsFilterPopover.tsx`: reviewed-state visuals + quick-search filter bar + noise-filter integration.
+- `app/src/pages/MonitorDetail.tsx`: read `pip=auto` query param; engage PiP on stream-ready.
+- `app/src/plugins/pip/`: expose `engageOnReady(videoEl)` API safe to call when PiP is unsupported.
+- New `app/src/plugins/suppression-store/`: thin Capacitor plugin shim for the cross-process suppression store (iOS Swift, Android Kotlin, web shim using `localStorage`).
+- New `app/src/pages/TriageCenter.tsx` (replaces the originally-planned Snooze Management screen).
+- New `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted).
+- `app/ios/App/ImageNotification/NotificationService.swift`: locale resolution, suppression check, priority mapping, strip composition.
+- New iOS sources: `MuteStore.swift`, notification category registration, action handlers, App Group accessors, per-language `Localizable.strings`, **WidgetKit target** for the home-screen widget.
+- New Android sources: `ZMNFirebaseMessagingService.kt`, `MuteStore.kt`, action `BroadcastReceiver`s, four `NotificationChannel`s, per-language `strings.xml`, `AppWidgetProvider` for the home-screen widget.
+- New Tauri sources: system-tray icon + popover via `tauri-plugin-systemtray` (or equivalent — version-pinned to current Tauri 2 setup), event-snapshot reader.
+- New web component: `app/src/components/layout/QuickLookDock.tsx` mounted in the root layout, dismissable per-session.
+- `app/src/locales/{en,de,es,fr,zh}/translation.json`: new strings for Triage Center, quick-search bar, reviewed-state, noise filter, priority labels, widget/dock empty states.
+
+**APIs / external systems**
+- ES payload contract (zmeventnotificationNg): additive only. Coordination required with the ES project to publish the new fields. Older ES versions remain supported.
+- ZM Direct mode: no improvement beyond what ZM core already sends; client gracefully formats whatever fields are present.
+- FCM payload size: stays well under 4KB even with all nice fields populated.
+
+**Dependencies**
+- iOS App Group entitlement and shared Keychain — App Store Connect provisioning-profile updates required.
+- iOS WidgetKit target — Xcode project configuration updates required.
+- Tauri: confirm `tauri-plugin-systemtray` (or current-equivalent) compatibility with the Tauri 2 + Rust setup; JS and Rust packages must move together (rule #16).
+- No new Capacitor plugins. The existing push plugin is wrapped (Android) or coexists (iOS) without replacement.
+
+**Out of scope (explicit non-goals — partly mirrors prior PROJECT.md)**
+- Live Activities / Dynamic Island.
+- iOS Notification Content Extension (custom expanded UI).
+- iOS Critical Alerts entitlement (App Store rejects general home-security/surveillance use cases per `.planning/research/PITFALLS.md`).
+- Apple Watch / Wear OS app.
+- Geofence-based arm/disarm.
+- Cloud / off-device storage / account sync.
+- Server-side mute on ES; server-side quiet-hours.
+- New client-side ML / object detection models — the noise filter consumes existing ZM `score` and `cause` text only.
+- Live view / Montage redesign — out of scope per prior milestone scope.
+- Any improvement for ZM Direct-mode users beyond what ZM core sends.
+
+**Risks (full design treatment in `design.md`)**
+1. Capacitor + native FCM coexistence on Android — needs a pre-implementation spike (highest risk).
+2. iOS App Group + shared Keychain provisioning + WidgetKit target setup.
+3. Extension/service-shipped localization drift (extensions outside the React i18n context).
+4. Profile scoping discipline — every payload and store entry must carry `profile_id`.
+5. Android `NotificationChannel` migration from one legacy channel to four — users with custom per-channel settings need clear handling.
+6. Tauri system-tray plugin compatibility under Tauri 2.
+7. Widget data freshness on iOS / Android — widgets refresh on OS schedule, not on arbitrary push; staleness must be explicit (timestamp shown).
+8. Scope size — this is a milestone-level change inside one OpenSpec change. `tasks.md` phases the work internally.

--- a/openspec/changes/add-10s-notification-triage/specs/event-noise-filter/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/event-noise-filter/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Noise-Filter Rule Application to Events List
+
+The Events list SHALL evaluate every noise-filter rule from the suppression store (capability `notification-mute-store` kind `"noise_filter"`) against each rendered event. When ANY rule matches an event, the event SHALL be either hidden or dimmed depending on the rule's `mode`.
+
+Match definition (mirrors push pipeline):
+- `min_alarm_score > event.score` (rule's threshold strictly exceeds event's score), OR
+- ANY string in `exclude_cause_patterns` is found as a case-insensitive substring of `event.cause`.
+
+If multiple rules match, the strictest mode wins (`hide` > `dim`).
+
+#### Scenario: Event below score threshold (hide mode)
+- **WHEN** a rule has `min_alarm_score = 30, mode = hide` and an event has `score = 12`
+- **THEN** the event is excluded from the rendered list
+
+#### Scenario: Event below score threshold (dim mode)
+- **WHEN** a rule has `min_alarm_score = 30, mode = dim` and an event has `score = 12`
+- **THEN** the event is rendered with the dimmed-by-noise visual treatment
+
+#### Scenario: Cause-exclude match
+- **WHEN** a rule has `exclude_cause_patterns = ["Continuous"]` and an event has `cause = "Continuous Recording"`
+- **THEN** the rule matches and `mode` decides hide vs. dim
+
+#### Scenario: Multiple rules — hide wins over dim
+- **WHEN** two rules both match an event, one in `mode: dim` and the other in `mode: hide`
+- **THEN** the event is hidden
+
+#### Scenario: No `cause` text on event
+- **WHEN** an event has no `cause` text
+- **THEN** cause-exclude patterns SHALL NOT match; only the score check applies
+
+### Requirement: Single Source of Truth with Push Pipeline
+
+The Events list SHALL consume the SAME store entries that the push pipeline consumes. Adding, editing, or deleting a noise-filter rule via Triage Center SHALL affect both surfaces immediately (or on next focus, whichever is sooner). There SHALL NOT be a separate "list filter" rule set.
+
+#### Scenario: Rule added in Triage Center reflects in Events list
+- **WHEN** the user adds a hide-mode rule and the Events list is open
+- **THEN** matching events SHALL be removed from the list on next refresh / focus
+
+#### Scenario: Rule deleted in Triage Center un-hides events
+- **WHEN** the user deletes a hide-mode rule
+- **THEN** previously hidden events SHALL reappear in the list on next refresh / focus
+
+### Requirement: Visual Treatment Distinct From Reviewed-Dim
+
+The "dimmed by noise filter" treatment SHALL be visually distinguishable from the "dimmed because reviewed" treatment so the user can tell at a glance which suppression caused which fade. Suggested treatment: noise-dimmed events use a small "low-score" iconography in addition to opacity, while reviewed-dimmed events use a checkmark.
+
+#### Scenario: Noise-dimmed event shows distinct icon
+- **WHEN** an event is rendered as noise-dimmed (rule `mode: dim` matched)
+- **THEN** a localized "low-score" / "filtered" icon SHALL be visible on the card alongside the dim treatment
+
+#### Scenario: Event matches both noise-dim and reviewed
+- **WHEN** an event is both reviewed AND matches a noise-dim rule
+- **THEN** both icons SHALL be visible; opacity SHALL not stack lower than 50% (single dim)
+
+### Requirement: One-Tap Bypass
+
+The user SHALL be able to temporarily show all noise-filtered events in the Events list via a "Show filtered" toggle exposed inline in the quick-search filter bar (capability `event-quick-search`). The toggle SHALL be session-scoped (not persisted) so the next session starts in the user's configured-filter state.
+
+#### Scenario: Show filtered toggled on
+- **WHEN** the user taps "Show filtered" with active hide-mode rules
+- **THEN** previously hidden events appear (rendered with the noise-dim treatment to indicate they would normally be filtered) for the duration of the session
+
+#### Scenario: Session ends
+- **WHEN** the user closes and reopens the app
+- **THEN** the "Show filtered" toggle SHALL reset to off
+
+### Requirement: First-Run Default Rule Offer
+
+When the Events list first detects more than 50 events with `score < 30` in the user's history, the app SHALL offer (one-time, dismissable) to add a default noise-filter rule (`min_alarm_score = 30, mode = dim, monitor_id_or_all = "*"`). The user SHALL be able to accept, decline, or "ask me later." Once dismissed (accept or decline), the offer SHALL not reappear.
+
+#### Scenario: Threshold reached, user accepts
+- **WHEN** the threshold of 50 low-score events is reached and the user accepts the offer
+- **THEN** a noise-filter rule SHALL be written to the suppression store and the list SHALL re-evaluate
+
+#### Scenario: User declines
+- **WHEN** the user declines
+- **THEN** no rule SHALL be written; the offer SHALL not reappear
+
+#### Scenario: User dismisses with "ask later"
+- **WHEN** the user picks "ask later"
+- **THEN** the offer SHALL re-appear at the next session that meets the threshold
+
+### Requirement: Localization in 5 Languages
+
+All user-facing strings (icon tooltips, "Show filtered" toggle label, first-run offer copy and buttons, dimmed-card iconography accessibility labels) SHALL be localized in en, de, es, fr, zh per rule #5.
+
+#### Scenario: Each supported locale renders without missing keys
+- **WHEN** the user switches locale and interacts with noise-filter UI
+- **THEN** all visible strings SHALL be localized

--- a/openspec/changes/add-10s-notification-triage/specs/event-quick-search/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/event-quick-search/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Quick-Search Filter Bar
+
+The Events page SHALL expose a quick-search filter bar above the events list. The bar SHALL contain the following common-case filters, all visible at once on tablet / desktop and collapsible on phone portrait:
+
+- **Date range** — presets (Today, Last 7 days, Last 30 days, Custom) plus a custom date-range picker.
+- **Monitor multiselect** — chip-style multiselect of the current profile's monitors.
+- **Object class** — chip-style multiselect of `{person, vehicle, animal, package, unknown}` (matching the extension-shipped vocabulary).
+- **Cause contains** — free-text input matching against `event.cause` (case-insensitive substring).
+- **Alarm score min** — numeric input or slider 0–100.
+- **Show reviewed** toggle (binds to capability `event-review-state`).
+- **Show filtered** toggle (binds to capability `event-noise-filter`, session-only).
+
+The advanced popover (existing `EventsFilterPopover.tsx`) SHALL remain available for advanced filters not covered by the bar.
+
+#### Scenario: User narrows by date range and monitor
+- **WHEN** the user selects "Last 7 days" and picks two monitors
+- **THEN** the events list SHALL filter to events from those monitors in that range
+
+#### Scenario: User combines filters
+- **WHEN** the user selects "Today" + monitor `m1` + class "person" + score min 30
+- **THEN** the events list SHALL filter to today's events from `m1` with object label `person` (any confidence) AND `score >= 30`
+
+#### Scenario: Cause contains
+- **WHEN** the user types "package" into the cause-contains input
+- **THEN** events whose cause text contains "package" (case-insensitive) SHALL match
+
+#### Scenario: All filters cleared
+- **WHEN** the user taps "Clear all"
+- **THEN** all bar filters SHALL reset to their defaults (today's preset on phone, last-7-days on tablet/desktop, all monitors, all classes, no cause text, score min 0); the popover advanced filters SHALL NOT be cleared
+
+### Requirement: Filter State Persistence
+
+Filter bar state SHALL persist across navigations within a session and SHALL reset when the active profile changes. State SHALL NOT persist across full app restarts (per the "fresh session" expectation).
+
+#### Scenario: Navigate away and back, filters persist
+- **WHEN** the user sets filters, navigates to Dashboard, and returns to Events
+- **THEN** the filters SHALL still be set
+
+#### Scenario: Profile switch resets filters
+- **WHEN** the user switches profiles
+- **THEN** filters SHALL reset to defaults for the new profile
+
+#### Scenario: App restart resets filters
+- **WHEN** the user closes the app and relaunches
+- **THEN** filters SHALL be at defaults
+
+### Requirement: Phone Portrait Collapse
+
+On phone portrait, the filter bar SHALL collapse to a single row showing the active filter count and a "Filters" expand button. Tapping expands an inline panel containing the same filters as the bar.
+
+#### Scenario: Phone portrait, no active filters
+- **WHEN** the screen is in phone portrait orientation and no non-default filters are active
+- **THEN** the bar collapses to a single "Filters" button with no count
+
+#### Scenario: Phone portrait, 3 filters active
+- **WHEN** 3 non-default filters are active in phone portrait
+- **THEN** the bar shows "Filters · 3"
+
+### Requirement: One-Tap Preset
+
+The bar SHALL expose a one-tap "Today's high-score events" preset that sets: date range = Today, score min = 50, all monitors, all classes, cause text empty. The preset SHALL be a button next to "Clear all" and SHALL be present on all screen sizes.
+
+#### Scenario: User taps "Today's high-score" preset
+- **WHEN** the user taps the preset button
+- **THEN** filters SHALL be set as specified and the list SHALL re-render
+
+### Requirement: Popover Advanced Filters Coexist
+
+Filters set in the popover (e.g., tag filters, alarm-frame-only) SHALL apply on top of the bar filters as an AND. The popover SHALL surface its own active-filter count and Clear button independent of the bar's.
+
+#### Scenario: Bar and popover active simultaneously
+- **WHEN** the user sets the bar to "Last 7 days" + monitor `m1`, and adds a tag filter `tag = "garbage"` in the popover
+- **THEN** the events list SHALL filter to events satisfying ALL of those constraints
+
+### Requirement: data-testid Attributes
+
+Every interactive element on the filter bar SHALL carry a `data-testid="kebab-case-name"` per rule #13 to support e2e testing across platforms.
+
+#### Scenario: All bar elements have data-testid
+- **WHEN** the bar is rendered in any state
+- **THEN** every button, chip, input, and toggle SHALL have a stable `data-testid`
+
+### Requirement: Localization in 5 Languages
+
+All user-facing strings on the filter bar (preset names, picker labels, class chip labels, toggle labels, "Clear all", "Today's high-score events" label, collapsed-bar count text, validation messages) SHALL be localized in en, de, es, fr, zh per rule #5 and SHALL fit on a 320 px-wide screen per rule #23.
+
+#### Scenario: Each supported locale renders without missing keys
+- **WHEN** the user switches locale and uses the filter bar
+- **THEN** all visible strings SHALL be localized

--- a/openspec/changes/add-10s-notification-triage/specs/event-review-state/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/event-review-state/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Reviewed-State Store
+
+The system SHALL maintain a profile-scoped Zustand store (`eventReviewState`) holding the set of `event_id`s the user has marked reviewed. The store SHALL persist via `localStorage` (web) / Capacitor `Preferences` (native) under a versioned key, scoped per profile.
+
+#### Scenario: Reviewed state survives app restart
+- **WHEN** the user marks event `e1` reviewed and reloads / re-opens the app
+- **THEN** event `e1` is still marked reviewed for the same profile
+
+#### Scenario: Profile switch isolates reviewed state
+- **WHEN** profile A has `e1` marked reviewed and the user switches to profile B
+- **THEN** profile B's view of event `e1` (if it exists in B's data) SHALL NOT be marked reviewed
+
+### Requirement: Sources of Reviewed-State Writes
+
+Reviewed state SHALL be writable from three sources, all converging on the same store:
+
+1. **Per-card "Mark reviewed" affordance** on `EventCard` (and equivalent in list views).
+2. **Bulk "Mark all reviewed" action** on the Events page, acting on the currently filtered/rendered window of up to 500 events.
+3. **Notification "Reviewed" action** (capability `push-notification-triage`), via a "review-pending" shared file/list (App Group on iOS, shared `SharedPreferences` on Android) drained on next foreground.
+
+#### Scenario: Marking reviewed from EventCard
+- **WHEN** the user taps "Mark reviewed" on an `EventCard`
+- **THEN** the event's `event_id` SHALL be added to `eventReviewState` for the current profile
+
+#### Scenario: Bulk mark reviewed
+- **WHEN** the user taps "Mark all reviewed" with 47 events visible in the filtered window
+- **THEN** all 47 `event_id`s SHALL be added in a single batched write; the operation SHALL not block the UI for more than 100 ms
+
+#### Scenario: Bulk action exceeds 500-event cap
+- **WHEN** the filtered window contains more than 500 events
+- **THEN** the bulk action SHALL act on at most 500 (the rendered window) and surface a localized notice; events beyond the window SHALL be unaffected
+
+#### Scenario: Reviewed action drained from notification
+- **WHEN** the user tapped Reviewed on a background notification while the app was killed, then opens the app
+- **THEN** the React app SHALL drain the review-pending shared store on first foreground and merge entries into `eventReviewState`; the review-pending source SHALL be cleared after successful merge
+
+### Requirement: Visual Distinction in Lists
+
+Reviewed events SHALL be visually distinct in `EventCard` and list views: 50% opacity on the card, with a small reviewed-checkmark icon adjacent to the title. The visual distinction SHALL apply consistently in `Events.tsx`, `EventsFilterPopover` results, dashboard recent-events widget, and any other surface that renders `EventCard`.
+
+#### Scenario: Reviewed event in main Events list
+- **WHEN** an event is reviewed and rendered in the main Events list
+- **THEN** the card SHALL render at 50% opacity with a checkmark icon
+
+#### Scenario: Reviewed event in dashboard recent-events widget
+- **WHEN** the same event appears in the dashboard recent-events widget
+- **THEN** the same dimmed treatment SHALL apply
+
+### Requirement: Show / Hide Reviewed Toggle
+
+The Events page SHALL expose a "Show reviewed" toggle in the quick-search filter bar (capability `event-quick-search`). The toggle SHALL default to off on phone portrait (where space is constrained) and on for tablet / desktop. State SHALL be persisted profile-scoped.
+
+#### Scenario: Toggle off — reviewed events hidden
+- **WHEN** the toggle is off
+- **THEN** events whose `event_id` is in `eventReviewState` SHALL NOT appear in the filtered list
+
+#### Scenario: Toggle on — reviewed events visible but dimmed
+- **WHEN** the toggle is on
+- **THEN** reviewed events SHALL appear in the list with the dimmed-reviewed treatment
+
+### Requirement: Per-Card Unmark
+
+Reviewed state SHALL be reversible per event from the `EventCard` overflow / context menu.
+
+#### Scenario: User unmarks a reviewed event
+- **WHEN** the user opens the overflow menu on a reviewed event and taps "Unmark reviewed"
+- **THEN** the event_id SHALL be removed from `eventReviewState` and the visual treatment SHALL revert
+
+### Requirement: Localization in 5 Languages
+
+All user-facing strings related to reviewed state (action labels, toggle label, bulk action confirmation, notice when bulk caps at 500, overflow menu items) SHALL be localized in en, de, es, fr, zh per rule #5.
+
+#### Scenario: Each supported locale renders without missing keys
+- **WHEN** the user switches locale and interacts with reviewed-state UI
+- **THEN** all visible strings SHALL be localized; no raw translation keys SHALL appear

--- a/openspec/changes/add-10s-notification-triage/specs/monitor-live-deeplink/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/monitor-live-deeplink/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: PiP-Auto Deep Link to MonitorDetail
+
+The system SHALL accept a deep link of the form `MonitorDetail?monitor_id=<id>&profile_id=<id>&pip=auto`. When this route is mounted with `pip=auto`, the existing PiP plugin SHALL engage automatically once the live stream is ready, without requiring a user gesture.
+
+#### Scenario: Live action launches into PiP
+- **WHEN** the user taps the Live notification action and the app launches into `MonitorDetail?monitor_id=m1&profile_id=p1&pip=auto`
+- **THEN** the live stream for monitor `m1` under profile `p1` SHALL begin loading and PiP SHALL engage when the stream is ready
+
+#### Scenario: Stream fails to start
+- **WHEN** the stream fails to load (network error, monitor offline)
+- **THEN** the page SHALL surface the existing error UI for `MonitorDetail` and SHALL NOT attempt to engage PiP
+
+#### Scenario: Profile mismatch
+- **WHEN** the deep link references a `profile_id` that is not the currently active profile
+- **THEN** the system SHALL switch to the referenced profile before mounting `MonitorDetail`
+
+#### Scenario: PiP unsupported on platform
+- **WHEN** the deep link is followed on a platform where PiP is not supported (e.g., Tauri desktop without PiP capability)
+- **THEN** `MonitorDetail` SHALL load normally and the `pip=auto` parameter SHALL be ignored
+
+### Requirement: Deep Link is Reusable
+
+The `pip=auto` query parameter SHALL be a public part of the deep-link contract — usable from sources other than notification actions (e.g., a future home-screen widget, a future shortcut). The parameter SHALL be the only contract; no notification-specific coupling SHALL leak into `MonitorDetail`.
+
+#### Scenario: Same deep link from different source
+- **WHEN** the same deep link is invoked from a non-notification source (e.g., a Capacitor URL handler test)
+- **THEN** the behavior SHALL be identical to invocation from the Live action
+
+### Requirement: PiP Plugin Auto-Engage Entry Point
+
+The existing `app/src/plugins/pip` plugin SHALL expose an entry point that engages PiP on a video element provided by `MonitorDetail`, callable once the stream is ready. The entry point SHALL be safe to call when PiP is unsupported (no-op + log).
+
+#### Scenario: Entry point called when PiP supported
+- **WHEN** `MonitorDetail` mounts with `pip=auto`, the stream becomes ready, and the platform supports PiP
+- **THEN** the plugin SHALL engage PiP on the stream's video element
+
+#### Scenario: Entry point called when PiP unsupported
+- **WHEN** the same conditions apply but the platform does not support PiP
+- **THEN** the plugin SHALL log via `log.notifications` (or appropriate component logger) and return without error

--- a/openspec/changes/add-10s-notification-triage/specs/monitor-notification-priority/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/monitor-notification-priority/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Per-Monitor Priority Field
+
+Each monitor in the current profile SHALL carry a notification priority field stored in profile-scoped settings via `getProfileSettings`/`updateProfileSettings` (rule #7). Allowed values: `high`, `normal` (default), `low`, `silent`. Unknown / missing values SHALL be treated as `normal`.
+
+#### Scenario: Reading priority for a monitor with no explicit value
+- **WHEN** a monitor has no priority field stored
+- **THEN** reads SHALL return `normal`
+
+#### Scenario: User changes a monitor's priority
+- **WHEN** the user sets monitor `m1` to `high` via the Triage Center Per-Monitor Priority section
+- **THEN** the value SHALL be persisted profile-scoped and SHALL be readable by the iOS Service Extension and Android FCM service via the cross-process accessor
+
+#### Scenario: Migration from legacy "notifications-enabled" boolean
+- **WHEN** a monitor has the legacy boolean `notifications_enabled = false` and no priority field
+- **THEN** the priority SHALL be presented as `silent` in the UI; on first save, the legacy field SHALL be migrated to `priority = silent` and the legacy field cleared
+
+### Requirement: OS-Level Mapping
+
+Per-monitor priority SHALL map to OS-level notification importance at the moment of presentation, after the suppression check passes.
+
+| Priority | iOS `interruptionLevel` | Android channel | Channel importance |
+|---|---|---|---|
+| `high` | `.timeSensitive` | `zmn_high` | `IMPORTANCE_HIGH` |
+| `normal` | `.active` | `zmn_normal` | `IMPORTANCE_DEFAULT` |
+| `low` | `.passive` | `zmn_low` | `IMPORTANCE_LOW` |
+| `silent` | (suppressed) | `zmn_silent` | `IMPORTANCE_NONE` |
+
+The four Android channels SHALL be created at app first launch and SHALL persist. `silent` SHALL prevent display while still updating notification history and the event-snapshot for the quick-look surface.
+
+#### Scenario: Priority high on iOS
+- **WHEN** a push for a monitor with priority `high` is presented on iOS
+- **THEN** the system SHALL set `interruptionLevel = .timeSensitive`
+
+#### Scenario: Priority silent on Android
+- **WHEN** a push for a monitor with priority `silent` is processed on Android
+- **THEN** no system notification SHALL be shown; the event SHALL still be appended to notification history and the event-snapshot SHALL still be updated
+
+### Requirement: Channel Migration on First Launch After Upgrade
+
+The Android FCM service SHALL migrate the legacy single notification channel's user-tweaked settings (sound, vibration, importance) to the new `zmn_normal` channel exactly once on first launch after the upgrade. The legacy channel SHALL be deleted after a successful copy. A one-time in-app notice SHALL inform the user that channels have changed and that they may need to reconfirm preferences.
+
+#### Scenario: First launch after upgrade
+- **WHEN** the user upgrades from a build with the single legacy channel and launches the new build for the first time
+- **THEN** the four `zmn_*` channels SHALL be created, the legacy channel's settings SHALL be copied to `zmn_normal`, the legacy channel SHALL be deleted, and a one-time in-app notice SHALL be shown
+
+#### Scenario: Subsequent launches
+- **WHEN** the user launches the upgraded build any subsequent time
+- **THEN** the migration SHALL NOT run again
+
+### Requirement: Cross-Process Read Path
+
+The iOS Service Extension and Android `FirebaseMessagingService` SHALL be able to read the current monitor's priority cross-process (App Group `UserDefaults` on iOS, `SharedPreferences` on Android) without invoking the React app. The React app SHALL write priority changes to that shared store on save.
+
+#### Scenario: Priority readable from iOS extension
+- **WHEN** the React app sets monitor `m1` priority to `low` and a push arrives
+- **THEN** the iOS Service Extension SHALL read `low` and select `interruptionLevel = .passive`
+
+#### Scenario: Priority readable from Android FCM service
+- **WHEN** the same conditions apply on Android
+- **THEN** the FCM service SHALL select channel `zmn_low`
+
+### Requirement: Display in Existing Monitor Surfaces
+
+The current priority SHALL be visible on the monitor's row in the Triage Center Per-Monitor Priority section AND as a small icon/badge on `MonitorCard` (capability path `app/src/components/monitors/MonitorCard.tsx`). The badge SHALL be hidden when priority is `normal` to reduce visual noise.
+
+#### Scenario: Non-default priority shows badge on MonitorCard
+- **WHEN** monitor `m1` priority is `high`, `low`, or `silent`
+- **THEN** `MonitorCard` SHALL display a small icon/badge indicating the priority
+
+#### Scenario: Default priority hides the badge
+- **WHEN** monitor priority is `normal`
+- **THEN** no badge SHALL be displayed on `MonitorCard`

--- a/openspec/changes/add-10s-notification-triage/specs/notification-mute-store/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/notification-mute-store/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Cross-Process Suppression Store
+
+The system SHALL maintain a profile-scoped suppression store accessible from the iOS Service Extension, the iOS app process, the Android `FirebaseMessagingService`, the Android `BroadcastReceiver`s, and the Android app process. The store covers three entry kinds, each persisted across app kill, device reboot, and OS update.
+
+Storage:
+- iOS: App Group `UserDefaults` (suite name shared between extension, widget, and main app).
+- Android: `SharedPreferences` (or shared file via `ContentProvider`) accessible from FCM service, broadcast receivers, widget provider, and the Capacitor `WebView` host activity.
+
+Entry kinds:
+
+1. **Ad-hoc mute**: `{kind: "mute", profile_id, monitor_id, until, created_at}`
+2. **Quiet-hours window**: `{kind: "quiet_hours", profile_id, monitor_id_or_all, start_local_time: "HH:MM", end_local_time: "HH:MM", weekday_mask: number 0..127, label, created_at}`
+3. **Noise-filter rule**: `{kind: "noise_filter", profile_id, monitor_id_or_all, min_alarm_score, exclude_cause_patterns: string[], mode: "hide" | "dim", created_at}`
+
+`monitor_id_or_all` is either a specific monitor id or the literal `"*"` meaning all monitors for that profile.
+
+#### Scenario: Action handler writes a mute entry
+- **WHEN** the user taps Mute 1h on a notification
+- **THEN** an entry of kind `"mute"` SHALL be written with `until = now + 3600s` and the entry SHALL be readable from the extension/service on the next push
+
+#### Scenario: User adds a quiet-hours window from Triage Center
+- **WHEN** the user adds a quiet-hours window covering weekdays 22:00–07:00 for all monitors
+- **THEN** an entry of kind `"quiet_hours"` SHALL be written with the corresponding fields and the entry SHALL be readable from the extension/service
+
+#### Scenario: User adds a noise-filter rule
+- **WHEN** the user adds a noise-filter rule with `min_alarm_score = 30, mode = hide` for all monitors
+- **THEN** an entry of kind `"noise_filter"` SHALL be written and SHALL be consulted by both the push pipeline and the Events list (capability `event-noise-filter`)
+
+#### Scenario: Read after device reboot
+- **WHEN** the device is rebooted while a mute, quiet-hours, or noise-filter entry exists
+- **THEN** the entry SHALL still be present and matched by the next push
+
+#### Scenario: Multiple profiles, same `monitor_id` collision
+- **WHEN** profile A mutes its `monitor_id=1` and profile B receives a push for its own `monitor_id=1`
+- **THEN** profile B's push SHALL NOT be suppressed
+
+### Requirement: Profile Scoping
+
+All entries SHALL be keyed `(profile_id, …)` and lookups SHALL match on `profile_id` exactly. Action handlers SHALL preserve `profile_id` from the originating notification. The `monitor_id_or_all` `"*"` wildcard SHALL match any `monitor_id` for the same `profile_id` only.
+
+#### Scenario: Action preserves profile_id
+- **WHEN** a notification carrying `profile_id=p1, monitor_id=m1` triggers a Mute action
+- **THEN** the written entry SHALL have `profile_id=p1, monitor_id=m1`
+
+#### Scenario: Lookup with mismatched profile_id
+- **WHEN** the store contains an entry for `(p1, m1)` and a push arrives for `(p2, m1)`
+- **THEN** the lookup SHALL return no match
+
+#### Scenario: Wildcard quiet-hours respects profile boundary
+- **WHEN** profile A has a quiet-hours window with `monitor_id_or_all = "*"` and profile B receives a push during the same time window
+- **THEN** profile B's push SHALL NOT be suppressed by profile A's window
+
+### Requirement: Mute Lifecycle
+
+Each ad-hoc mute entry SHALL have an absolute expiry timestamp (`until`). When the current time is greater than or equal to `until`, the entry is expired and SHALL NOT suppress notifications. Expired entries MAY be lazily removed; readers MUST treat them as inert regardless.
+
+#### Scenario: Mute set, then time passes beyond `until`
+- **WHEN** a mute is set with `until = now + 60s`, time advances to `now + 90s`, and a push arrives
+- **THEN** the push SHALL be presented normally
+
+#### Scenario: User clears mute via Triage Center
+- **WHEN** the user clears a mute via Triage Center (capability `snooze-management-screen`)
+- **THEN** the entry SHALL be removed and subsequent pushes for the `(profile_id, monitor_id)` SHALL be presented normally
+
+#### Scenario: User extends mute duration via Triage Center
+- **WHEN** the user extends an active mute
+- **THEN** `until` SHALL be set to the new absolute time and `created_at` SHALL be preserved
+
+### Requirement: Quiet-Hours Lifecycle
+
+Quiet-hours entries SHALL have `start_local_time` and `end_local_time` in the user's local timezone (read from the device at evaluation time) and a `weekday_mask` bitfield (bit 0 = Sunday … bit 6 = Saturday). A window is "active" when (a) today's weekday bit is set, AND (b) the current local time falls between `start_local_time` and `end_local_time` (inclusive of start, exclusive of end). Windows that cross midnight (e.g., 22:00–07:00) SHALL be treated as active when current time ≥ start OR current time < end, with the weekday check applying to whichever date the start belongs to.
+
+#### Scenario: Window 22:00–07:00 weekdays, current time 23:30 Tuesday
+- **WHEN** a window is configured 22:00–07:00 with weekday_mask covering Mon–Fri, and the current local time is Tuesday 23:30
+- **THEN** the window is active
+
+#### Scenario: Window 22:00–07:00, current time 03:00 Saturday
+- **WHEN** the same window is configured Mon–Fri and the current local time is Saturday 03:00 (Friday's window crossing midnight)
+- **THEN** the window is active (weekday check applies to Friday, the start date)
+
+#### Scenario: Window outside its weekdays
+- **WHEN** a Mon–Fri window is queried at 23:30 Saturday
+- **THEN** the window is inactive
+
+### Requirement: Noise-Filter Rule Evaluation
+
+Noise-filter rules SHALL be evaluated by both the push pipeline and the Events list filter. A rule "matches" a push or event when:
+
+- `min_alarm_score > payload.alarm_score` (rule's threshold strictly exceeds event's score), OR
+- ANY string in `exclude_cause_patterns` is found as a case-insensitive substring of `payload.cause_text`.
+
+Multiple rules per profile are OR'd; ANY match suppresses (or dims). Rules in `mode: hide` cause the push pipeline to suppress the notification AND the Events list to hide the event. Rules in `mode: dim` cause only the Events list to dim the event (notification is still shown).
+
+#### Scenario: Rule with score 30 hide-mode, push score 12
+- **WHEN** a rule has `min_alarm_score = 30, mode = hide` and a push has `alarm_score = 12`
+- **THEN** the push is suppressed and the corresponding event is hidden in the Events list
+
+#### Scenario: Rule with score 30 dim-mode, push score 12
+- **WHEN** a rule has `min_alarm_score = 30, mode = dim` and a push has `alarm_score = 12`
+- **THEN** the push is presented; the event appears in the Events list dimmed
+
+#### Scenario: Cause-exclude match
+- **WHEN** a rule has `exclude_cause_patterns = ["Continuous"]` and a push has `cause_text = "Continuous Recording"`
+- **THEN** the rule matches and `mode` decides hide vs. dim
+
+#### Scenario: No `cause_text` on payload
+- **WHEN** a push lacks `cause_text`
+- **THEN** cause-exclude patterns SHALL NOT match; only the score check applies
+
+### Requirement: Concurrent Access Safety
+
+Reads from the iOS Service Extension or Android `FirebaseMessagingService` MAY race with writes from action handlers, the Triage Center, or the in-app filter UI. The store SHALL guarantee that reads return either the pre-write or the post-write state — never a torn or partial state.
+
+#### Scenario: Read during write
+- **WHEN** an action handler writes an entry while the extension reads the store on a concurrent push
+- **THEN** the read SHALL return either the new state (push suppressed) or the prior state (push shown), and SHALL NOT crash or return torn data

--- a/openspec/changes/add-10s-notification-triage/specs/push-notification-triage/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/push-notification-triage/spec.md
@@ -1,0 +1,194 @@
+## ADDED Requirements
+
+### Requirement: ES FCM Payload Contract
+
+The system SHALL accept an additive FCM data payload from zmeventnotificationNg with the following fields. All fields are optional on the wire. The client MUST tolerate any subset of fields being absent and fall back to the closest legacy behavior.
+
+Required for any new (Tier-1+) behavior to engage:
+- `monitor_id` (string)
+- `monitor_name` (string)
+- `event_id` (string)
+- `started_at` (ISO 8601 string)
+- `profile_id` (string)
+
+Strong (Tier-1 read benefit):
+- `object_labels` — array of `{label: string, confidence: number 0..1}`. Client SHALL show at most 2 labels in the title, sorted by confidence descending.
+- `image_url_jpg` (string) — single thumbnail URL.
+- `alarm_score` (number 0..100) — ZM-native alarm score; consumed by the noise filter and may be displayed in the title when present.
+
+Nice (Tier-1/2 polish):
+- `image_urls_strip` — array of exactly 3 URLs. When present, supersedes `image_url_jpg` for attachment composition.
+- `color_hex` (string, e.g. `#FF8800`) — monitor brand colour.
+- `category_id` (string) — selects iOS `UNNotificationCategory` action set.
+- `cause_text` (string) — ZM-native cause text; consumed by noise-filter cause-exclude patterns.
+
+#### Scenario: Full payload received from upgraded ES
+- **WHEN** an FCM message arrives with all required and strong fields plus `image_urls_strip`
+- **THEN** the system SHALL fetch all three strip URLs in parallel, composite them horizontally into a single JPEG attachment, format the title using `object_labels` + `monitor_name`, and present the notification
+
+#### Scenario: Older ES — only legacy fields present
+- **WHEN** an FCM message arrives with only `monitor_name` and a single image URL (today's pre-change behavior)
+- **THEN** the system SHALL present the notification using legacy formatting (no object label in title, single-image attachment) without error
+
+#### Scenario: Newer ES — client ignores unknown future fields
+- **WHEN** an FCM message arrives with a field the client does not recognize
+- **THEN** the system SHALL ignore the unknown field and present the notification using only fields it does recognize
+
+#### Scenario: Required field missing — Tier-1 disabled
+- **WHEN** an FCM message lacks any of the required fields (`monitor_id`, `monitor_name`, `event_id`, `started_at`, `profile_id`)
+- **THEN** the system SHALL fall back to the legacy presentation (today's title and single-image attachment) and SHALL NOT consult the mute store or attach action buttons
+
+### Requirement: Locale-Aware Title Formatting in Extensions
+
+The iOS Service Extension and the Android `FirebaseMessagingService` SHALL format the notification title using the user's selected locale, read from a cross-process store (App Group `UserDefaults` on iOS, `SharedPreferences` on Android) that the React app writes whenever language changes. Templated strings SHALL be shipped inside the extension/service bundle (`Localizable.strings` for iOS, `strings.xml` for Android) for each of en, de, es, fr, zh.
+
+Title format: `<top-label> <confidence>% · <monitor_name>` when `object_labels` is present and the top label has confidence ≥ 0.5; otherwise `<monitor_name>`.
+
+Body format (legacy fallback only): today's "Motion detected" string, localized.
+
+#### Scenario: User locale is Spanish, payload has person label at 92%
+- **WHEN** a push arrives with `object_labels: [{label: "person", confidence: 0.92}]` and the user's locale is `es`
+- **THEN** the title SHALL be presented using the `es` `Localizable.strings` template (e.g., `Persona 92% · Driveway`)
+
+#### Scenario: User locale is unknown to the extension
+- **WHEN** the user's locale is missing from the cross-process store or is one not shipped inside the extension bundle
+- **THEN** the system SHALL fall back to English
+
+#### Scenario: Confidence below display threshold
+- **WHEN** the top object label has confidence < 0.5
+- **THEN** the title SHALL contain only the monitor name, with no label
+
+### Requirement: Multi-Frame Strip Composition
+
+When the FCM payload contains `image_urls_strip` (length 3), the iOS Service Extension and Android `FirebaseMessagingService` SHALL fetch the three URLs in parallel and composite them horizontally into a single JPEG, which is attached to the notification. When `image_urls_strip` is absent and `image_url_jpg` is present, the single image SHALL be attached.
+
+#### Scenario: Strip fetch succeeds for all 3 URLs
+- **WHEN** all three strip URLs are reachable
+- **THEN** a single horizontally-composited JPEG SHALL be attached to the notification
+
+#### Scenario: One of the 3 strip URLs fails
+- **WHEN** any one strip URL fails to fetch within the extension's time budget
+- **THEN** the system SHALL composite from the URLs that did succeed; if at least one succeeded, the notification SHALL include that partial image; if all failed, the system SHALL fall back to `image_url_jpg` if present, otherwise no attachment
+
+#### Scenario: Only `image_url_jpg` present
+- **WHEN** the payload contains `image_url_jpg` and not `image_urls_strip`
+- **THEN** the single image SHALL be attached unchanged (today's behavior)
+
+### Requirement: Suppression Before Display
+
+The iOS Service Extension and Android `FirebaseMessagingService` SHALL consult the cross-process suppression store (see capability `notification-mute-store`) before presenting any notification. The store covers three entry kinds: ad-hoc mutes, recurring quiet-hours windows, and noise-filter rules. When ANY entry kind matches the incoming push for the `(profile_id, monitor_id)` pair, the system SHALL drop the push without showing a system notification and without invoking the JS-side foreground handler.
+
+Match semantics:
+- **Ad-hoc mute**: matches when an unexpired entry exists for `(profile_id, monitor_id)`.
+- **Quiet-hours**: matches when the current local time falls inside an active window for `(profile_id, monitor_id_or_all)` whose `weekday_mask` includes today.
+- **Noise-filter**: matches when a rule for `(profile_id, monitor_id_or_all)` has `min_alarm_score > payload.alarm_score`, OR when any `exclude_cause_patterns` entry is found in `payload.cause_text` (substring, case-insensitive). Noise-filter rules in `mode: hide` suppress the notification; rules in `mode: dim` do NOT suppress notifications (they affect only the Events list — see capability `event-noise-filter`).
+
+Quiet-hours collision with priority: when a push would be suppressed by quiet-hours but the per-monitor priority is `high`, quiet-hours SHALL still win (user explicitly scheduled silence; `time-sensitive` is for OS Focus, not user schedule).
+
+#### Scenario: Push for muted monitor while app is backgrounded
+- **WHEN** an FCM message arrives for a `(profile_id, monitor_id)` pair with an active unexpired ad-hoc mute
+- **THEN** no system notification is shown and no JS handler is invoked
+
+#### Scenario: Push for muted monitor while app is foregrounded
+- **WHEN** the same conditions apply but the app is in the foreground
+- **THEN** no system notification is shown and no in-app toast is shown
+
+#### Scenario: Mute expired
+- **WHEN** the mute entry's `until` timestamp is in the past at push receipt time
+- **THEN** the system SHALL ignore the entry and present the notification normally
+
+#### Scenario: Push falls inside an active quiet-hours window
+- **WHEN** an FCM message arrives during an active quiet-hours window for the matching `(profile_id, monitor_id_or_all)` and today's weekday is included in the window's `weekday_mask`
+- **THEN** no system notification is shown and no JS handler is invoked
+
+#### Scenario: Quiet-hours active but priority is high
+- **WHEN** a push would be suppressed by quiet-hours and the per-monitor priority is `high`
+- **THEN** quiet-hours wins; no system notification is shown
+
+#### Scenario: Push below noise-filter score threshold (hide mode)
+- **WHEN** a push arrives with `alarm_score = 12` and a noise-filter rule for the matching `(profile_id, monitor_id_or_all)` has `min_alarm_score = 30, mode = hide`
+- **THEN** no system notification is shown
+
+#### Scenario: Push below noise-filter score threshold (dim mode)
+- **WHEN** the same conditions apply but `mode = dim`
+- **THEN** the notification SHALL be presented normally (dim mode affects Events list only)
+
+#### Scenario: Push matches a noise-filter cause-exclude pattern
+- **WHEN** a push arrives with `cause_text = "Continuous"` and a noise-filter rule has `exclude_cause_patterns: ["Continuous"], mode = hide`
+- **THEN** no system notification is shown
+
+#### Scenario: Required `profile_id` missing
+- **WHEN** the push lacks `profile_id`
+- **THEN** the system SHALL skip suppression entirely and fall back to legacy presentation
+
+### Requirement: Notification Action Set
+
+When `category_id` is present in the FCM payload, the system SHALL present three actions on the notification: **Mute monitor 1h**, **Reviewed**, and **Live**. Action labels SHALL be localized via the same extension/service `Localizable.strings` / `strings.xml` mechanism as the title.
+
+- **Mute monitor 1h**: writes a mute entry to the cross-process suppression store with `until = now + 1 hour`. Runs natively without app launch. iOS uses non-`.foreground` action option; Android uses a `BroadcastReceiver` `PendingIntent`.
+- **Reviewed**: writes the event to a "review-pending" shared file/list (see capability `event-review-state`) and dismisses the notification. Runs natively without app launch.
+- **Live**: deep-links to `MonitorDetail?pip=auto` (see capability `monitor-live-deeplink`). iOS uses `.foreground` action option; Android uses an `Activity` `PendingIntent` with appropriate flags.
+
+#### Scenario: User taps Mute 1h on iOS background
+- **WHEN** the user taps the Mute action on a notification while the app is not running
+- **THEN** the action handler runs in the background, writes the mute entry, and the app does not launch
+
+#### Scenario: User taps Mute 1h on Android background
+- **WHEN** the user taps the Mute action on Android while the app is not running
+- **THEN** the `BroadcastReceiver` runs, writes the mute entry, and the app does not launch
+
+#### Scenario: User taps Reviewed
+- **WHEN** the user taps the Reviewed action
+- **THEN** the notification is dismissed, the event is recorded as reviewed in the review-pending shared store, and the app does not launch. On next foreground, the React app drains the pending entries into the `eventReviewState` Zustand store.
+
+#### Scenario: User taps Live
+- **WHEN** the user taps the Live action
+- **THEN** the app launches (foreground), routes to `MonitorDetail` for the corresponding `monitor_id`, and engages PiP on mount
+
+### Requirement: Coexistence with Existing Foreground Handler
+
+When the app is in the foreground, the existing in-app FCM toast and ES-vs-Direct deduplication flow (today's behavior in `NotificationHandler.tsx`) SHALL continue to operate. The new native pipeline MUST NOT show a system notification when the app is in the foreground; instead, it SHALL hand off to the JS layer so the in-app toast renders and dedup runs.
+
+#### Scenario: Push arrives while app is foreground, monitor not muted
+- **WHEN** an FCM message arrives and the app is in the foreground
+- **THEN** the system SHALL NOT show a system notification and SHALL deliver the message to the JS handler so it renders an in-app toast and runs ES/Direct deduplication
+
+#### Scenario: Push arrives while app is foreground, monitor muted
+- **WHEN** an FCM message arrives, the app is foreground, and the monitor is muted
+- **THEN** the system SHALL NOT show a system notification and SHALL NOT deliver the message to the JS handler
+
+### Requirement: Per-Monitor Priority Mapping at Display Time
+
+After the suppression check passes, the system SHALL apply per-monitor priority (see capability `monitor-notification-priority`) to OS-level notification importance. iOS sets `interruptionLevel`; Android selects the corresponding `NotificationChannel`. A `silent` priority SHALL prevent display entirely while still allowing the event to be recorded in notification history and the event-snapshot for the quick-look surface.
+
+#### Scenario: Monitor priority is high
+- **WHEN** a push arrives, suppression does not match, and the monitor's priority is `high`
+- **THEN** the notification SHALL be presented with iOS `interruptionLevel = .timeSensitive` (Android channel `zmn_high`)
+
+#### Scenario: Monitor priority is silent
+- **WHEN** a push arrives, suppression does not match, and the monitor's priority is `silent`
+- **THEN** no system notification SHALL be shown; the event SHALL still be recorded in notification history and the event-snapshot SHALL still be updated for widgets/tray/dock
+
+#### Scenario: Priority not configured
+- **WHEN** a monitor has no explicit priority set
+- **THEN** the system SHALL treat it as `normal` (iOS `interruptionLevel = .active`, Android channel `zmn_normal`)
+
+### Requirement: Event-Snapshot Update on Delivery
+
+After a notification is presented (or recorded as silent), the system SHALL update the platform-specific event-snapshot source consumed by the quick-look surface (see capability `quick-look-surfaces`). The snapshot SHALL contain the most recent 5 events with `event_id, monitor_id, monitor_name, started_at, image_url, top_label, alarm_score`. Suppressed pushes (mute / quiet-hours / noise-filter hide) SHALL NOT update the snapshot.
+
+#### Scenario: Notification delivered, snapshot updated
+- **WHEN** a push is presented or recorded as `silent`
+- **THEN** the event-snapshot SHALL be updated with the new event prepended to the list, oldest entries dropped beyond 5
+
+#### Scenario: Push suppressed, snapshot unchanged
+- **WHEN** a push is suppressed by mute / quiet-hours / noise-filter (hide)
+- **THEN** the event-snapshot SHALL NOT be updated
+
+### Requirement: Graceful Degradation for ZM Direct Mode
+
+The system SHALL present whatever payload ZoneMinder's Direct-mode Notifications API sends, formatted using only the fields present. No new behavior beyond Tier-1 fallback (legacy title and single-image attachment) is required for Direct mode.
+
+#### Scenario: Direct-mode push arrives
+- **WHEN** an FCM message arrives from ZoneMinder Direct mode (without ES-only fields like `object_labels` or `category_id`)
+- **THEN** the system SHALL present a legacy-format notification with whatever monitor name and image are available, and SHALL NOT attach action buttons

--- a/openspec/changes/add-10s-notification-triage/specs/quick-look-surfaces/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/quick-look-surfaces/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Shared Event-Snapshot Source
+
+The system SHALL maintain a platform-specific event-snapshot source that holds the most recent 5 delivered events for the active profile. The snapshot SHALL be written from `app/src/services/notifications.ts` (or equivalent shared location) on every successful event delivery and at notification-time on iOS / Android (capability `push-notification-triage`).
+
+Snapshot format (JSON):
+```
+{
+  updated_at: ISO8601,
+  profile_id: string,
+  events: [
+    { event_id, monitor_id, monitor_name, started_at, image_url, top_label, alarm_score }
+  ]
+}
+```
+
+Storage:
+- iOS: App Group container file (suite shared with extension and widget).
+- Android: `ContentProvider`-exposed file or `SharedPreferences`.
+- Tauri: app-data directory file.
+- Web: `localStorage` keyed by profile.
+
+Suppressed pushes (mute / quiet-hours / noise-filter `mode: hide`) SHALL NOT update the snapshot. Pushes for `silent`-priority monitors SHALL update the snapshot.
+
+#### Scenario: Push delivered, snapshot updated
+- **WHEN** a notification is presented or recorded as silent
+- **THEN** the event SHALL be prepended to the snapshot's events array; entries beyond 5 SHALL be dropped
+
+#### Scenario: Push suppressed, snapshot unchanged
+- **WHEN** a push is suppressed by mute / quiet-hours / noise-filter hide
+- **THEN** the snapshot SHALL NOT be updated
+
+#### Scenario: Profile switch
+- **WHEN** the user switches active profile
+- **THEN** the snapshot SHALL be re-pointed to the new profile's snapshot file/key; widgets / tray / dock SHALL render the new profile's events on next refresh
+
+### Requirement: iOS Home-Screen Widget
+
+A WidgetKit widget SHALL ship in a separate iOS extension target. It SHALL support three sizes:
+
+- **Small (1×1 home grid)**: 1 event — thumbnail + monitor name + relative time + top label.
+- **Medium (2×1 home grid)**: 3 events — thumbnail strip + monitor name + relative time per item.
+- **Large (2×2 home grid)**: 5 events — list with thumbnails + monitor name + relative time + top label per item.
+
+Each item SHALL deep-link via `zmninja://event/<event_id>?profile_id=<profile_id>` to `EventDetail` when tapped (or `zmninja://monitor/<monitor_id>?profile_id=<profile_id>&pip=auto` when configured).
+
+Widget refresh: WidgetKit OS-driven cadence (typically 5–15 min) with a force-refresh attempt via `WidgetCenter.shared.reloadTimelines` on every push receipt. The widget SHALL display `formatRelative(updated_at)` so staleness is explicit.
+
+#### Scenario: Widget shows latest events
+- **WHEN** the user adds the small widget to the home screen and a push is delivered
+- **THEN** the widget SHALL refresh (within OS budget) to show the new event with thumbnail, monitor name, and relative time
+
+#### Scenario: Widget tap deep-links
+- **WHEN** the user taps an event row in any size widget
+- **THEN** the app launches and routes to `EventDetail` for that event
+
+#### Scenario: Widget when no events available
+- **WHEN** the snapshot is empty (no events delivered yet for this profile)
+- **THEN** the widget SHALL render a localized empty-state placeholder
+
+### Requirement: Android Home-Screen Widget
+
+An `AppWidgetProvider` SHALL ship with three sizes:
+
+- **1×1**: 1 event — thumbnail + monitor name.
+- **2×2**: 3 events.
+- **4×2**: 5 events.
+
+Tap deep-link semantics SHALL match iOS. Refresh on push receipt via `AppWidgetManager.notifyAppWidgetViewDataChanged`. Empty state SHALL match iOS.
+
+#### Scenario: User adds 4×2 widget, receives push
+- **WHEN** the user has the 4×2 widget installed and a push is delivered
+- **THEN** the widget SHALL refresh to show the new event at the top of the list
+
+#### Scenario: Widget tap deep-links
+- **WHEN** the user taps an event row
+- **THEN** the app launches and routes to `EventDetail`
+
+### Requirement: Tauri Desktop System-Tray Quick-Look
+
+A system-tray (menu-bar on macOS, system tray on Windows / Linux) icon SHALL be installed via `tauri-plugin-systemtray` (or current Tauri 2-compatible equivalent). Clicking the icon SHALL open a popover or compact window listing the latest 5 events with thumbnail, monitor name, started-at, and top label. Clicking an event SHALL bring the main window to front and route to `EventDetail` or `MonitorDetail?pip=auto`.
+
+The tray icon SHALL show a small dot/badge when there are unreviewed events in the snapshot, cleared when the user opens the popover or marks events reviewed.
+
+#### Scenario: Tray icon click opens popover
+- **WHEN** the user clicks the tray icon
+- **THEN** a popover/compact window SHALL appear listing the 5 most recent events
+
+#### Scenario: Unreviewed badge
+- **WHEN** the snapshot contains events the user has not yet reviewed
+- **THEN** the tray icon SHALL display a small dot/badge
+
+#### Scenario: Click event in popover
+- **WHEN** the user clicks an event row in the popover
+- **THEN** the main app window SHALL come to front and route to `EventDetail` for that event
+
+#### Scenario: Plugin unavailable / unsupported on host OS
+- **WHEN** the host OS or plugin version does not support the system-tray API
+- **THEN** the app SHALL log via `log.notifications` (rule #9), continue without the tray, and fall back to a global keyboard shortcut that opens the same popover as a foreground window
+
+### Requirement: Web In-Tab Dock
+
+A `QuickLookDock.tsx` component SHALL be mounted in the root layout on web. It SHALL display a compact strip at the bottom of the viewport listing the latest 3–5 events (responsive count) with thumbnail, monitor name, and relative time. Each item SHALL be a link to `EventDetail`. The dock SHALL be present on every route.
+
+The dock SHALL be dismissable per session (state in `sessionStorage`); the next session SHALL start with the dock visible. The dock SHALL be hidden on mobile-web phone-portrait viewports below 480 px wide to avoid stealing thumb space.
+
+#### Scenario: Dock visible on every route
+- **WHEN** the user navigates between Dashboard, Events, Monitors, Settings on web
+- **THEN** the dock SHALL be present at the bottom of every route
+
+#### Scenario: Dock dismiss
+- **WHEN** the user dismisses the dock
+- **THEN** the dock SHALL hide for the remainder of the session and reappear on the next session
+
+#### Scenario: Phone-portrait web viewport
+- **WHEN** the viewport width is < 480 px
+- **THEN** the dock SHALL be hidden regardless of dismiss state
+
+#### Scenario: Dock empty state
+- **WHEN** the snapshot has no events
+- **THEN** the dock SHALL render a localized empty-state line and SHALL still be dismissable
+
+### Requirement: Functional-Equivalent Parity
+
+The four surfaces SHALL deliver the same user job — "answer 'anything new and worth my time?' without launching the full UI" — on every supported platform. Pixel parity is NOT required; functional parity (latest events glanceable, deep-linkable on tap, refresh on event delivery, empty-state localized) IS required.
+
+#### Scenario: Same job across platforms
+- **WHEN** the user has set up the appropriate surface on each of iOS, Android, Tauri, web
+- **THEN** each surface SHALL display the latest events and SHALL deep-link to `EventDetail` on tap/click
+
+### Requirement: Localization in 5 Languages
+
+All visible strings on widgets, tray popover, and dock (empty states, accessibility labels, badge tooltips, time-ago text) SHALL be localized in en, de, es, fr, zh. Time-ago text SHALL go through `useDateTimeFormat()` on web/Tauri and through extension-shipped formatters on iOS/Android (rule #24).
+
+#### Scenario: Each surface renders in current locale
+- **WHEN** the user switches locale and the surface refreshes
+- **THEN** all visible strings SHALL be localized
+
+### Requirement: data-testid for Web and Tauri
+
+Interactive elements on the web dock and (where the test harness can reach them) Tauri popover SHALL carry `data-testid="kebab-case-name"` per rule #13.
+
+#### Scenario: Dock items have data-testid
+- **WHEN** the dock is rendered with events
+- **THEN** each event row, the dismiss button, and the dock root SHALL have stable `data-testid`s

--- a/openspec/changes/add-10s-notification-triage/specs/snooze-management-screen/spec.md
+++ b/openspec/changes/add-10s-notification-triage/specs/snooze-management-screen/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Triage Center Screen
+
+The app SHALL provide an in-app **Triage Center** screen that consolidates management of all notification triage controls for the current profile. The screen SHALL be reachable from Notification Settings via a labelled link/button. It SHALL contain four sections, each addressable via tab or scroll-anchor:
+
+1. **Mutes** — list of active ad-hoc mutes (capability `notification-mute-store` kind `"mute"`), ordered by `until` ascending. Each row shows monitor name, time remaining (relative, via `useDateTimeFormat()`), and Clear / Extend actions.
+2. **Quiet Hours** — list of recurring quiet-hours windows (kind `"quiet_hours"`). Each row shows label, time range, weekdays, monitor scope (specific or "All monitors"), and Edit / Delete. An "Add quiet-hours window" affordance is always present.
+3. **Per-Monitor Priority** — list of monitors for the current profile with their current priority level (`high` / `normal` / `low` / `silent`). Each row exposes a priority selector. An info banner explains the OS-level mapping.
+4. **Noise Filter** — list of noise-filter rules (kind `"noise_filter"`). Each row shows the monitor scope, score threshold, cause-exclude patterns, and mode (hide / dim). Edit / Delete + Add. A help line shows the active default rule (if any).
+
+#### Scenario: User opens Triage Center
+- **WHEN** the user opens Triage Center
+- **THEN** all four sections SHALL be present and SHALL render without error even when each section is empty
+
+#### Scenario: Empty state in any section
+- **WHEN** a section has no entries
+- **THEN** a localized empty-state message SHALL be shown for that section, alongside its Add affordance where applicable
+
+### Requirement: Mute Section Operations
+
+The Mutes section SHALL allow Clearing or Extending each mute entry.
+
+#### Scenario: User clears a mute
+- **WHEN** the user taps Clear on a mute row
+- **THEN** the entry SHALL be removed from the suppression store and the row SHALL be removed from the list
+
+#### Scenario: User extends a mute
+- **WHEN** the user taps Extend, picks a duration (1h, 4h, 24h, custom), and confirms
+- **THEN** the entry's `until` SHALL be set to `now + duration` and the time-remaining SHALL update
+
+#### Scenario: Mute expires while screen is open
+- **WHEN** a mute's `until` passes while the user views the screen
+- **THEN** the row SHALL be removed (refresh on focus or via interval)
+
+### Requirement: Quiet-Hours Section Operations
+
+The Quiet Hours section SHALL allow adding, editing, and deleting recurring quiet-hours windows.
+
+#### Scenario: User adds a quiet-hours window
+- **WHEN** the user taps Add, enters a label, picks start/end times and weekdays and monitor scope, and confirms
+- **THEN** an entry of kind `"quiet_hours"` SHALL be written to the suppression store with the chosen fields
+
+#### Scenario: User edits a quiet-hours window
+- **WHEN** the user opens an existing window for edit, changes the time range, and saves
+- **THEN** the underlying entry SHALL be updated; subsequent pushes during the new range SHALL be suppressed
+
+#### Scenario: User deletes a quiet-hours window
+- **WHEN** the user deletes a window
+- **THEN** the entry SHALL be removed and pushes during what was its active range SHALL be presented normally
+
+#### Scenario: Window with empty weekday mask is rejected
+- **WHEN** the user attempts to save a window with no weekdays selected
+- **THEN** the save SHALL be blocked with a localized validation message
+
+### Requirement: Per-Monitor Priority Section Operations
+
+The Per-Monitor Priority section SHALL list monitors for the current profile with their current priority and SHALL allow inline change.
+
+#### Scenario: User changes a monitor's priority
+- **WHEN** the user changes a monitor's priority from `normal` to `high`
+- **THEN** the change SHALL be persisted via `updateProfileSettings` (rule #7) and SHALL take effect on the next push
+
+#### Scenario: Monitor list reflects current profile only
+- **WHEN** the user switches profiles
+- **THEN** the monitor list SHALL refresh to the new profile's monitors
+
+### Requirement: Noise Filter Section Operations
+
+The Noise Filter section SHALL allow adding, editing, and deleting noise-filter rules.
+
+#### Scenario: User adds a default noise-filter rule
+- **WHEN** the user taps Add, picks `min_alarm_score = 30`, no cause patterns, mode hide, all monitors, and confirms
+- **THEN** an entry of kind `"noise_filter"` SHALL be written
+
+#### Scenario: User adds a cause-exclude rule
+- **WHEN** the user adds a rule with `exclude_cause_patterns = ["Continuous", "TestEvent"]`, mode dim, all monitors
+- **THEN** matching events SHALL be dimmed in the Events list and notifications SHALL still be shown
+
+#### Scenario: User edits an existing rule
+- **WHEN** the user changes an existing rule's mode from hide to dim
+- **THEN** the underlying entry SHALL be updated
+
+### Requirement: Profile Scoping in Triage Center
+
+The screen SHALL only show entries belonging to the currently active profile. Switching profiles SHALL refresh all four sections.
+
+#### Scenario: Profile switch refreshes all sections
+- **WHEN** the user is viewing Triage Center and switches profiles
+- **THEN** all four sections SHALL refresh and show only the new profile's entries
+
+### Requirement: Localization in 5 Languages
+
+All user-facing strings on Triage Center (titles, section headers, labels, empty states, action labels, validation messages, duration picker options, weekday names, priority level names, help banners) SHALL be present in the React i18n bundle for en, de, es, fr, zh, and SHALL fit on a 320 px-wide screen (rule #23).
+
+#### Scenario: Each supported locale renders without missing keys
+- **WHEN** the user switches to any of en, de, es, fr, zh and opens Triage Center
+- **THEN** all visible strings SHALL be localized; no raw translation keys SHALL appear
+
+### Requirement: Entry Point from Notification Settings
+
+The Notification Settings page SHALL include a clearly labelled entry point ("Triage Center" or equivalent, localized) that navigates to the Triage Center screen. The entry point SHALL be visible regardless of whether any entries currently exist.
+
+#### Scenario: Notification Settings shows entry point
+- **WHEN** the user opens Notification Settings
+- **THEN** a localized "Triage Center" link SHALL be visible and tapping it SHALL navigate to the Triage Center screen

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -1,0 +1,228 @@
+## 1. Spike — Android FCM coexistence (BLOCKER for §8–§10)
+
+- [ ] 1.1 Stub a custom `FirebaseMessagingService` in `app/android/app/src/main/java/...`, register it in `AndroidManifest.xml` with priority above the Capacitor plugin's, and confirm it receives FCM messages first
+- [ ] 1.2 Verify foreground delivery still reaches the existing JS handler in `NotificationHandler.tsx` after the custom service runs (in-app toast + ES/Direct dedup unchanged)
+- [ ] 1.3 Verify background delivery results in a single system notification (no duplicate from Capacitor's default handling)
+- [ ] 1.4 Document findings in `design.md` § Open Questions; if blocked, escalate to D5's rejected alternative and re-estimate before proceeding
+
+## 2. Spike — Tauri system-tray plugin compatibility (BLOCKER for §16)
+
+- [ ] 2.1 Confirm `tauri-plugin-systemtray` (or current equivalent) version pair compatible with the project's Tauri 2 + Rust setup; pin both JS and Rust packages (rule #16)
+- [ ] 2.2 Stub a tray icon + click-to-popover in a throwaway branch; verify it works on macOS, Windows, Linux
+- [ ] 2.3 If blocked: design fallback (global keyboard shortcut → foreground popover window); update `design.md` § Open Questions
+
+## 3. ES payload contract (zmeventnotificationNg)
+
+- [ ] 3.1 Land additive payload fields per `proposal.md` (`monitor_id`, `monitor_name`, `event_id`, `started_at`, `profile_id`, `object_labels`, `image_url_jpg`, `alarm_score`, `image_urls_strip`, `color_hex`, `category_id`, `cause_text`)
+- [ ] 3.2 Generate strip URLs server-side using existing `nph-zms` frame endpoints
+- [ ] 3.3 Truncate `cause_text` server-side at 200 chars to keep payload < 4KB worst-case
+- [ ] 3.4 Confirm payload size with worst-case populated values; deploy to a test ES instance for client integration testing
+
+## 4. Cross-platform suppression store (mute + quiet-hours + noise-filter)
+
+- [ ] 4.1 Define on-disk format: JSON array of entries `{kind, profile_id, …}` per `notification-mute-store/spec.md`
+- [ ] 4.2 iOS: `MuteStore.swift` module backed by App Group `UserDefaults` (suite `group.com.zoneminder.zmNinjaNG`); read/write/lookup/expire APIs covering all three entry kinds
+- [ ] 4.3 Android: `MuteStore.kt` module backed by `SharedPreferences` (single shared file); same API surface
+- [ ] 4.4 JS bridge: `app/src/plugins/suppression-store/` Capacitor plugin shim with `list()`, `add()`, `update()`, `remove()`, plus typed entry-kind helpers
+- [ ] 4.5 Web shim: `localStorage`-backed implementation for parity (no native push on web, but the noise-filter rules must still drive the Events list)
+- [ ] 4.6 Quiet-hours evaluator (shared logic): given `now` (local) and a window entry, return active/inactive — handle weekday mask, midnight crossing
+- [ ] 4.7 Noise-filter evaluator (shared logic): given event and rule, return `match: bool, mode`
+- [ ] 4.8 Unit tests for read/write/expiry semantics on both native sides + JS shim
+- [ ] 4.9 Concurrent access test (read during write does not return torn data)
+
+## 5. Per-monitor priority — settings + cross-process read
+
+- [ ] 5.1 Add `priority` field to monitor settings under `getProfileSettings`/`updateProfileSettings`; default `normal`
+- [ ] 5.2 Migration: detect legacy `notifications_enabled = false` and present as `silent`; on first save, write `priority = silent` and clear the legacy field
+- [ ] 5.3 Cross-process read accessor: extension/service reads from same App Group / SharedPreferences source the React app writes to
+- [ ] 5.4 Display priority badge on `MonitorCard` (`app/src/components/monitors/MonitorCard.tsx`) when non-default
+
+## 6. iOS — App Group + entitlements + Widget target setup
+
+- [ ] 6.1 Add App Group capability to main app target, `ImageNotification` extension, and the new Widget target in Xcode
+- [ ] 6.2 Add Keychain Sharing capability if action handlers need credentials (defer if not needed for v1)
+- [ ] 6.3 Update Apple Developer provisioning profiles for all three targets (maintainer-side)
+- [ ] 6.4 Verify all three targets read/write the same App Group `UserDefaults` suite and shared file paths
+
+## 7. iOS — Service Extension upgrades
+
+- [ ] 7.1 Extend `app/ios/App/ImageNotification/NotificationService.swift` to read `profile_id`, `monitor_id`, `alarm_score`, `cause_text`; consult the suppression store; drop the push when matched
+- [ ] 7.2 Add locale resolution from App Group `UserDefaults` (key: `selectedLocale`); default to English when missing
+- [ ] 7.3 Ship `Localizable.strings` for en, de, es, fr, zh inside the extension bundle (templated keys: title format, label vocabulary, action labels, monitor-fallback)
+- [ ] 7.4 Implement title formatting: `<top-label> <confidence>% · <monitor_name>` when applicable; fallback to `<monitor_name>`
+- [ ] 7.5 Implement multi-frame strip composition (parallel `URLSession` fetches via `DispatchGroup`, `UIGraphics` horizontal composite, single JPEG attachment); fallback to single image when strip absent
+- [ ] 7.6 Honour `category_id` and per-monitor priority — set `interruptionLevel` based on priority lookup
+- [ ] 7.7 Update event-snapshot file in App Group container with the new event (capability `quick-look-surfaces`)
+
+## 8. iOS — Notification categories + action handlers
+
+- [ ] 8.1 Register `UNNotificationCategory` (`zmEventStandard`) with three `UNNotificationAction`s in `AppDelegate.swift` at app launch: `mute1h` (no `.foreground`), `reviewed` (no `.foreground`), `live` (with `.foreground`)
+- [ ] 8.2 Implement `userNotificationCenter(_:didReceive:withCompletionHandler:)` to dispatch on `actionIdentifier`
+- [ ] 8.3 `mute1h` handler: write a mute entry via `MuteStore` with `until = now + 3600s`, log via `os_log`, complete without UI
+- [ ] 8.4 `reviewed` handler: append the `event_id` to a "review-pending" file in App Group container; the React app drains on next foreground
+- [ ] 8.5 `live` handler: emit deep link `zmninja://monitor/<monitor_id>?profile_id=<profile_id>&pip=auto`
+- [ ] 8.6 Wire deep-link handler in `AppDelegate.swift` / `Info.plist` URL schemes if not already present (also used by widgets)
+
+## 9. Android — Custom FirebaseMessagingService + channels
+
+- [ ] 9.1 Create `app/android/app/src/main/java/.../ZMNFirebaseMessagingService.kt` extending `FirebaseMessagingService`
+- [ ] 9.2 Register in `AndroidManifest.xml` ahead of Capacitor's plugin service
+- [ ] 9.3 Create the four `NotificationChannel`s on first launch: `zmn_high`, `zmn_normal`, `zmn_low`, `zmn_silent`
+- [ ] 9.4 Channel migration: copy legacy single channel's user-tweaked settings to `zmn_normal`, delete legacy channel, set a one-time-shown flag, surface in-app notice on first foreground after migration
+- [ ] 9.5 In `onMessageReceived`: parse same payload fields as iOS; consult suppression store via `MuteStore`; drop if matched
+- [ ] 9.6 Foreground branch: hand off to Capacitor pipeline (per spike #1.2 outcome) so existing JS toast/dedup runs
+- [ ] 9.7 Background branch: build `NotificationCompat.Builder` with `BigPictureStyle` (single image or composited strip), formatted title, three `addAction()` entries; pick channel based on per-monitor priority
+- [ ] 9.8 Ship per-language `strings.xml` keys for title format, label vocabulary, action labels (en, de, es, fr, zh)
+- [ ] 9.9 Read selected locale from `SharedPreferences` (key: `selectedLocale` written by React app)
+- [ ] 9.10 Implement Bitmap composite for the 3-frame strip (parallel OkHttp calls, `Canvas` horizontal composite)
+- [ ] 9.11 Update event-snapshot file via `ContentProvider` (capability `quick-look-surfaces`)
+
+## 10. Android — Action handlers
+
+- [ ] 10.1 Create `MuteActionReceiver` (`BroadcastReceiver`) — writes mute entry via `MuteStore`, dismisses notification, returns
+- [ ] 10.2 Create `ReviewedActionReceiver` — appends to review-pending shared file, dismisses, returns
+- [ ] 10.3 Wire `addAction()` `PendingIntent`s targeting the receivers (mute, reviewed) and an Activity (live) with extras: `monitor_id`, `profile_id`
+- [ ] 10.4 Live action target: existing `MainActivity` with deep-link URI `zmninja://monitor/<monitor_id>?profile_id=<profile_id>&pip=auto`
+
+## 11. PiP-on-tap deep link
+
+- [ ] 11.1 Update `app/src/plugins/pip/index.ts` (and platform implementations) to expose `engageOnReady(videoEl)` API safe to call when PiP is unsupported
+- [ ] 11.2 Update `app/src/pages/MonitorDetail.tsx` to read `pip=auto` query param; call `engageOnReady` once the video is ready
+- [ ] 11.3 Update the app's deep-link handler (Capacitor `App.addListener('appUrlOpen', ...)`) to route `zmninja://monitor/<id>?…` to `MonitorDetail` and `zmninja://event/<id>?…` to `EventDetail`
+- [ ] 11.4 Handle profile mismatch — switch active profile before mounting the target route if `profile_id` differs from the currently active one
+
+## 12. Reviewed-state store + integrations
+
+- [ ] 12.1 Create `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted via Capacitor `Preferences` / `localStorage`); versioned key
+- [ ] 12.2 Drain logic: on app foreground, read the iOS App Group / Android shared "review-pending" source and merge into store; clear source after successful merge
+- [ ] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
+- [ ] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
+- [ ] 12.5 Visual treatment: 50% opacity + checkmark icon on reviewed events across `EventCard`, `Events.tsx`, dashboard recent-events widget, montage view (where applicable)
+- [ ] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session)
+- [ ] 12.7 Unit tests for store, batched-write performance test, drain test
+
+## 13. Events page — Quick-Search filter bar
+
+- [ ] 13.1 Create `app/src/components/events/QuickSearchFilterBar.tsx` mounted above the events list on `Events.tsx`
+- [ ] 13.2 Implement filters: date range presets + custom picker; monitor multiselect; class chips ({person, vehicle, animal, package, unknown}); cause-contains input; alarm-score-min slider; "Show reviewed"; "Show filtered"
+- [ ] 13.3 Phone-portrait collapse to "Filters · N" with expandable inline panel
+- [ ] 13.4 "Today's high-score events" preset and "Clear all" buttons
+- [ ] 13.5 Persist bar state profile-scoped within session; reset on profile switch and on app restart
+- [ ] 13.6 Coexist with existing `EventsFilterPopover` (popover filters AND with bar filters; independent active-filter counts)
+- [ ] 13.7 Add `data-testid` to every interactive element (rule #13)
+- [ ] 13.8 Use `useDateTimeFormat()` for date display (rule #24)
+
+## 14. Events page — Noise filter integration
+
+- [ ] 14.1 Apply suppression-store `noise_filter` rules to the events list render — hide events where any rule in `mode: hide` matches; dim events where any rule in `mode: dim` matches
+- [ ] 14.2 Distinct visual treatment: noise-dimmed events show a "filtered" icon, distinct from the reviewed-checkmark
+- [ ] 14.3 Resolve stacked dim: cap opacity at 50% when both reviewed and noise-dim apply
+- [ ] 14.4 "Show filtered" session-scoped toggle in the quick-search bar — temporarily un-hides hide-mode events, rendered as noise-dimmed
+- [ ] 14.5 First-run default-rule offer: when >50 low-score events detected in the user's history for the active profile, show one-time dismissable offer (Accept / Decline / Ask later)
+- [ ] 14.6 Single-source-of-truth: rule add/edit/delete in Triage Center reflects in events list on next focus
+
+## 15. Triage Center screen
+
+- [ ] 15.1 Create `app/src/pages/TriageCenter.tsx` with four sections: Mutes, Quiet Hours, Per-Monitor Priority, Noise Filter
+- [ ] 15.2 Mutes section: list ordered by `until` ascending, Clear / Extend (1h, 4h, 24h, custom) per row, empty state
+- [ ] 15.3 Quiet Hours section: list with label, time range, weekdays, monitor scope; Add / Edit / Delete; weekday-mask validation (reject empty)
+- [ ] 15.4 Per-Monitor Priority section: list current profile's monitors with priority selector (`high` / `normal` / `low` / `silent`); info banner explaining OS-level mapping
+- [ ] 15.5 Noise Filter section: list rules with monitor scope, score threshold, cause-exclude patterns, mode; Add / Edit / Delete; help line showing default rule status
+- [ ] 15.6 Use `useDateTimeFormat()` for time-remaining and time-range display (rule #24)
+- [ ] 15.7 Auto-refresh on focus and on a 30 s interval (use `useBandwidthSettings()` if a fitting interval already exists; else hardcoded 30 s with comment justification)
+- [ ] 15.8 Add `data-testid` attributes to all interactive elements (rule #13)
+- [ ] 15.9 Add an entry-point link/button to `app/src/pages/NotificationSettings.tsx`
+- [ ] 15.10 Add route to the app router
+
+## 16. Quick-look surfaces
+
+### iOS Widget
+- [ ] 16.1 Create new WidgetKit extension target in Xcode; configure App Group; bundle identifier
+- [ ] 16.2 Implement three widget sizes (small / medium / large) reading from App Group event-snapshot file
+- [ ] 16.3 Force-refresh on push receipt via `WidgetCenter.shared.reloadTimelines`
+- [ ] 16.4 Tap deep-link via `zmninja://event/...` and `zmninja://monitor/...?pip=auto`
+- [ ] 16.5 Empty state with localized placeholder (extension-shipped strings)
+
+### Android Widget
+- [ ] 16.6 Create `AppWidgetProvider` with three sizes (1×1, 2×2, 4×2) and `RemoteViewsService` for list rendering
+- [ ] 16.7 Read event-snapshot via `ContentProvider`; refresh on push receipt via `AppWidgetManager.notifyAppWidgetViewDataChanged`
+- [ ] 16.8 Tap deep-link to `EventDetail` / `MonitorDetail?pip=auto`
+- [ ] 16.9 Empty state localized via `strings.xml`
+
+### Tauri system-tray
+- [ ] 16.10 Install `tauri-plugin-systemtray` (or equivalent — version-pinned per spike #2)
+- [ ] 16.11 Tray icon with badge dot when unreviewed events exist
+- [ ] 16.12 Click → popover/window listing latest 5 events; click event → bring main window front + route to `EventDetail` / `MonitorDetail?pip=auto`
+- [ ] 16.13 Read event-snapshot from app-data directory; refresh on push delivery
+- [ ] 16.14 Fallback: global keyboard shortcut opening the same popover as a foreground window when tray plugin unavailable
+
+### Web in-tab dock
+- [ ] 16.15 Create `app/src/components/layout/QuickLookDock.tsx` mounted in the root layout
+- [ ] 16.16 Read event-snapshot from `localStorage` (profile-scoped key); subscribe to events store updates for live refresh
+- [ ] 16.17 Hide on viewports < 480 px wide
+- [ ] 16.18 Dismiss button persists per-session in `sessionStorage`
+- [ ] 16.19 Tap event row → navigate to `EventDetail`
+- [ ] 16.20 Empty state localized
+
+### Shared snapshot writer
+- [ ] 16.21 Implement event-snapshot writer in `app/src/services/notifications.ts` (or shared utility) that writes the latest 5 events for the active profile to the platform-specific source on every successful event delivery
+- [ ] 16.22 Snapshot is written on iOS by the Service Extension (capability `push-notification-triage`) and on Android by `ZMNFirebaseMessagingService` (additionally to the JS-side writer for foreground delivery)
+- [ ] 16.23 Profile switch re-points the snapshot to the new profile's source
+
+## 17. i18n — all 5 languages (rule #5)
+
+- [ ] 17.1 Add Triage Center strings to `app/src/locales/{en,de,es,fr,zh}/translation.json` (titles, section headers, labels, empty states, action labels, validation messages, weekday names, priority level names, duration picker options, help banners)
+- [ ] 17.2 Add quick-search filter bar strings (preset names, picker labels, class chip labels, toggle labels, "Clear all", "Today's high-score", collapsed-bar count text)
+- [ ] 17.3 Add reviewed-state strings (action labels, toggle, bulk confirmation, 500-cap notice, overflow menu)
+- [ ] 17.4 Add noise-filter strings (icon tooltips, "Show filtered" toggle, first-run offer copy and buttons, dimmed-card a11y labels)
+- [ ] 17.5 Add web-dock strings (empty state, dismiss tooltip, time-ago via `useDateTimeFormat()`)
+- [ ] 17.6 Add iOS extension `Localizable.strings` for title format template, label vocabulary (`person/vehicle/animal/package/unknown`), action labels (`Mute 1h / Reviewed / Live`), widget empty-state — all 5 locales
+- [ ] 17.7 Add Android `strings.xml` keys for the same set under `values/`, `values-de/`, `values-es/`, `values-fr/`, `values-zh/`
+- [ ] 17.8 Add a build-time check (script in `scripts/`) asserting every extension-shipped key has a value in all 5 locales for both platforms; the script SHALL fail the build on drift
+- [ ] 17.9 Verify all labels fit on a 320 px-wide screen / are concise per rule #23
+
+## 18. Tests
+
+- [ ] 18.1 Unit tests: title formatter (locales × confidence × label counts) — JS helper for in-app surfaces, Swift `XCTest` for iOS extension, Kotlin instrumented test for Android service
+- [ ] 18.2 Unit tests: suppression store — add / lookup / expiry / extend / clear / quiet-hours window evaluation (incl. midnight crossing) / noise-filter rule evaluation / profile-scoped collision
+- [ ] 18.3 Unit tests: deep-link parser for `zmninja://monitor/...?pip=auto` and `zmninja://event/...`
+- [ ] 18.4 Unit tests: `eventReviewState` store — add / batched-add / unmark / persistence / profile switch
+- [ ] 18.5 Unit tests: priority OS-level mapping — given priority, return correct iOS `interruptionLevel` and Android channel id
+- [ ] 18.6 E2E (web/Chromium) `app/tests/features/triage-center.feature` — open from notification settings, list each section, add/edit/delete entries in each, profile switch refresh, with `@visual` baseline
+- [ ] 18.7 E2E (web) `app/tests/features/quick-search-bar.feature` — date / monitor / class / cause / score combinations; preset; clear all; popover coexistence; phone-portrait collapse; persistence across navigation; reset on profile switch
+- [ ] 18.8 E2E (web) `app/tests/features/event-review-state.feature` — per-card mark/unmark; bulk action; show-reviewed toggle; persistence; profile-scoped isolation
+- [ ] 18.9 E2E (web) `app/tests/features/noise-filter.feature` — hide vs. dim mode; cause-exclude; show-filtered session toggle; first-run offer
+- [ ] 18.10 E2E (web) `app/tests/features/web-dock.feature` — visible across routes; dismiss session-scoped; phone-portrait hidden; tap event navigates
+- [ ] 18.11 E2E (web) `app/tests/features/monitor-live-deeplink.feature` — deep-link routes to MonitorDetail; PiP engagement is platform-dependent and verified manually
+- [ ] 18.12 Manual platform verification matrix (iOS phone, iOS tablet, Android phone, Tauri desktop) for: lock-screen presentation, expanded notification action set, Mute 1h enforcement after app kill, Reviewed flow drain, Live deep-link auto-PiP, widget refresh + tap, tray icon + popover, channel migration in-app notice — captured as a checklist artifact in this change directory before archiving
+- [ ] 18.13 Visual baselines on web for all new UI (`@visual` tagged scenarios) regenerated and committed via screenshot-diff (NOT raw screenshots — per memory)
+
+## 19. Documentation
+
+- [ ] 19.1 Update `docs/user-guide/notifications.md`: lock-screen behavior, action buttons, per-monitor priority + OS mapping, mute lifecycle, quiet-hours, noise filter, Triage Center, graceful degradation against older ES + Direct mode
+- [ ] 19.2 Update `docs/user-guide/events.md`: reviewed state, quick-search filter bar, noise filter, "Show reviewed" / "Show filtered" toggles
+- [ ] 19.3 Update `docs/user-guide/dashboard.md` (or new `docs/user-guide/quick-look.md`): widgets / tray / web dock per platform, including how to add the widget on each OS
+- [ ] 19.4 Update `docs/developer-guide/`: `suppression-store` plugin shim, `engageOnReady` PiP API, deep-link contract (`zmninja://`), event-snapshot format and writer, `eventReviewState` Zustand store, Triage Center component map (rule #4)
+- [ ] 19.5 Add a maintainer note covering Apple Developer portal steps for App Group, Keychain Sharing, and the new Widget Extension target
+
+## 20. Verification gate (per AGENTS.md rules #3, #20)
+
+- [ ] 20.1 `npm test` passes
+- [ ] 20.2 `npx tsc --noEmit` passes
+- [ ] 20.3 `npm run build` passes (rule #3 — final check, not just `tsc --noEmit`)
+- [ ] 20.4 `npm run test:e2e -- triage-center.feature quick-search-bar.feature event-review-state.feature noise-filter.feature web-dock.feature monitor-live-deeplink.feature` passes
+- [ ] 20.5 Manual platform matrix from §18.12 passes on iOS phone, iOS tablet, Android phone, Tauri desktop (rule #6 — manual-invoke only, not auto-run)
+- [ ] 20.6 GitHub issue created (rule #2) and conventional-commit messages reference it via `refs #<id>` / `fixes #<id>`
+- [ ] 20.7 Per-task atomic commits per rule #20 — one logical change per commit; no batched unrelated changes per rule #21
+
+## 21. Internal phasing guidance (informational)
+
+The following phase order is the suggested execution sequence within this single change. It is not part of the apply checklist; it exists to coordinate work across the surface area without re-fragmenting the change.
+
+- **Phase A (foundation):** §1, §2, §3, §4, §5, §6 — spikes, ES contract, store, priority field, iOS entitlements
+- **Phase B (push pipeline):** §7, §8, §9, §10 — iOS extension upgrades + actions, Android service + actions
+- **Phase C (in-app surfaces):** §11, §12, §13, §14, §15 — deep link, reviewed state, quick-search, noise filter integration, Triage Center
+- **Phase D (quick-look):** §16 — widgets, tray, dock, snapshot writer
+- **Phase E (polish + ship):** §17, §18, §19, §20 — i18n, tests, docs, verification gate
+
+If plan-phase reveals the change is too large to land safely, this design supports a clean split into 3–5 follow-on changes without restructuring spec content (per `design.md` § R13).

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -103,14 +103,14 @@
 
 ## 13. Events page — Quick-Search filter bar
 
-- [ ] 13.1 Create `app/src/components/events/QuickSearchFilterBar.tsx` mounted above the events list on `Events.tsx`
-- [ ] 13.2 Implement filters: date range presets + custom picker; monitor multiselect; class chips ({person, vehicle, animal, package, unknown}); cause-contains input; alarm-score-min slider; "Show reviewed"; "Show filtered"
-- [ ] 13.3 Phone-portrait collapse to "Filters · N" with expandable inline panel
-- [ ] 13.4 "Today's high-score events" preset and "Clear all" buttons
-- [ ] 13.5 Persist bar state profile-scoped within session; reset on profile switch and on app restart
-- [ ] 13.6 Coexist with existing `EventsFilterPopover` (popover filters AND with bar filters; independent active-filter counts)
-- [ ] 13.7 Add `data-testid` to every interactive element (rule #13)
-- [ ] 13.8 Use `useDateTimeFormat()` for date display (rule #24)
+- [x] 13.1 Create `app/src/components/events/QuickSearchFilterBar.tsx` mounted above the events list on `Events.tsx`
+- [~] 13.2 Implement filters: date range presets + custom picker; monitor multiselect; class chips ({person, vehicle, animal, package, unknown}); cause-contains input; alarm-score-min slider; "Show reviewed"; "Show filtered" — bar MVP includes cause-contains + score-min + Today's HS preset; date range still uses inline `QuickDateRangeButtons`; monitor / class chips deferred (need detection metadata wiring)
+- [~] 13.3 Phone-portrait collapse to "Filters · N" with expandable inline panel — bar uses responsive `flex-col sm:flex-row` layout; explicit "Filters · N" collapsed state deferred until monitor/class chips land
+- [x] 13.4 "Today's high-score events" preset and "Clear all" buttons
+- [x] 13.5 Persist bar state profile-scoped within session; reset on profile switch and on app restart
+- [x] 13.6 Coexist with existing `EventsFilterPopover` (popover filters AND with bar filters; independent active-filter counts)
+- [x] 13.7 Add `data-testid` to every interactive element (rule #13)
+- [x] 13.8 Use `useDateTimeFormat()` for date display (rule #24)
 
 ## 14. Events page — Noise filter integration
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -96,7 +96,7 @@
 - [x] 12.1 Create `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted via Capacitor `Preferences` / `localStorage`); versioned key
 - [ ] 12.2 Drain logic: on app foreground, read the iOS App Group / Android shared "review-pending" source and merge into store; clear source after successful merge
 - [x] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
-- [ ] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
+- [x] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
 - [ ] 12.5 Visual treatment: 50% opacity + checkmark icon on reviewed events across `EventCard`, `Events.tsx`, dashboard recent-events widget, montage view (where applicable)
 - [ ] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session)
 - [~] 12.7 Unit tests for store, batched-write performance test, drain test (store + batched-write covered; drain test deferred to §12.2)

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -199,8 +199,8 @@
 
 ## 19. Documentation
 
-- [ ] 19.1 Update `docs/user-guide/notifications.md`: lock-screen behavior, action buttons, per-monitor priority + OS mapping, mute lifecycle, quiet-hours, noise filter, Triage Center, graceful degradation against older ES + Direct mode
-- [ ] 19.2 Update `docs/user-guide/events.md`: reviewed state, quick-search filter bar, noise filter, "Show reviewed" / "Show filtered" toggles
+- [~] 19.1 Update `docs/user-guide/notifications.md`: lock-screen behavior, action buttons, per-monitor priority + OS mapping, mute lifecycle, quiet-hours, noise filter, Triage Center, graceful degradation against older ES + Direct mode — Triage Center sections + web Quick-Look dock landed; lock-screen / action-buttons / priority sections wait until the native release
+- [x] 19.2 Update `docs/user-guide/events.md`: reviewed state, quick-search filter bar, noise filter, "Show reviewed" / "Show filtered" toggles
 - [ ] 19.3 Update `docs/user-guide/dashboard.md` (or new `docs/user-guide/quick-look.md`): widgets / tray / web dock per platform, including how to add the widget on each OS
 - [ ] 19.4 Update `docs/developer-guide/`: `suppression-store` plugin shim, `engageOnReady` PiP API, deep-link contract (`zmninja://`), event-snapshot format and writer, `eventReviewState` Zustand store, Triage Center component map (rule #4)
 - [ ] 19.5 Add a maintainer note covering Apple Developer portal steps for App Group, Keychain Sharing, and the new Widget Extension target

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -157,12 +157,12 @@
 - [ ] 16.14 Fallback: global keyboard shortcut opening the same popover as a foreground window when tray plugin unavailable
 
 ### Web in-tab dock
-- [ ] 16.15 Create `app/src/components/layout/QuickLookDock.tsx` mounted in the root layout
-- [ ] 16.16 Read event-snapshot from `localStorage` (profile-scoped key); subscribe to events store updates for live refresh
-- [ ] 16.17 Hide on viewports < 480 px wide
-- [ ] 16.18 Dismiss button persists per-session in `sessionStorage`
-- [ ] 16.19 Tap event row → navigate to `EventDetail`
-- [ ] 16.20 Empty state localized
+- [x] 16.15 Create `app/src/components/layout/QuickLookDock.tsx` mounted in the root layout
+- [~] 16.16 Read event-snapshot from `localStorage` (profile-scoped key); subscribe to events store updates for live refresh — currently subscribes to `useNotificationStore.profileEvents` directly; localStorage snapshot adapter pairs with §16.21
+- [x] 16.17 Hide on viewports < 480 px wide
+- [x] 16.18 Dismiss button persists per-session in `sessionStorage`
+- [x] 16.19 Tap event row → navigate to `EventDetail`
+- [x] 16.20 Empty state localized
 
 ### Shared snapshot writer
 - [ ] 16.21 Implement event-snapshot writer in `app/src/services/notifications.ts` (or shared utility) that writes the latest 5 events for the active profile to the platform-specific source on every successful event delivery

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -93,13 +93,13 @@
 
 ## 12. Reviewed-state store + integrations
 
-- [ ] 12.1 Create `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted via Capacitor `Preferences` / `localStorage`); versioned key
+- [x] 12.1 Create `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted via Capacitor `Preferences` / `localStorage`); versioned key
 - [ ] 12.2 Drain logic: on app foreground, read the iOS App Group / Android shared "review-pending" source and merge into store; clear source after successful merge
 - [ ] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
 - [ ] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
 - [ ] 12.5 Visual treatment: 50% opacity + checkmark icon on reviewed events across `EventCard`, `Events.tsx`, dashboard recent-events widget, montage view (where applicable)
 - [ ] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session)
-- [ ] 12.7 Unit tests for store, batched-write performance test, drain test
+- [~] 12.7 Unit tests for store, batched-write performance test, drain test (store + batched-write covered; drain test deferred to §12.2)
 
 ## 13. Events page — Quick-Search filter bar
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -88,8 +88,8 @@
 
 - [x] 11.1 Update `app/src/plugins/pip/index.ts` (and platform implementations) to expose `engageOnReady(videoEl)` API safe to call when PiP is unsupported
 - [x] 11.2 Update `app/src/pages/MonitorDetail.tsx` to read `pip=auto` query param; call `engageOnReady` once the video is ready
-- [ ] 11.3 Update the app's deep-link handler (Capacitor `App.addListener('appUrlOpen', ...)`) to route `zmninja://monitor/<id>?…` to `MonitorDetail` and `zmninja://event/<id>?…` to `EventDetail`
-- [ ] 11.4 Handle profile mismatch — switch active profile before mounting the target route if `profile_id` differs from the currently active one
+- [x] 11.3 Update the app's deep-link handler (Capacitor `App.addListener('appUrlOpen', ...)`) to route `zmninja://monitor/<id>?…` to `MonitorDetail` and `zmninja://event/<id>?…` to `EventDetail`
+- [x] 11.4 Handle profile mismatch — switch active profile before mounting the target route if `profile_id` differs from the currently active one
 
 ## 12. Reviewed-state store + integrations
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -114,12 +114,12 @@
 
 ## 14. Events page — Noise filter integration
 
-- [ ] 14.1 Apply suppression-store `noise_filter` rules to the events list render — hide events where any rule in `mode: hide` matches; dim events where any rule in `mode: dim` matches
-- [ ] 14.2 Distinct visual treatment: noise-dimmed events show a "filtered" icon, distinct from the reviewed-checkmark
-- [ ] 14.3 Resolve stacked dim: cap opacity at 50% when both reviewed and noise-dim apply
-- [ ] 14.4 "Show filtered" session-scoped toggle in the quick-search bar — temporarily un-hides hide-mode events, rendered as noise-dimmed
+- [x] 14.1 Apply suppression-store `noise_filter` rules to the events list render — hide events where any rule in `mode: hide` matches; dim events where any rule in `mode: dim` matches
+- [x] 14.2 Distinct visual treatment: noise-dimmed events show a "filtered" icon, distinct from the reviewed-checkmark
+- [x] 14.3 Resolve stacked dim: cap opacity at 50% when both reviewed and noise-dim apply
+- [x] 14.4 "Show filtered" session-scoped toggle in the quick-search bar — temporarily un-hides hide-mode events, rendered as noise-dimmed
 - [ ] 14.5 First-run default-rule offer: when >50 low-score events detected in the user's history for the active profile, show one-time dismissable offer (Accept / Decline / Ask later)
-- [ ] 14.6 Single-source-of-truth: rule add/edit/delete in Triage Center reflects in events list on next focus
+- [x] 14.6 Single-source-of-truth: rule add/edit/delete in Triage Center reflects in events list on next focus
 
 ## 15. Triage Center screen
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -86,8 +86,8 @@
 
 ## 11. PiP-on-tap deep link
 
-- [ ] 11.1 Update `app/src/plugins/pip/index.ts` (and platform implementations) to expose `engageOnReady(videoEl)` API safe to call when PiP is unsupported
-- [ ] 11.2 Update `app/src/pages/MonitorDetail.tsx` to read `pip=auto` query param; call `engageOnReady` once the video is ready
+- [x] 11.1 Update `app/src/plugins/pip/index.ts` (and platform implementations) to expose `engageOnReady(videoEl)` API safe to call when PiP is unsupported
+- [x] 11.2 Update `app/src/pages/MonitorDetail.tsx` to read `pip=auto` query param; call `engageOnReady` once the video is ready
 - [ ] 11.3 Update the app's deep-link handler (Capacitor `App.addListener('appUrlOpen', ...)`) to route `zmninja://monitor/<id>?…` to `MonitorDetail` and `zmninja://event/<id>?…` to `EventDetail`
 - [ ] 11.4 Handle profile mismatch — switch active profile before mounting the target route if `profile_id` differs from the currently active one
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -20,14 +20,14 @@
 
 ## 4. Cross-platform suppression store (mute + quiet-hours + noise-filter)
 
-- [ ] 4.1 Define on-disk format: JSON array of entries `{kind, profile_id, …}` per `notification-mute-store/spec.md`
+- [x] 4.1 Define on-disk format: JSON array of entries `{kind, profile_id, …}` per `notification-mute-store/spec.md`
 - [ ] 4.2 iOS: `MuteStore.swift` module backed by App Group `UserDefaults` (suite `group.com.zoneminder.zmNinjaNG`); read/write/lookup/expire APIs covering all three entry kinds
 - [ ] 4.3 Android: `MuteStore.kt` module backed by `SharedPreferences` (single shared file); same API surface
 - [ ] 4.4 JS bridge: `app/src/plugins/suppression-store/` Capacitor plugin shim with `list()`, `add()`, `update()`, `remove()`, plus typed entry-kind helpers
-- [ ] 4.5 Web shim: `localStorage`-backed implementation for parity (no native push on web, but the noise-filter rules must still drive the Events list)
-- [ ] 4.6 Quiet-hours evaluator (shared logic): given `now` (local) and a window entry, return active/inactive — handle weekday mask, midnight crossing
-- [ ] 4.7 Noise-filter evaluator (shared logic): given event and rule, return `match: bool, mode`
-- [ ] 4.8 Unit tests for read/write/expiry semantics on both native sides + JS shim
+- [x] 4.5 Web shim: `localStorage`-backed implementation for parity (no native push on web, but the noise-filter rules must still drive the Events list)
+- [x] 4.6 Quiet-hours evaluator (shared logic): given `now` (local) and a window entry, return active/inactive — handle weekday mask, midnight crossing
+- [x] 4.7 Noise-filter evaluator (shared logic): given event and rule, return `match: bool, mode`
+- [~] 4.8 Unit tests for read/write/expiry semantics on both native sides + JS shim — 41 unit tests on JS shim + evaluators landed; native sides deferred
 - [ ] 4.9 Concurrent access test (read during write does not return torn data)
 
 ## 5. Per-monitor priority — settings + cross-process read

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -98,7 +98,7 @@
 - [x] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
 - [x] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
 - [ ] 12.5 Visual treatment: 50% opacity + checkmark icon on reviewed events across `EventCard`, `Events.tsx`, dashboard recent-events widget, montage view (where applicable)
-- [ ] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session)
+- [~] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session) — lightweight integration into existing filter popover; final inline placement on the quick-search bar follows §13
 - [~] 12.7 Unit tests for store, batched-write performance test, drain test (store + batched-write covered; drain test deferred to §12.2)
 
 ## 13. Events page — Quick-Search filter bar

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -123,16 +123,16 @@
 
 ## 15. Triage Center screen
 
-- [ ] 15.1 Create `app/src/pages/TriageCenter.tsx` with four sections: Mutes, Quiet Hours, Per-Monitor Priority, Noise Filter
-- [ ] 15.2 Mutes section: list ordered by `until` ascending, Clear / Extend (1h, 4h, 24h, custom) per row, empty state
-- [ ] 15.3 Quiet Hours section: list with label, time range, weekdays, monitor scope; Add / Edit / Delete; weekday-mask validation (reject empty)
-- [ ] 15.4 Per-Monitor Priority section: list current profile's monitors with priority selector (`high` / `normal` / `low` / `silent`); info banner explaining OS-level mapping
-- [ ] 15.5 Noise Filter section: list rules with monitor scope, score threshold, cause-exclude patterns, mode; Add / Edit / Delete; help line showing default rule status
-- [ ] 15.6 Use `useDateTimeFormat()` for time-remaining and time-range display (rule #24)
+- [x] 15.1 Create `app/src/pages/TriageCenter.tsx` with four sections: Mutes, Quiet Hours, Per-Monitor Priority, Noise Filter
+- [~] 15.2 Mutes section: list ordered by `until` ascending, Clear / Extend (1h, 4h, 24h, custom) per row, empty state — 1h extend in MVP; 4h/24h/custom in §15 follow-up
+- [x] 15.3 Quiet Hours section: list with label, time range, weekdays, monitor scope; Add / Edit / Delete; weekday-mask validation (reject empty)
+- [~] 15.4 Per-Monitor Priority section: list current profile's monitors with priority selector (`high` / `normal` / `low` / `silent`); info banner explaining OS-level mapping — placeholder card; depends on §5 cross-process priority field
+- [x] 15.5 Noise Filter section: list rules with monitor scope, score threshold, cause-exclude patterns, mode; Add / Edit / Delete; help line showing default rule status
+- [x] 15.6 Use `useDateTimeFormat()` for time-remaining and time-range display (rule #24)
 - [ ] 15.7 Auto-refresh on focus and on a 30 s interval (use `useBandwidthSettings()` if a fitting interval already exists; else hardcoded 30 s with comment justification)
-- [ ] 15.8 Add `data-testid` attributes to all interactive elements (rule #13)
-- [ ] 15.9 Add an entry-point link/button to `app/src/pages/NotificationSettings.tsx`
-- [ ] 15.10 Add route to the app router
+- [x] 15.8 Add `data-testid` attributes to all interactive elements (rule #13)
+- [x] 15.9 Add an entry-point link/button to `app/src/pages/NotificationSettings.tsx`
+- [x] 15.10 Add route to the app router
 
 ## 16. Quick-look surfaces
 

--- a/openspec/changes/add-10s-notification-triage/tasks.md
+++ b/openspec/changes/add-10s-notification-triage/tasks.md
@@ -95,7 +95,7 @@
 
 - [x] 12.1 Create `app/src/stores/eventReviewState.ts` (Zustand, profile-scoped, persisted via Capacitor `Preferences` / `localStorage`); versioned key
 - [ ] 12.2 Drain logic: on app foreground, read the iOS App Group / Android shared "review-pending" source and merge into store; clear source after successful merge
-- [ ] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
+- [x] 12.3 Per-card "Mark reviewed" affordance + "Unmark reviewed" overflow item on `EventCard`
 - [ ] 12.4 Bulk "Mark all reviewed" action on the Events page; cap at 500 events with localized notice when exceeded
 - [ ] 12.5 Visual treatment: 50% opacity + checkmark icon on reviewed events across `EventCard`, `Events.tsx`, dashboard recent-events widget, montage view (where applicable)
 - [ ] 12.6 "Show reviewed" toggle integration with quick-search filter bar (default off on phone portrait, on for tablet/desktop, persisted profile-scoped within session)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Summary

- Bootstraps OpenSpec across Claude, Gemini, and agent runtimes, then proposes the **10-second notification triage** milestone end-to-end (proposal + design + 9 capability specs + 21-section task plan) under `openspec/changes/add-10s-notification-triage/`.
- Lands the first executable web slice of that milestone — reviewed-state primitive, `zmninja://` deep-link router with native URL-scheme registration on iOS/Android, suppression store (mute / quiet-hours / noise-filter) with pure-logic evaluators, in-app filter integration on the Events page, and a Triage Center MVP for managing mutes / quiet-hours / noise-filter rules.
- All user-facing strings localized in en, de, es, fr, zh per `AGENTS.md` rule #5. 62 new unit tests; full suite at **1263 / 1263 ✓**.

## What's included

**Planning (OpenSpec)**
- `openspec/` config + `openspec/changes/add-10s-notification-triage/` — proposal, design (14 decisions, 14 risks, migration plan), 9 capability specs, 21-section task plan.
- `/opsx:*` slash commands and skills for Claude, Gemini, and the agent runtime so future planning work is discoverable.

**Code (Phase A/C foundations, web-only — 23 of 148 tasks)**
- **`event-review-state`** ✅ end-to-end: Zustand store, EventCard toggle (`CheckCircle2` + opacity-50), bulk "Mark all reviewed" action with 500-cap toast, hide-by-default with "Show reviewed" toggle.
- **`monitor-live-deeplink`** ✅ end-to-end: `engageOnReady(videoEl)` PiP helper (native first, browser fallback, safe no-op), `MonitorDetail?pip=auto` wiring, `zmninja://` URL scheme registered in `Info.plist` and `AndroidManifest.xml`, profile-switching deep-link router.
- **`notification-mute-store`** ✅ web side: types, pure evaluators (mute / quiet-hours w/ midnight crossing + weekday mask / noise-filter score + cause-exclude), localStorage-backed store under `zmng-suppression-store-v1`, singleton + `useSyncExternalStore` subscription.
- **`event-noise-filter`** ✅ list-side: hide-mode rules drop events from the list, dim-mode renders distinct \"filtered\" icon + opacity-50 (capped when stacked with reviewed), session-scoped \"Show filtered\" toggle.
- **`snooze-management-screen`** ✅ MVP: new `/notifications/triage` route — Mutes / Quiet Hours / Noise Filter sections functional with add / clear / extend; Per-Monitor Priority shows placeholder (depends on §5 cross-process bridge).

## What's deferred

Per `tasks.md` § 21 phasing — these are intentionally NOT in this PR and remain milestone-tracked:

- **Phase A spikes** §1 (Android Capacitor + native FCM coexistence) and §2 (Tauri tray plugin) — block native execution.
- **Phase B native push pipeline** §7–§10 — ES payload contract update, iOS Service Extension upgrades + UNNotificationCategory actions, Android custom `FirebaseMessagingService` + `BroadcastReceiver`s + 4 channels, App Group entitlement.
- **Phase C remainder** §13 quick-search filter bar, §14.5 first-run noise-filter offer, §15 priority section + custom durations + auto-refresh, §10 in-app history drain.
- **Phase D quick-look surfaces** §16 — iOS / Android widgets, Tauri tray, web dock.
- **Phase E ship** §17 extension-shipped i18n, §18 e2e + manual matrix, §19 docs, §20 verification gate.

## Test plan

- [x] `npm test` ✓ 1263 / 1263 (62 new unit tests across `eventReviewState`, `engageOnReady`, `deep-link`, `evaluators`, `WebSuppressionStore`)
- [x] `npx tsc --noEmit` ✓
- [x] `npm run build` ✓ (per rule #3 — `tsc -b` strict pass, not just `tsc --noEmit`)
- [ ] `npm run test:e2e` — add scenarios for reviewed-state, deep link, Triage Center add/edit/clear, noise filter; tagged `@web @visual` per `AGENTS.md`
- [ ] Manual platform matrix (iOS phone, iOS tablet, Android phone, Tauri desktop) — deferred to Phase E
- [ ] Run `/opsx:verify add-10s-notification-triage` for a partial-progress audit
- [ ] Update `docs/user-guide/{notifications,events}.md`

## Notes for review

- This is **the first PR** of a multi-PR milestone. Prefer reviewing `openspec/changes/add-10s-notification-triage/proposal.md` first for context.
- Two intentional divergences from the prior `.planning/PROJECT.md` are recorded in `design.md` § \"Relationship to prior PROJECT.md\": ES payload changes are now in scope, and the milestone is consolidated into a single OpenSpec change.
- No new dependencies; no Capacitor plugins added. Existing PiP plugin extended with a top-level `engageOnReady` helper.
- Every new interactive element carries `data-testid=\"kebab-case-name\"` per rule #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)