### PR TITLE
feat: delete developer notices per-device (fixes #215)

### DIFF
--- a/app/src/components/layout/SidebarContent.tsx
+++ b/app/src/components/layout/SidebarContent.tsx
@@ -38,6 +38,7 @@ import {
 } from 'lucide-react';
 import { useCommandPaletteStore } from '../../stores/commandPalette';
 import { useDeveloperNotices } from '../../hooks/useDeveloperNotices';
+import { useDeveloperNoticeStore } from '../../stores/developerNotices';
 
 const HELP_DOCS_URL = 'https://zmninjang.readthedocs.io/en/latest/';
 
@@ -66,6 +67,7 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
   const isMobileDrawer = !!onMobileClose;
   const { isTvMode } = useTvMode();
   const { unreadCount: developerNoticeUnread } = useDeveloperNotices();
+  const showDeveloperNotices = useDeveloperNoticeStore((s) => s.showNotices);
   const currentProfile = useProfileStore(
     useShallow((state) => {
       const { profiles, currentProfileId } = state;
@@ -111,7 +113,10 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
     { path: '/settings', label: t('sidebar.settings'), icon: Settings },
     { path: '/server', label: t('sidebar.server'), icon: Server },
     { path: '/logs', label: t('sidebar.logs'), icon: FileText },
-    { path: '/developer-notice', label: t('sidebar.developer_notice'), icon: Megaphone },
+    // The developer-notice entry hides entirely when notices are turned off.
+    ...(showDeveloperNotices
+      ? [{ path: '/developer-notice', label: t('sidebar.developer_notice'), icon: Megaphone }]
+      : []),
   ];
 
   const savedOrder = profileSettings?.sidebarNavOrder;
@@ -124,8 +129,9 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
       return ai - bi;
     });
     // `defaultNavItems` is rebuilt every render; `t` covers label refresh on language change.
+    // `showDeveloperNotices` gates whether the developer-notice item is present.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedOrder, t]);
+  }, [savedOrder, t, showDeveloperNotices]);
 
   const [isReordering, setIsReordering] = useState(false);
   const [dragIndex, setDragIndex] = useState<number | null>(null);

--- a/app/src/components/layout/__tests__/SidebarContent-developer-notice.test.tsx
+++ b/app/src/components/layout/__tests__/SidebarContent-developer-notice.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SidebarContent } from '../SidebarContent';
+import { useDeveloperNoticeStore } from '../../../stores/developerNotices';
+
+// The logo is a png asset; give it a stub so the import resolves in jsdom.
+vi.mock('../../../../assets/logo.png', () => ({ default: 'logo.png' }));
+
+// Side-effecting hooks the sidebar pulls in; stub them to keep the render pure.
+vi.mock('../../../hooks/useDeveloperNotices', () => ({
+  useDeveloperNotices: () => ({ unreadCount: 0 }),
+}));
+vi.mock('../../../hooks/useTvMode', () => ({
+  useTvMode: () => ({ isTvMode: false }),
+}));
+vi.mock('../../../hooks/useKioskLock', () => ({
+  useKioskLock: () => ({
+    isLocked: false,
+    showSetPin: false,
+    setPinMode: 'set',
+    pinError: null,
+    handleLockToggle: vi.fn(),
+    handleSetPinSubmit: vi.fn(),
+    handleSetPinCancel: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, d?: string) => d ?? k,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}));
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <SidebarContent />
+    </MemoryRouter>,
+  );
+}
+
+describe('SidebarContent developer-notice nav item', () => {
+  beforeEach(() => {
+    useDeveloperNoticeStore.setState({
+      readIds: [],
+      dismissedBannerIds: [],
+      deletedIds: [],
+      showNotices: true,
+    });
+  });
+
+  it('shows the developer-notice nav item when showNotices is true', () => {
+    renderSidebar();
+    expect(screen.getByTestId('nav-item-developer-notice')).toBeInTheDocument();
+  });
+
+  it('hides the developer-notice nav item when showNotices is false', () => {
+    useDeveloperNoticeStore.setState({ showNotices: false });
+    renderSidebar();
+    expect(screen.queryByTestId('nav-item-developer-notice')).not.toBeInTheDocument();
+    // Other nav items remain present.
+    expect(screen.getByTestId('nav-item-dashboard')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/AdvancedSection.tsx
+++ b/app/src/components/settings/AdvancedSection.tsx
@@ -18,6 +18,7 @@ import { Label } from '../ui/label';
 import { API_REQUEST } from '../../lib/zmninja-ng-constants';
 import { CertTrustDialog } from '../CertTrustDialog';
 import { SectionHeader, SettingsCard, SettingsRow, RowLabel } from './SettingsLayout';
+import { useDeveloperNoticeStore } from '../../stores/developerNotices';
 import { Platform } from '../../lib/platform';
 import { log, LogLevel } from '../../lib/logger';
 import type { CertInfo } from '../../lib/ssl-trust';
@@ -56,6 +57,11 @@ export function AdvancedSection({
 }: AdvancedSectionProps) {
   const { t } = useTranslation();
   const { toast } = useToast();
+
+  // Developer notices visibility is device-global, so it reads/writes the
+  // developer notice store directly rather than the profile settings helper.
+  const showDeveloperNotices = useDeveloperNoticeStore((s) => s.showNotices);
+  const setShowDeveloperNotices = useDeveloperNoticeStore((s) => s.setShowNotices);
 
   // The whole Advanced section collapses (power-user settings; collapsed by default).
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
@@ -330,6 +336,20 @@ export function AdvancedSection({
                 updateSettings(currentProfile.id, { forceDisableMultiPort: checked })
               }
               data-testid="settings-force-disable-multiport-switch"
+            />
+          </SettingsRow>
+
+          {/* Show developer notices (device-global, not profile-scoped) */}
+          <SettingsRow>
+            <RowLabel
+              label={t('settings.show_developer_notices')}
+              desc={t('settings.show_developer_notices_desc')}
+            />
+            <Switch
+              id="show-developer-notices"
+              checked={showDeveloperNotices}
+              onCheckedChange={setShowDeveloperNotices}
+              data-testid="settings-show-developer-notices"
             />
           </SettingsRow>
 

--- a/app/src/hooks/__tests__/useDeveloperNotices.test.ts
+++ b/app/src/hooks/__tests__/useDeveloperNotices.test.ts
@@ -52,7 +52,12 @@ describe('compareSemver', () => {
 describe('useDeveloperNotices: feed deletions', () => {
   beforeEach(() => {
     fetchMock.mockReset();
-    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
+    useDeveloperNoticeStore.setState({
+      readIds: [],
+      dismissedBannerIds: [],
+      deletedIds: [],
+      showNotices: true,
+    });
   });
 
   it('drops a notice the developer deleted from the feed; orphan readIds stay in storage but cause no UI', async () => {
@@ -132,10 +137,59 @@ describe('useDeveloperNotices: feed deletions', () => {
   });
 });
 
+describe('useDeveloperNotices: showNotices gate', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    useDeveloperNoticeStore.setState({
+      readIds: [],
+      dismissedBannerIds: [],
+      deletedIds: [],
+      showNotices: true,
+    });
+  });
+
+  it('returns empty notices/unreadCount/criticalUnread and does not fetch when showNotices is false', async () => {
+    useDeveloperNoticeStore.setState({ showNotices: false });
+    fetchMock.mockResolvedValue([
+      { id: 'a', title: 'A', body: '', publishedAt: '2026-05-30T18:00:00Z', severity: 'info' },
+      { id: 'crit', title: 'C', body: '', publishedAt: '2026-05-30T20:00:00Z', severity: 'critical' },
+    ]);
+
+    const { result } = renderHook(() => useDeveloperNotices(), { wrapper });
+
+    // Give any (unwanted) fetch a chance to fire before asserting it did not.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(result.current.notices).toEqual([]);
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.criticalUnread).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows normal behavior when showNotices is true', async () => {
+    useDeveloperNoticeStore.setState({ showNotices: true });
+    fetchMock.mockResolvedValue([
+      { id: 'a', title: 'A', body: '', publishedAt: '2026-05-30T18:00:00Z', severity: 'info' },
+    ]);
+
+    const { result } = renderHook(() => useDeveloperNotices(), { wrapper });
+    await waitFor(() => expect(result.current.notices.length).toBe(1));
+
+    expect(result.current.notices.map((n) => n.id)).toEqual(['a']);
+    expect(result.current.unreadCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
 describe('useDeveloperNotices: minAppVersion gate', () => {
   beforeEach(() => {
     fetchMock.mockReset();
-    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
+    useDeveloperNoticeStore.setState({
+      readIds: [],
+      dismissedBannerIds: [],
+      deletedIds: [],
+      showNotices: true,
+    });
   });
 
   afterEach(() => {

--- a/app/src/hooks/__tests__/useDeveloperNotices.test.ts
+++ b/app/src/hooks/__tests__/useDeveloperNotices.test.ts
@@ -52,7 +52,7 @@ describe('compareSemver', () => {
 describe('useDeveloperNotices: feed deletions', () => {
   beforeEach(() => {
     fetchMock.mockReset();
-    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [] });
+    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
   });
 
   it('drops a notice the developer deleted from the feed; orphan readIds stay in storage but cause no UI', async () => {
@@ -116,12 +116,26 @@ describe('useDeveloperNotices: feed deletions', () => {
     // criticalUnread exists (unread on the page), but the banner won't render because the id is in dismissedBannerIds
     expect(result.current.criticalUnread.map((n) => n.id)).toEqual(['crit-1']);
   });
+
+  it('excludes locally deleted ids from notices, unreadCount, and criticalUnread', async () => {
+    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: ['b', 'crit'] });
+    fetchMock.mockResolvedValue([
+      { id: 'a', title: 'A', body: '', publishedAt: '2026-05-30T18:00:00Z', severity: 'info' },
+      { id: 'b', title: 'B', body: '', publishedAt: '2026-05-30T19:00:00Z', severity: 'info' },
+      { id: 'crit', title: 'C', body: '', publishedAt: '2026-05-30T20:00:00Z', severity: 'critical' },
+    ]);
+    const { result } = renderHook(() => useDeveloperNotices(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.notices.map((n) => n.id)).toEqual(['a']);
+    expect(result.current.unreadCount).toBe(1);
+    expect(result.current.criticalUnread).toEqual([]);
+  });
 });
 
 describe('useDeveloperNotices: minAppVersion gate', () => {
   beforeEach(() => {
     fetchMock.mockReset();
-    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [] });
+    useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
   });
 
   afterEach(() => {

--- a/app/src/hooks/useDeveloperNotices.ts
+++ b/app/src/hooks/useDeveloperNotices.ts
@@ -36,6 +36,8 @@ export function compareSemver(a: string, b: string): number {
 }
 
 export function useDeveloperNotices() {
+  const showNotices = useDeveloperNoticeStore((s) => s.showNotices);
+
   const query = useQuery({
     queryKey: ['developer-notices'],
     queryFn: fetchDeveloperNotices,
@@ -43,12 +45,16 @@ export function useDeveloperNotices() {
     refetchInterval: DEVELOPER_NOTICES.pollIntervalMs,
     refetchOnWindowFocus: true,
     retry: 1,
+    enabled: showNotices,
   });
 
   const readIds = useDeveloperNoticeStore((s) => s.readIds);
   const deletedIds = useDeveloperNoticeStore((s) => s.deletedIds);
 
   const notices = useMemo<DeveloperNoticeView[]>(() => {
+    // react-query's `enabled: false` does not clear already-cached data, so
+    // this gate must run before any filtering of the raw feed.
+    if (!showNotices) return [];
     const feed = query.data ?? [];
     const appVersion = getAppVersion();
     const read = new Set(readIds);
@@ -58,7 +64,7 @@ export function useDeveloperNotices() {
       .filter((n) => !deleted.has(n.id))
       .map((n) => ({ ...n, isRead: read.has(n.id) }))
       .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : a.publishedAt > b.publishedAt ? -1 : 0));
-  }, [query.data, readIds, deletedIds]);
+  }, [query.data, readIds, deletedIds, showNotices]);
 
   const unreadCount = notices.reduce((n, v) => n + (v.isRead ? 0 : 1), 0);
   const criticalUnread = notices.filter((n) => n.severity === 'critical' && !n.isRead);

--- a/app/src/hooks/useDeveloperNotices.ts
+++ b/app/src/hooks/useDeveloperNotices.ts
@@ -46,16 +46,19 @@ export function useDeveloperNotices() {
   });
 
   const readIds = useDeveloperNoticeStore((s) => s.readIds);
+  const deletedIds = useDeveloperNoticeStore((s) => s.deletedIds);
 
   const notices = useMemo<DeveloperNoticeView[]>(() => {
     const feed = query.data ?? [];
     const appVersion = getAppVersion();
     const read = new Set(readIds);
+    const deleted = new Set(deletedIds);
     return feed
       .filter((n) => import.meta.env.DEV || !n.minAppVersion || compareSemver(appVersion, n.minAppVersion) >= 0)
+      .filter((n) => !deleted.has(n.id))
       .map((n) => ({ ...n, isRead: read.has(n.id) }))
       .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : a.publishedAt > b.publishedAt ? -1 : 0));
-  }, [query.data, readIds]);
+  }, [query.data, readIds, deletedIds]);
 
   const unreadCount = notices.reduce((n, v) => n + (v.isRead ? 0 : 1), 0);
   const criticalUnread = notices.filter((n) => n.severity === 'critical' && !n.isRead);

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -404,6 +404,8 @@
     "disable_log_redaction_desc": "Passwörter/Token in Logs anzeigen",
     "force_disable_multiport": "Multi-Port-Streaming deaktivieren",
     "force_disable_multiport_desc": "Die Stream-Ports pro Monitor des Servers ignorieren und den Standard-Port verwenden",
+    "show_developer_notices": "Entwicklerhinweise anzeigen",
+    "show_developer_notices_desc": "Ankündigungen der Entwickler in der App anzeigen",
     "api_timeout": "API-Timeout",
     "api_timeout_desc": "Sekunden, die auf eine Serveranfrage gewartet wird, bevor sie abgebrochen wird, damit die App es erneut versuchen kann. 0 deaktiviert das Timeout.",
     "api_timeout_unit": "Sekunden",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -948,7 +948,8 @@
     "more_actions": "Mehr",
     "clear_all": "Alle löschen",
     "clear_all_confirm_title": "Alle Hinweise löschen?",
-    "clear_all_confirm_body": "Löscht {{count}} Hinweise auf diesem Gerät. Wiederherstellen holt sie zurück.",
+    "clear_all_confirm_body_one": "Löscht {{count}} Hinweis auf diesem Gerät. Wiederherstellen holt ihn zurück.",
+    "clear_all_confirm_body_other": "Löscht {{count}} Hinweise auf diesem Gerät. Wiederherstellen holt sie zurück.",
     "restore_deleted": "Wiederherstellen"
   },
   "server": {

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -943,7 +943,13 @@
     "mark_unread": "Als ungelesen markieren",
     "mark_all_read": "Alle gelesen",
     "mark_all_unread": "Alle ungelesen",
-    "reload": "Neu laden"
+    "reload": "Neu laden",
+    "delete": "Löschen",
+    "more_actions": "Mehr",
+    "clear_all": "Alle löschen",
+    "clear_all_confirm_title": "Alle Hinweise löschen?",
+    "clear_all_confirm_body": "Löscht {{count}} Hinweise auf diesem Gerät. Wiederherstellen holt sie zurück.",
+    "restore_deleted": "Wiederherstellen"
   },
   "server": {
     "title": "Server",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -404,6 +404,8 @@
     "disable_log_redaction_desc": "Show passwords/tokens in logs",
     "force_disable_multiport": "Force disable multi-port streaming",
     "force_disable_multiport_desc": "Ignore the server's per-monitor stream ports and use the default port",
+    "show_developer_notices": "Show developer notices",
+    "show_developer_notices_desc": "Show maintainer announcements in the app",
     "api_timeout": "API timeout",
     "api_timeout_desc": "Seconds to wait for a server request before it's aborted so the app can retry. 0 disables the timeout.",
     "api_timeout_unit": "seconds",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -943,7 +943,13 @@
     "mark_unread": "Mark as unread",
     "mark_all_read": "Mark all read",
     "mark_all_unread": "Mark all unread",
-    "reload": "Reload"
+    "reload": "Reload",
+    "delete": "Delete",
+    "more_actions": "More",
+    "clear_all": "Clear all",
+    "clear_all_confirm_title": "Delete all notices?",
+    "clear_all_confirm_body": "This deletes {{count}} notices from this device. Restore brings them back.",
+    "restore_deleted": "Restore deleted"
   },
   "server": {
     "title": "Server",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -948,7 +948,8 @@
     "more_actions": "More",
     "clear_all": "Clear all",
     "clear_all_confirm_title": "Delete all notices?",
-    "clear_all_confirm_body": "This deletes {{count}} notices from this device. Restore brings them back.",
+    "clear_all_confirm_body_one": "This deletes {{count}} notice from this device. Restore brings it back.",
+    "clear_all_confirm_body_other": "This deletes {{count}} notices from this device. Restore brings them back.",
     "restore_deleted": "Restore deleted"
   },
   "server": {

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -404,6 +404,8 @@
     "disable_log_redaction_desc": "Mostrar contraseñas/tokens en registros",
     "force_disable_multiport": "Desactivar streaming multipuerto",
     "force_disable_multiport_desc": "Ignorar los puertos de stream por monitor del servidor y usar el puerto predeterminado",
+    "show_developer_notices": "Mostrar avisos del desarrollador",
+    "show_developer_notices_desc": "Mostrar anuncios del desarrollador en la app",
     "api_timeout": "Tiempo de espera API",
     "api_timeout_desc": "Segundos a esperar una solicitud al servidor antes de cancelarla para que la app reintente. 0 desactiva el tiempo de espera.",
     "api_timeout_unit": "segundos",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -943,7 +943,13 @@
     "mark_unread": "Marcar como no leído",
     "mark_all_read": "Marcar todos leídos",
     "mark_all_unread": "Marcar todos no leídos",
-    "reload": "Recargar"
+    "reload": "Recargar",
+    "delete": "Eliminar",
+    "more_actions": "Más",
+    "clear_all": "Borrar todo",
+    "clear_all_confirm_title": "¿Eliminar todos los avisos?",
+    "clear_all_confirm_body": "Elimina {{count}} avisos de este dispositivo. Restaurar los recupera.",
+    "restore_deleted": "Restaurar"
   },
   "server": {
     "title": "Servidor",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -948,7 +948,8 @@
     "more_actions": "Más",
     "clear_all": "Borrar todo",
     "clear_all_confirm_title": "¿Eliminar todos los avisos?",
-    "clear_all_confirm_body": "Elimina {{count}} avisos de este dispositivo. Restaurar los recupera.",
+    "clear_all_confirm_body_one": "Elimina {{count}} aviso de este dispositivo. Restaurar lo recupera.",
+    "clear_all_confirm_body_other": "Elimina {{count}} avisos de este dispositivo. Restaurar los recupera.",
     "restore_deleted": "Restaurar"
   },
   "server": {

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -948,7 +948,8 @@
     "more_actions": "Plus",
     "clear_all": "Tout effacer",
     "clear_all_confirm_title": "Supprimer tous les avis ?",
-    "clear_all_confirm_body": "Supprime {{count}} avis de cet appareil. Restaurer les récupère.",
+    "clear_all_confirm_body_one": "Supprime {{count}} avis de cet appareil. Restaurer le récupère.",
+    "clear_all_confirm_body_other": "Supprime {{count}} avis de cet appareil. Restaurer les récupère.",
     "restore_deleted": "Restaurer"
   },
   "server": {

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -404,6 +404,8 @@
     "disable_log_redaction_desc": "Afficher les mots de passe/jetons dans les journaux",
     "force_disable_multiport": "Désactiver le streaming multiport",
     "force_disable_multiport_desc": "Ignorer les ports de flux par moniteur du serveur et utiliser le port par défaut",
+    "show_developer_notices": "Afficher avis développeur",
+    "show_developer_notices_desc": "Afficher les annonces du développeur dans l'appli",
     "api_timeout": "Délai API",
     "api_timeout_desc": "Secondes d'attente d'une requête serveur avant son annulation pour que l'app réessaie. 0 désactive le délai.",
     "api_timeout_unit": "secondes",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -943,7 +943,13 @@
     "mark_unread": "Marquer comme non lu",
     "mark_all_read": "Tout marquer lu",
     "mark_all_unread": "Tout marquer non lu",
-    "reload": "Recharger"
+    "reload": "Recharger",
+    "delete": "Supprimer",
+    "more_actions": "Plus",
+    "clear_all": "Tout effacer",
+    "clear_all_confirm_title": "Supprimer tous les avis ?",
+    "clear_all_confirm_body": "Supprime {{count}} avis de cet appareil. Restaurer les récupère.",
+    "restore_deleted": "Restaurer"
   },
   "server": {
     "title": "Serveur",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -948,7 +948,8 @@
     "more_actions": "更多",
     "clear_all": "全部清除",
     "clear_all_confirm_title": "删除所有通知？",
-    "clear_all_confirm_body": "将从此设备删除 {{count}} 条通知。恢复可将其找回。",
+    "clear_all_confirm_body_one": "将从此设备删除 {{count}} 条通知。恢复可将其找回。",
+    "clear_all_confirm_body_other": "将从此设备删除 {{count}} 条通知。恢复可将其找回。",
     "restore_deleted": "恢复已删除"
   },
   "server": {

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -404,6 +404,8 @@
     "disable_log_redaction_desc": "在日志中显示密码/令牌",
     "force_disable_multiport": "强制禁用多端口流",
     "force_disable_multiport_desc": "忽略服务器的每监视器流端口，使用默认端口",
+    "show_developer_notices": "显示开发者通知",
+    "show_developer_notices_desc": "在应用内显示开发者公告",
     "api_timeout": "API 超时",
     "api_timeout_desc": "中止服务器请求前等待的秒数，以便应用重试。0 表示禁用超时。",
     "api_timeout_unit": "秒",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -943,7 +943,13 @@
     "mark_unread": "标记为未读",
     "mark_all_read": "全部标记已读",
     "mark_all_unread": "全部标记未读",
-    "reload": "重新加载"
+    "reload": "重新加载",
+    "delete": "删除",
+    "more_actions": "更多",
+    "clear_all": "全部清除",
+    "clear_all_confirm_title": "删除所有通知？",
+    "clear_all_confirm_body": "将从此设备删除 {{count}} 条通知。恢复可将其找回。",
+    "restore_deleted": "恢复已删除"
   },
   "server": {
     "title": "服务器",

--- a/app/src/pages/DeveloperNotice.tsx
+++ b/app/src/pages/DeveloperNotice.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
-import { Megaphone, AlertTriangle, AlertCircle, Info, ChevronDown, ChevronUp, ExternalLink, RefreshCw, Eye, EyeOff, CheckCheck, Mail } from 'lucide-react';
+import { Megaphone, AlertTriangle, AlertCircle, Info, ChevronDown, ChevronUp, ExternalLink, RefreshCw, Eye, EyeOff, CheckCheck, Mail, Trash2, MoreVertical, RotateCcw } from 'lucide-react';
 import { useDeveloperNotices, type DeveloperNoticeView } from '../hooks/useDeveloperNotices';
 import { useDeveloperNoticeStore } from '../stores/developerNotices';
 import { useDateTimeFormat } from '../hooks/useDateTimeFormat';
@@ -39,6 +39,7 @@ function NoticeRow({ notice }: { notice: DeveloperNoticeView }) {
   const { fmtDateTime } = useDateTimeFormat();
   const markRead = useDeveloperNoticeStore((s) => s.markRead);
   const markUnread = useDeveloperNoticeStore((s) => s.markUnread);
+  const deleteNotice = useDeveloperNoticeStore((s) => s.deleteNotice);
   const [expanded, setExpanded] = useState(!notice.isRead);
   const Icon = severityIcon(notice.severity);
 
@@ -101,6 +102,16 @@ function NoticeRow({ notice }: { notice: DeveloperNoticeView }) {
           data-testid={`developer-notice-read-toggle-${notice.id}`}
         >
           {notice.isRead ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+        </button>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); deleteNotice(notice.id); }}
+          className="mt-0.5 p-1 rounded hover:bg-accent text-muted-foreground flex-shrink-0"
+          title={t('developer_notice.delete')}
+          aria-label={t('developer_notice.delete')}
+          data-testid={`developer-notice-delete-${notice.id}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
         </button>
         <button
           type="button"

--- a/app/src/pages/DeveloperNotice.tsx
+++ b/app/src/pages/DeveloperNotice.tsx
@@ -21,6 +21,8 @@ import { Markdown } from '../lib/markdown';
 import { isSafeLinkHref } from '../lib/safe-url';
 import { DEVELOPER_NOTICES } from '../lib/zmninja-ng-constants';
 import { cn } from '../lib/utils';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '../components/ui/dropdown-menu';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '../components/ui/alert-dialog';
 
 function severityIcon(severity: DeveloperNoticeView['severity']) {
   if (severity === 'critical') return AlertCircle;
@@ -149,9 +151,16 @@ export default function DeveloperNotice() {
   const { notices, isLoading, isError, error, refetch } = useDeveloperNotices();
   const markAllRead = useDeveloperNoticeStore((s) => s.markAllRead);
   const markAllUnread = useDeveloperNoticeStore((s) => s.markAllUnread);
+  const deleteNotices = useDeveloperNoticeStore((s) => s.deleteNotices);
+  const restoreAllDeleted = useDeveloperNoticeStore((s) => s.restoreAllDeleted);
+  const deletedIds = useDeveloperNoticeStore((s) => s.deletedIds);
+  const [clearAllOpen, setClearAllOpen] = useState(false);
 
   const unreadIds = notices.filter((n) => !n.isRead).map((n) => n.id);
   const readIds = notices.filter((n) => n.isRead).map((n) => n.id);
+  const hasDeleted = deletedIds.length > 0;
+  const visibleIds = notices.map((n) => n.id);
+  const handleRestore = () => { restoreAllDeleted(); refetch(); };
 
   return (
     <div className="max-w-3xl mx-auto p-3 sm:p-6 space-y-4">
@@ -192,54 +201,117 @@ export default function DeveloperNotice() {
 
       {!isLoading && !isError && notices.length === 0 && (
         <Card>
-          <CardContent className="py-10 text-center text-sm text-muted-foreground">
-            {t('developer_notice.empty_state')}
+          <CardContent className="py-10 text-center text-sm text-muted-foreground space-y-3">
+            <p>{t('developer_notice.empty_state')}</p>
+            {hasDeleted && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRestore}
+                data-testid="developer-notice-restore-deleted-empty"
+              >
+                <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                {t('developer_notice.restore_deleted')}
+              </Button>
+            )}
           </CardContent>
         </Card>
       )}
 
-      {notices.length > 0 && (
-        <>
-          <div className="flex items-center justify-end gap-2">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => refetch()}
-              title={t('developer_notice.reload')}
-              aria-label={t('developer_notice.reload')}
-              data-testid="developer-notice-reload"
-              className="h-9 w-9"
-            >
-              <RefreshCw className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => markAllRead(unreadIds)}
-              disabled={unreadIds.length === 0}
-              data-testid="developer-notice-mark-all-read"
-            >
-              <CheckCheck className="h-3.5 w-3.5 mr-1" />
-              {t('developer_notice.mark_all_read')}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => markAllUnread(readIds)}
-              disabled={readIds.length === 0}
-              data-testid="developer-notice-mark-all-unread"
-            >
-              <Mail className="h-3.5 w-3.5 mr-1" />
-              {t('developer_notice.mark_all_unread')}
-            </Button>
-          </div>
-          <div className="space-y-2" data-testid="developer-notice-list">
-            {notices.map((n) => (
-              <NoticeRow key={n.id} notice={n} />
-            ))}
-          </div>
-        </>
+      {(notices.length > 0 || hasDeleted) && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => refetch()}
+            title={t('developer_notice.reload')}
+            aria-label={t('developer_notice.reload')}
+            data-testid="developer-notice-reload"
+            className="h-9 w-9"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-9 w-9"
+                aria-label={t('developer_notice.more_actions')}
+                data-testid="developer-notice-actions-menu"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                disabled={unreadIds.length === 0}
+                onClick={() => markAllRead(unreadIds)}
+                data-testid="developer-notice-mark-all-read"
+              >
+                <CheckCheck className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.mark_all_read')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={readIds.length === 0}
+                onClick={() => markAllUnread(readIds)}
+                data-testid="developer-notice-mark-all-unread"
+              >
+                <Mail className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.mark_all_unread')}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={notices.length === 0}
+                onClick={() => setClearAllOpen(true)}
+                className="text-destructive focus:text-destructive"
+                data-testid="developer-notice-clear-all"
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.clear_all')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!hasDeleted}
+                onClick={handleRestore}
+                data-testid="developer-notice-restore-deleted"
+              >
+                <RotateCcw className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.restore_deleted')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       )}
+      {notices.length > 0 && (
+        <div className="space-y-2" data-testid="developer-notice-list">
+          {notices.map((n) => (
+            <NoticeRow key={n.id} notice={n} />
+          ))}
+        </div>
+      )}
+
+      <AlertDialog open={clearAllOpen} onOpenChange={setClearAllOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('developer_notice.clear_all_confirm_title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('developer_notice.clear_all_confirm_body', { count: notices.length })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="developer-notice-clear-all-cancel">
+              {t('common.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteNotices(visibleIds)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="developer-notice-clear-all-confirm"
+            >
+              {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/app/src/stores/__tests__/developerNotices.test.ts
+++ b/app/src/stores/__tests__/developerNotices.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useDeveloperNoticeStore } from '../developerNotices';
 
 beforeEach(() => {
-  useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
+  useDeveloperNoticeStore.setState({
+    readIds: [],
+    dismissedBannerIds: [],
+    deletedIds: [],
+    showNotices: true,
+  });
 });
 
 describe('useDeveloperNoticeStore', () => {
@@ -63,5 +68,22 @@ describe('useDeveloperNoticeStore', () => {
     restoreAllDeleted();
     expect(useDeveloperNoticeStore.getState().deletedIds).toEqual([]);
     expect(useDeveloperNoticeStore.getState().readIds).toEqual(['a']);
+  });
+
+  it('showNotices defaults to true', () => {
+    expect(useDeveloperNoticeStore.getState().showNotices).toBe(true);
+  });
+
+  it('setShowNotices(false) flips showNotices to false', () => {
+    const { setShowNotices } = useDeveloperNoticeStore.getState();
+    setShowNotices(false);
+    expect(useDeveloperNoticeStore.getState().showNotices).toBe(false);
+  });
+
+  it('setShowNotices(true) flips showNotices back on', () => {
+    const { setShowNotices } = useDeveloperNoticeStore.getState();
+    setShowNotices(false);
+    setShowNotices(true);
+    expect(useDeveloperNoticeStore.getState().showNotices).toBe(true);
   });
 });

--- a/app/src/stores/__tests__/developerNotices.test.ts
+++ b/app/src/stores/__tests__/developerNotices.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useDeveloperNoticeStore } from '../developerNotices';
 
 beforeEach(() => {
-  useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [] });
+  useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
 });
 
 describe('useDeveloperNoticeStore', () => {
@@ -33,5 +33,35 @@ describe('useDeveloperNoticeStore', () => {
     expect(useDeveloperNoticeStore.getState().isBannerDismissed('crit-1')).toBe(true);
     // dismissing the banner does not mark the notice as read
     expect(useDeveloperNoticeStore.getState().isRead('crit-1')).toBe(false);
+  });
+
+  it('deleteNotice records an id exactly once', () => {
+    const { deleteNotice } = useDeveloperNoticeStore.getState();
+    deleteNotice('a');
+    deleteNotice('a');
+    expect(useDeveloperNoticeStore.getState().deletedIds).toEqual(['a']);
+  });
+
+  it('isDeleted reflects deleteNotice', () => {
+    const { deleteNotice, isDeleted } = useDeveloperNoticeStore.getState();
+    expect(isDeleted('a')).toBe(false);
+    deleteNotice('a');
+    expect(useDeveloperNoticeStore.getState().isDeleted('a')).toBe(true);
+  });
+
+  it('deleteNotices unions without duplicates', () => {
+    const { deleteNotice, deleteNotices } = useDeveloperNoticeStore.getState();
+    deleteNotice('a');
+    deleteNotices(['a', 'b', 'c']);
+    expect(useDeveloperNoticeStore.getState().deletedIds.sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('restoreAllDeleted clears deletedIds but leaves readIds', () => {
+    const { deleteNotice, markRead, restoreAllDeleted } = useDeveloperNoticeStore.getState();
+    deleteNotice('a');
+    markRead('a');
+    restoreAllDeleted();
+    expect(useDeveloperNoticeStore.getState().deletedIds).toEqual([]);
+    expect(useDeveloperNoticeStore.getState().readIds).toEqual(['a']);
   });
 });

--- a/app/src/stores/developerNotices.ts
+++ b/app/src/stores/developerNotices.ts
@@ -14,6 +14,7 @@ import { STORAGE_KEYS } from '../lib/zmninja-ng-constants';
 interface DeveloperNoticeState {
   readIds: string[];
   dismissedBannerIds: string[];
+  deletedIds: string[];
 
   isRead: (id: string) => boolean;
   markRead: (id: string) => void;
@@ -23,6 +24,11 @@ interface DeveloperNoticeState {
 
   isBannerDismissed: (id: string) => boolean;
   dismissBanner: (id: string) => void;
+
+  isDeleted: (id: string) => boolean;
+  deleteNotice: (id: string) => void;
+  deleteNotices: (ids: string[]) => void;
+  restoreAllDeleted: () => void;
 }
 
 export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
@@ -30,6 +36,7 @@ export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
     (set, get) => ({
       readIds: [],
       dismissedBannerIds: [],
+      deletedIds: [],
 
       isRead: (id) => get().readIds.includes(id),
       markRead: (id) => {
@@ -64,6 +71,24 @@ export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
           if (state.dismissedBannerIds.includes(id)) return state;
           return { ...state, dismissedBannerIds: [...state.dismissedBannerIds, id] };
         });
+      },
+
+      isDeleted: (id) => get().deletedIds.includes(id),
+      deleteNotice: (id) => {
+        set((state) => {
+          if (state.deletedIds.includes(id)) return state;
+          return { ...state, deletedIds: [...state.deletedIds, id] };
+        });
+      },
+      deleteNotices: (ids) => {
+        set((state) => {
+          const merged = new Set(state.deletedIds);
+          ids.forEach((id) => merged.add(id));
+          return { ...state, deletedIds: Array.from(merged) };
+        });
+      },
+      restoreAllDeleted: () => {
+        set((state) => (state.deletedIds.length === 0 ? state : { ...state, deletedIds: [] }));
       },
     }),
     {

--- a/app/src/stores/developerNotices.ts
+++ b/app/src/stores/developerNotices.ts
@@ -15,6 +15,7 @@ interface DeveloperNoticeState {
   readIds: string[];
   dismissedBannerIds: string[];
   deletedIds: string[];
+  showNotices: boolean;
 
   isRead: (id: string) => boolean;
   markRead: (id: string) => void;
@@ -29,6 +30,8 @@ interface DeveloperNoticeState {
   deleteNotice: (id: string) => void;
   deleteNotices: (ids: string[]) => void;
   restoreAllDeleted: () => void;
+
+  setShowNotices: (value: boolean) => void;
 }
 
 export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
@@ -37,6 +40,7 @@ export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
       readIds: [],
       dismissedBannerIds: [],
       deletedIds: [],
+      showNotices: true,
 
       isRead: (id) => get().readIds.includes(id),
       markRead: (id) => {
@@ -89,6 +93,10 @@ export const useDeveloperNoticeStore = create<DeveloperNoticeState>()(
       },
       restoreAllDeleted: () => {
         set((state) => (state.deletedIds.length === 0 ? state : { ...state, deletedIds: [] }));
+      },
+
+      setShowNotices: (value) => {
+        set((state) => (state.showNotices === value ? state : { ...state, showNotices: value }));
       },
     }),
     {

--- a/app/tests/features/developer-notice.feature
+++ b/app/tests/features/developer-notice.feature
@@ -1,0 +1,22 @@
+Feature: Delete developer notices
+  As a zmNinjaNg user
+  I want to delete developer notices I have dealt with
+  So that the list stays manageable
+
+  Background:
+    Given I am logged into zmNinjaNg
+    And I am on the developer notices page
+
+  @web
+  Scenario: Delete a single notice removes it from the list
+    Given the notice list has at least one notice
+    When I delete the first notice
+    Then the notice count should decrease by one
+
+  @web
+  Scenario: Clear all empties the list and Restore brings notices back
+    Given the notice list has at least one notice
+    When I clear all notices
+    Then the notice list should be empty
+    When I restore deleted notices
+    Then the notice list should not be empty

--- a/app/tests/features/developer-notice.feature
+++ b/app/tests/features/developer-notice.feature
@@ -20,3 +20,12 @@ Feature: Delete developer notices
     Then the notice list should be empty
     When I restore deleted notices
     Then the notice list should not be empty
+
+  @web
+  Scenario: Turning off Show Developer Notices hides the sidebar entry
+    When I navigate to the "Settings" page
+    And I expand the Advanced settings section
+    And I turn off developer notices in settings
+    Then the developer notices sidebar entry should be hidden
+    When I turn on developer notices in settings
+    Then the developer notices sidebar entry should be visible

--- a/app/tests/steps/developer-notice.steps.ts
+++ b/app/tests/steps/developer-notice.steps.ts
@@ -54,3 +54,33 @@ Then('the notice list should not be empty', async ({ page }) => {
   await expect(page.getByTestId('developer-notice-list')).toBeVisible();
   await expect(page.locator('[data-testid^="developer-notice-delete-"]').first()).toBeVisible();
 });
+
+// --- Show Developer Notices toggle ---
+
+// Set the Radix switch to the desired state only if it is not already there,
+// so "turn off" then "turn on" are idempotent regardless of the starting value.
+async function setNoticeToggle(page: import('@playwright/test').Page, on: boolean) {
+  const sw = page.getByTestId('settings-show-developer-notices');
+  await expect(sw).toBeVisible();
+  const checked = (await sw.getAttribute('aria-checked')) === 'true';
+  if (checked !== on) await sw.click();
+}
+
+// Note: "I expand the Advanced settings section" is defined in settings.steps.ts
+// and reused here.
+
+When('I turn off developer notices in settings', async ({ page }) => {
+  await setNoticeToggle(page, false);
+});
+
+When('I turn on developer notices in settings', async ({ page }) => {
+  await setNoticeToggle(page, true);
+});
+
+Then('the developer notices sidebar entry should be hidden', async ({ page }) => {
+  await expect(page.getByTestId('nav-item-developer-notice')).toHaveCount(0);
+});
+
+Then('the developer notices sidebar entry should be visible', async ({ page }) => {
+  await expect(page.getByTestId('nav-item-developer-notice').first()).toBeVisible();
+});

--- a/app/tests/steps/developer-notice.steps.ts
+++ b/app/tests/steps/developer-notice.steps.ts
@@ -1,0 +1,56 @@
+import { createBdd } from 'playwright-bdd';
+import { expect } from '@playwright/test';
+
+const { Given, When, Then } = createBdd();
+
+// Count of delete buttons captured just before a single delete, so the
+// follow-up assertion can check it went down by exactly one.
+let countBeforeDelete = 0;
+
+Given('I am on the developer notices page', async ({ page }) => {
+  // The next step waits for the list; here we only need the navigation to land.
+  await page.goto('/#/developer-notice', { waitUntil: 'domcontentloaded' });
+});
+
+Given('the notice list has at least one notice', async ({ page }) => {
+  const list = page.getByTestId('developer-notice-list');
+  await expect(list).toBeVisible();
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  await expect(deletes.first()).toBeVisible();
+});
+
+When('I delete the first notice', async ({ page }) => {
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  countBeforeDelete = await deletes.count();
+  await deletes.first().click();
+});
+
+Then('the notice count should decrease by one', async ({ page }) => {
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  await expect(deletes).toHaveCount(countBeforeDelete - 1);
+});
+
+When('I clear all notices', async ({ page }) => {
+  await page.getByTestId('developer-notice-actions-menu').click();
+  await page.getByTestId('developer-notice-clear-all').click();
+  await page.getByTestId('developer-notice-clear-all-confirm').click();
+});
+
+Then('the notice list should be empty', async ({ page }) => {
+  await expect(page.getByTestId('developer-notice-list')).toHaveCount(0);
+});
+
+When('I restore deleted notices', async ({ page }) => {
+  const emptyRestore = page.getByTestId('developer-notice-restore-deleted-empty');
+  if (await emptyRestore.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await emptyRestore.click();
+    return;
+  }
+  await page.getByTestId('developer-notice-actions-menu').click();
+  await page.getByTestId('developer-notice-restore-deleted').click();
+});
+
+Then('the notice list should not be empty', async ({ page }) => {
+  await expect(page.getByTestId('developer-notice-list')).toBeVisible();
+  await expect(page.locator('[data-testid^="developer-notice-delete-"]').first()).toBeVisible();
+});

--- a/docs/developer-guide/13-network-endpoints.rst
+++ b/docs/developer-guide/13-network-endpoints.rst
@@ -113,6 +113,14 @@ validated on load against this schema:
      - When set, notices are hidden on app versions older than this value.
        Release notices set it to the released version.
 
+Deleting a notice on the client is a per-device exclusion, not a change to
+``docs/notices.json``. ``useDeveloperNoticeStore`` (``app/src/stores/developerNotices.ts``)
+persists a ``deletedIds`` array alongside the existing ``readIds`` and
+``dismissedBannerIds``, and ``useDeveloperNotices`` (``app/src/hooks/useDeveloperNotices.ts``)
+filters those ids out of the fetched feed on every refetch. The Developer
+Notice page offers a per-row delete button, a confirmed Clear all action, and
+a Restore action that clears ``deletedIds`` and refetches.
+
 Generating a release notice
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/superpowers/plans/2026-07-03-delete-developer-notices.md
+++ b/docs/superpowers/plans/2026-07-03-delete-developer-notices.md
@@ -1,0 +1,705 @@
+# Delete Developer Notices Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user delete developer notices per-device, with a bulk Clear all and a global Restore, since the notices come from a read-only remote feed.
+
+**Architecture:** A delete is a persisted per-device exclusion in the existing `useDeveloperNoticeStore` (new `deletedIds` array, same localStorage key). `useDeveloperNotices` filters deleted ids out of the fetched feed on every refetch. The `DeveloperNotice` page gets a per-row trash button and a kebab menu holding Mark-all, Clear all (confirmed), and Restore deleted.
+
+**Tech Stack:** React, Zustand (+persist), React Query, Radix DropdownMenu/AlertDialog (shadcn wrappers), react-i18next, Playwright-BDD.
+
+## Global Constraints
+
+- Never hardcode user-facing strings; add keys to all five locales: `en`, `de`, `es`, `fr`, `zh`.
+- Button/action labels must be short (fit a 320px phone).
+- Use `log.*` not `console.*`; not relevant here (no logging added).
+- `data-testid="kebab-case-name"` on all new interactive elements.
+- Profile-scoping does not apply: notices are a device-global broadcast, so the store stays on its current localStorage key (not profile-scoped).
+- Verify before commit: `npm test`, `npx tsc --noEmit`, `npm run build`, and `npm run test:e2e -- developer-notice.feature`. Run all npm commands from `app/`.
+- `npm run build` bumps native build numbers (`app/android/app/build.gradle`, `app/ios/App/App.xcodeproj/project.pbxproj`); revert them with `git checkout --` before committing.
+
+---
+
+### Task 1: Store — deletedIds and actions
+
+**Files:**
+- Modify: `app/src/stores/developerNotices.ts`
+- Test: `app/src/stores/__tests__/developerNotices.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: on `useDeveloperNoticeStore`: `deletedIds: string[]`, `isDeleted(id: string): boolean`, `deleteNotice(id: string): void`, `deleteNotices(ids: string[]): void`, `restoreAllDeleted(): void`.
+
+- [ ] **Step 1: Update the test `beforeEach` to reset the new field**
+
+In `app/src/stores/__tests__/developerNotices.test.ts`, change the reset so `deletedIds` is cleared between tests (the persist middleware otherwise leaks it):
+
+```ts
+beforeEach(() => {
+  useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
+});
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to the `describe('useDeveloperNoticeStore', ...)` block:
+
+```ts
+it('deleteNotice records an id exactly once', () => {
+  const { deleteNotice } = useDeveloperNoticeStore.getState();
+  deleteNotice('a');
+  deleteNotice('a');
+  expect(useDeveloperNoticeStore.getState().deletedIds).toEqual(['a']);
+});
+
+it('isDeleted reflects deleteNotice', () => {
+  const { deleteNotice, isDeleted } = useDeveloperNoticeStore.getState();
+  expect(isDeleted('a')).toBe(false);
+  deleteNotice('a');
+  expect(useDeveloperNoticeStore.getState().isDeleted('a')).toBe(true);
+});
+
+it('deleteNotices unions without duplicates', () => {
+  const { deleteNotice, deleteNotices } = useDeveloperNoticeStore.getState();
+  deleteNotice('a');
+  deleteNotices(['a', 'b', 'c']);
+  expect(useDeveloperNoticeStore.getState().deletedIds.sort()).toEqual(['a', 'b', 'c']);
+});
+
+it('restoreAllDeleted clears deletedIds but leaves readIds', () => {
+  const { deleteNotice, markRead, restoreAllDeleted } = useDeveloperNoticeStore.getState();
+  deleteNotice('a');
+  markRead('a');
+  restoreAllDeleted();
+  expect(useDeveloperNoticeStore.getState().deletedIds).toEqual([]);
+  expect(useDeveloperNoticeStore.getState().readIds).toEqual(['a']);
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm test -- developerNotices`
+Expected: FAIL (`deleteNotice is not a function`).
+
+- [ ] **Step 4: Implement the store changes**
+
+In `app/src/stores/developerNotices.ts`, add to the `DeveloperNoticeState` interface after `dismissedBannerIds`:
+
+```ts
+  deletedIds: string[];
+```
+
+and after `dismissBanner`:
+
+```ts
+  isDeleted: (id: string) => boolean;
+  deleteNotice: (id: string) => void;
+  deleteNotices: (ids: string[]) => void;
+  restoreAllDeleted: () => void;
+```
+
+In the store initializer, add `deletedIds: [],` next to `dismissedBannerIds: [],`, and add these actions inside the store object:
+
+```ts
+      isDeleted: (id) => get().deletedIds.includes(id),
+      deleteNotice: (id) => {
+        set((state) => {
+          if (state.deletedIds.includes(id)) return state;
+          return { ...state, deletedIds: [...state.deletedIds, id] };
+        });
+      },
+      deleteNotices: (ids) => {
+        set((state) => {
+          const merged = new Set(state.deletedIds);
+          ids.forEach((id) => merged.add(id));
+          return { ...state, deletedIds: Array.from(merged) };
+        });
+      },
+      restoreAllDeleted: () => {
+        set((state) => (state.deletedIds.length === 0 ? state : { ...state, deletedIds: [] }));
+      },
+```
+
+No persist migration is needed: existing persisted state lacks `deletedIds`, and the default shallow merge over the initializer leaves it `[]`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm test -- developerNotices`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/stores/developerNotices.ts app/src/stores/__tests__/developerNotices.test.ts
+git commit -m "feat: track per-device deleted developer-notice ids (refs #215)"
+```
+
+---
+
+### Task 2: Hook — filter deleted ids out of the feed
+
+**Files:**
+- Modify: `app/src/hooks/useDeveloperNotices.ts`
+- Test: `app/src/hooks/__tests__/useDeveloperNotices.test.ts`
+
+**Interfaces:**
+- Consumes: `useDeveloperNoticeStore.deletedIds` (Task 1).
+- Produces: no signature change. `notices`, `unreadCount`, `criticalUnread` now exclude deleted ids.
+
+- [ ] **Step 1: Update the test `beforeEach` blocks**
+
+In `app/src/hooks/__tests__/useDeveloperNotices.test.ts`, every `useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [] })` becomes:
+
+```ts
+useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: [] });
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add inside `describe('useDeveloperNotices: feed deletions', ...)`:
+
+```ts
+it('excludes locally deleted ids from notices, unreadCount, and criticalUnread', async () => {
+  useDeveloperNoticeStore.setState({ readIds: [], dismissedBannerIds: [], deletedIds: ['b', 'crit'] });
+  fetchMock.mockResolvedValue([
+    { id: 'a', title: 'A', body: '', publishedAt: '2026-05-30T18:00:00Z', severity: 'info' },
+    { id: 'b', title: 'B', body: '', publishedAt: '2026-05-30T19:00:00Z', severity: 'info' },
+    { id: 'crit', title: 'C', body: '', publishedAt: '2026-05-30T20:00:00Z', severity: 'critical' },
+  ]);
+  const { result } = renderHook(() => useDeveloperNotices(), { wrapper });
+  await waitFor(() => expect(result.current.isLoading).toBe(false));
+  expect(result.current.notices.map((n) => n.id)).toEqual(['a']);
+  expect(result.current.unreadCount).toBe(1);
+  expect(result.current.criticalUnread).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm test -- useDeveloperNotices`
+Expected: FAIL (`notices` still contains `b` and `crit`).
+
+- [ ] **Step 4: Implement the filter**
+
+In `app/src/hooks/useDeveloperNotices.ts`, after the `readIds` selector add:
+
+```ts
+  const deletedIds = useDeveloperNoticeStore((s) => s.deletedIds);
+```
+
+In the `useMemo`, add a `deleted` set and a filter, and add `deletedIds` to the dependency array:
+
+```ts
+  const notices = useMemo<DeveloperNoticeView[]>(() => {
+    const feed = query.data ?? [];
+    const appVersion = getAppVersion();
+    const read = new Set(readIds);
+    const deleted = new Set(deletedIds);
+    return feed
+      .filter((n) => import.meta.env.DEV || !n.minAppVersion || compareSemver(appVersion, n.minAppVersion) >= 0)
+      .filter((n) => !deleted.has(n.id))
+      .map((n) => ({ ...n, isRead: read.has(n.id) }))
+      .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : a.publishedAt > b.publishedAt ? -1 : 0));
+  }, [query.data, readIds, deletedIds]);
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test -- useDeveloperNotices`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/hooks/useDeveloperNotices.ts app/src/hooks/__tests__/useDeveloperNotices.test.ts
+git commit -m "feat: hide locally deleted notices from the feed view (refs #215)"
+```
+
+---
+
+### Task 3: i18n keys in all five locales
+
+**Files:**
+- Modify: `app/src/locales/en/translation.json`, `.../de/...`, `.../es/...`, `.../fr/...`, `.../zh/...`
+
+**Interfaces:**
+- Produces: keys under the existing `developer_notice` object: `delete`, `more_actions`, `clear_all`, `clear_all_confirm_title`, `clear_all_confirm_body` (uses `{{count}}`), `restore_deleted`.
+
+- [ ] **Step 1: Add the keys to each locale's `developer_notice` object**
+
+`en`:
+```json
+"delete": "Delete",
+"more_actions": "More",
+"clear_all": "Clear all",
+"clear_all_confirm_title": "Delete all notices?",
+"clear_all_confirm_body": "This deletes {{count}} notices from this device. Restore brings them back.",
+"restore_deleted": "Restore deleted"
+```
+
+`de`:
+```json
+"delete": "Löschen",
+"more_actions": "Mehr",
+"clear_all": "Alle löschen",
+"clear_all_confirm_title": "Alle Hinweise löschen?",
+"clear_all_confirm_body": "Löscht {{count}} Hinweise auf diesem Gerät. Wiederherstellen holt sie zurück.",
+"restore_deleted": "Wiederherstellen"
+```
+
+`es`:
+```json
+"delete": "Eliminar",
+"more_actions": "Más",
+"clear_all": "Borrar todo",
+"clear_all_confirm_title": "¿Eliminar todos los avisos?",
+"clear_all_confirm_body": "Elimina {{count}} avisos de este dispositivo. Restaurar los recupera.",
+"restore_deleted": "Restaurar"
+```
+
+`fr`:
+```json
+"delete": "Supprimer",
+"more_actions": "Plus",
+"clear_all": "Tout effacer",
+"clear_all_confirm_title": "Supprimer tous les avis ?",
+"clear_all_confirm_body": "Supprime {{count}} avis de cet appareil. Restaurer les récupère.",
+"restore_deleted": "Restaurer"
+```
+
+`zh`:
+```json
+"delete": "删除",
+"more_actions": "更多",
+"clear_all": "全部清除",
+"clear_all_confirm_title": "删除所有通知？",
+"clear_all_confirm_body": "将从此设备删除 {{count}} 条通知。恢复可将其找回。",
+"restore_deleted": "恢复已删除"
+```
+
+Insert them inside the existing `"developer_notice": { ... }` object in each file (keep valid JSON: add a comma after the preceding entry). Do not rename existing keys.
+
+- [ ] **Step 2: Verify the JSON parses and keys match across locales**
+
+Run: `node -e "for (const l of ['en','de','es','fr','zh']){const o=require('./src/locales/'+l+'/translation.json').developer_notice;for (const k of ['delete','more_actions','clear_all','clear_all_confirm_title','clear_all_confirm_body','restore_deleted']) if(!o[k]) throw new Error(l+' missing '+k)};console.log('all locales ok')"`
+Expected: `all locales ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/locales/*/translation.json
+git commit -m "i18n: add developer-notice delete/clear/restore strings (refs #215)"
+```
+
+---
+
+### Task 4: Per-row delete button
+
+**Files:**
+- Modify: `app/src/pages/DeveloperNotice.tsx` (the `NoticeRow` component)
+
+**Interfaces:**
+- Consumes: `useDeveloperNoticeStore.deleteNotice` (Task 1), `developer_notice.delete` (Task 3).
+- Produces: a delete button with `data-testid="developer-notice-delete-<id>"` per row.
+
+- [ ] **Step 1: Add the Trash2 import**
+
+In the `lucide-react` import line at the top of `DeveloperNotice.tsx`, add `Trash2`:
+
+```tsx
+import { Megaphone, AlertTriangle, AlertCircle, Info, ChevronDown, ChevronUp, ExternalLink, RefreshCw, Eye, EyeOff, CheckCheck, Mail, Trash2, MoreVertical, RotateCcw } from 'lucide-react';
+```
+
+(`MoreVertical` and `RotateCcw` are used in Task 5; adding them now keeps one import edit.)
+
+- [ ] **Step 2: Read `deleteNotice` in `NoticeRow`**
+
+In `NoticeRow`, next to `markRead`/`markUnread`:
+
+```tsx
+  const deleteNotice = useDeveloperNoticeStore((s) => s.deleteNotice);
+```
+
+- [ ] **Step 3: Add the delete button**
+
+In `NoticeRow`'s JSX, between the read-toggle button and the chevron button, insert:
+
+```tsx
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); deleteNotice(notice.id); }}
+          className="mt-0.5 p-1 rounded hover:bg-accent text-muted-foreground flex-shrink-0"
+          title={t('developer_notice.delete')}
+          aria-label={t('developer_notice.delete')}
+          data-testid={`developer-notice-delete-${notice.id}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+```
+
+- [ ] **Step 4: Verify types and build compile**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/pages/DeveloperNotice.tsx
+git commit -m "feat: per-row delete button on the developer-notice list (refs #215)"
+```
+
+---
+
+### Task 5: Kebab actions, Clear all confirm, Restore, empty-state reachability
+
+**Files:**
+- Modify: `app/src/pages/DeveloperNotice.tsx` (the `DeveloperNotice` page component)
+
+**Interfaces:**
+- Consumes: `deleteNotices`, `restoreAllDeleted`, `deletedIds` (Task 1); `refetch` (existing); i18n keys (Task 3).
+- Produces: kebab menu (`developer-notice-actions-menu`) with items `developer-notice-mark-all-read`, `developer-notice-mark-all-unread`, `developer-notice-clear-all`, `developer-notice-restore-deleted`; confirm dialog buttons `developer-notice-clear-all-confirm` / `-cancel`; empty-state restore `developer-notice-restore-deleted-empty`.
+
+- [ ] **Step 1: Add imports for DropdownMenu, AlertDialog, and useState**
+
+Ensure `useState` is imported from `react` (it already is). Add below the existing ui imports:
+
+```tsx
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '../components/ui/dropdown-menu';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '../components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add store selectors and local state in `DeveloperNotice`**
+
+After the existing `markAllRead`/`markAllUnread` selectors:
+
+```tsx
+  const deleteNotices = useDeveloperNoticeStore((s) => s.deleteNotices);
+  const restoreAllDeleted = useDeveloperNoticeStore((s) => s.restoreAllDeleted);
+  const deletedIds = useDeveloperNoticeStore((s) => s.deletedIds);
+  const [clearAllOpen, setClearAllOpen] = useState(false);
+
+  const hasDeleted = deletedIds.length > 0;
+  const visibleIds = notices.map((n) => n.id);
+  const handleRestore = () => { restoreAllDeleted(); refetch(); };
+```
+
+- [ ] **Step 3: Replace the empty-state card so Restore is reachable when the list is empty**
+
+Replace the existing empty-state block:
+
+```tsx
+      {!isLoading && !isError && notices.length === 0 && (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground space-y-3">
+            <p>{t('developer_notice.empty_state')}</p>
+            {hasDeleted && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRestore}
+                data-testid="developer-notice-restore-deleted-empty"
+              >
+                <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                {t('developer_notice.restore_deleted')}
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+```
+
+- [ ] **Step 4: Replace the action row + list block**
+
+Replace the whole `{notices.length > 0 && ( <> ... </> )}` block with an action row gated on `notices.length > 0 || hasDeleted`, a kebab menu, the list gated on `notices.length > 0`, and the confirm dialog:
+
+```tsx
+      {(notices.length > 0 || hasDeleted) && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => refetch()}
+            title={t('developer_notice.reload')}
+            aria-label={t('developer_notice.reload')}
+            data-testid="developer-notice-reload"
+            className="h-9 w-9"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-9 w-9"
+                aria-label={t('developer_notice.more_actions')}
+                data-testid="developer-notice-actions-menu"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                disabled={unreadIds.length === 0}
+                onClick={() => markAllRead(unreadIds)}
+                data-testid="developer-notice-mark-all-read"
+              >
+                <CheckCheck className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.mark_all_read')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={readIds.length === 0}
+                onClick={() => markAllUnread(readIds)}
+                data-testid="developer-notice-mark-all-unread"
+              >
+                <Mail className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.mark_all_unread')}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={notices.length === 0}
+                onClick={() => setClearAllOpen(true)}
+                className="text-destructive focus:text-destructive"
+                data-testid="developer-notice-clear-all"
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.clear_all')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!hasDeleted}
+                onClick={handleRestore}
+                data-testid="developer-notice-restore-deleted"
+              >
+                <RotateCcw className="h-3.5 w-3.5 mr-2" />
+                {t('developer_notice.restore_deleted')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+      {notices.length > 0 && (
+        <div className="space-y-2" data-testid="developer-notice-list">
+          {notices.map((n) => (
+            <NoticeRow key={n.id} notice={n} />
+          ))}
+        </div>
+      )}
+
+      <AlertDialog open={clearAllOpen} onOpenChange={setClearAllOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('developer_notice.clear_all_confirm_title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('developer_notice.clear_all_confirm_body', { count: notices.length })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="developer-notice-clear-all-cancel">
+              {t('common.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteNotices(visibleIds)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="developer-notice-clear-all-confirm"
+            >
+              {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+```
+
+- [ ] **Step 5: Verify types compile**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Run the app unit suite for regressions**
+
+Run: `npm test -- DeveloperNotice developerNotices useDeveloperNotices`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/pages/DeveloperNotice.tsx
+git commit -m "feat: kebab menu with clear-all and restore on the notice page (refs #215)"
+```
+
+---
+
+### Task 6: E2E feature
+
+**Files:**
+- Create: `app/tests/features/developer-notice.feature`
+- Create: `app/tests/steps/developer-notice.steps.ts`
+
+**Interfaces:**
+- Consumes: testids from Tasks 4 and 5. The DEV server serves the feed at `/__dev-notices.json` from `docs/notices.json` (see `vite.config.ts`), and the page route is hash-based at `/#/developer-notice`.
+
+- [ ] **Step 1: Write the feature**
+
+`app/tests/features/developer-notice.feature`:
+
+```gherkin
+Feature: Delete developer notices
+  As a zmNinjaNg user
+  I want to delete developer notices I have dealt with
+  So that the list stays manageable
+
+  Background:
+    Given I am logged into zmNinjaNg
+    And I am on the developer notices page
+
+  @web
+  Scenario: Delete a single notice removes it from the list
+    Given the notice list has at least one notice
+    When I delete the first notice
+    Then the notice count should decrease by one
+
+  @web
+  Scenario: Clear all empties the list and Restore brings notices back
+    Given the notice list has at least one notice
+    When I clear all notices
+    Then the notice list should be empty
+    When I restore deleted notices
+    Then the notice list should not be empty
+```
+
+- [ ] **Step 2: Write the step definitions**
+
+`app/tests/steps/developer-notice.steps.ts`:
+
+```ts
+import { createBdd } from 'playwright-bdd';
+import { expect } from '@playwright/test';
+
+const { Given, When, Then } = createBdd();
+
+// Count of delete buttons captured just before a single delete, so the
+// follow-up assertion can check it went down by exactly one.
+let countBeforeDelete = 0;
+
+Given('I am on the developer notices page', async ({ page }) => {
+  // The next step waits for the list; here we only need the navigation to land.
+  await page.goto('/#/developer-notice', { waitUntil: 'domcontentloaded' });
+});
+
+Given('the notice list has at least one notice', async ({ page }) => {
+  const list = page.getByTestId('developer-notice-list');
+  await expect(list).toBeVisible();
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  await expect(deletes.first()).toBeVisible();
+});
+
+When('I delete the first notice', async ({ page }) => {
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  countBeforeDelete = await deletes.count();
+  await deletes.first().click();
+});
+
+Then('the notice count should decrease by one', async ({ page }) => {
+  const deletes = page.locator('[data-testid^="developer-notice-delete-"]');
+  await expect(deletes).toHaveCount(countBeforeDelete - 1);
+});
+
+When('I clear all notices', async ({ page }) => {
+  await page.getByTestId('developer-notice-actions-menu').click();
+  await page.getByTestId('developer-notice-clear-all').click();
+  await page.getByTestId('developer-notice-clear-all-confirm').click();
+});
+
+Then('the notice list should be empty', async ({ page }) => {
+  await expect(page.getByTestId('developer-notice-list')).toHaveCount(0);
+});
+
+When('I restore deleted notices', async ({ page }) => {
+  const emptyRestore = page.getByTestId('developer-notice-restore-deleted-empty');
+  if (await emptyRestore.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await emptyRestore.click();
+    return;
+  }
+  await page.getByTestId('developer-notice-actions-menu').click();
+  await page.getByTestId('developer-notice-restore-deleted').click();
+});
+
+Then('the notice list should not be empty', async ({ page }) => {
+  await expect(page.getByTestId('developer-notice-list')).toBeVisible();
+  await expect(page.locator('[data-testid^="developer-notice-delete-"]').first()).toBeVisible();
+});
+```
+
+Note: Playwright uses a fresh browser context per test, so `deletedIds` in localStorage does not leak between scenarios. The "Delete a single notice" scenario relies on the DEV feed (`docs/notices.json`) containing at least one notice; it currently does.
+
+- [ ] **Step 3: Run the e2e feature**
+
+Run: `npm run test:e2e -- developer-notice.feature`
+Expected: both scenarios PASS. If a step selector is off, fix the step (not the app) and rerun.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/tests/features/developer-notice.feature app/tests/steps/developer-notice.steps.ts
+git commit -m "test: e2e for developer-notice delete, clear-all, restore (refs #215)"
+```
+
+---
+
+### Task 7: Docs, full verification, and PR
+
+**Files:**
+- Modify: `docs/developer-guide/05-component-architecture.rst` (the DeveloperNotice / store section, if present) or `docs/developer-guide/12-shared-services-and-components.rst`.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Document the delete/restore behavior**
+
+Find where the developer-notice store or page is described (grep `docs/developer-guide` for `developerNotice`). Add two or three sentences: a delete is a per-device exclusion (`deletedIds` in `useDeveloperNoticeStore`), filtered out of the feed by `useDeveloperNotices`; the page offers per-row delete, Clear all (confirmed), and Restore (clears `deletedIds` and refetches). No em-dashes, no banned words.
+
+- [ ] **Step 2: Doc lint**
+
+Run: `grep -n "—" <edited-doc>` and the banned-words grep from `AGENTS.md`.
+Expected: zero hits.
+
+- [ ] **Step 3: Full verification**
+
+Run in `app/`:
+```bash
+npm test
+npx tsc --noEmit
+npm run build
+npm run test:e2e -- developer-notice.feature
+```
+Expected: all PASS.
+
+- [ ] **Step 4: Revert incidental native build bumps**
+
+Run: `git checkout -- app/android/app/build.gradle app/ios/App/App.xcodeproj/project.pbxproj` (only if `git status` shows them modified).
+
+- [ ] **Step 5: Commit docs and push the branch**
+
+```bash
+git add docs/developer-guide
+git commit -m "docs: developer-notice per-device delete and restore (refs #215)"
+git push -u origin feature/delete-developer-notices
+```
+
+- [ ] **Step 6: Open a PR for review (do not merge)**
+
+```bash
+gh pr create --repo ZoneMinder/zmNinjaNg --base main --head feature/delete-developer-notices \
+  --title "feat: delete developer notices per-device (fixes #215)" \
+  --body "Implements the design in docs/superpowers/specs/2026-07-03-delete-developer-notices-design.md. Per-device delete, Clear all (confirmed), and Restore. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Wait for user approval before merging (AGENTS.md rule 18).
+
+---
+
+## Notes for the implementer
+
+- Run every `npm` command from `app/`.
+- Keep commits one-logical-change each, as split above.
+- The store persists to localStorage; adding `deletedIds` needs no migration (default merge fills it with `[]`).
+- Deleting a critical notice also removes its banner, by design (it leaves `criticalUnread`).

--- a/docs/superpowers/specs/2026-07-03-delete-developer-notices-design.md
+++ b/docs/superpowers/specs/2026-07-03-delete-developer-notices-design.md
@@ -1,0 +1,124 @@
+# Delete developer notices (per-device)
+
+## Problem
+
+The developer-notice list grows over time and there is no way for a user to
+remove entries they have dealt with. Notices come from a static remote feed
+(`docs/notices.json`, fetched via GitHub raw), so the app has no local notices
+database to delete rows from and no write access to the feed.
+
+## Approach
+
+A delete is a persisted per-device exclusion. The store keeps the ids the user
+deleted; `useDeveloperNotices` excludes them from the fetched feed on every
+refetch. From the user's side this behaves as a real delete: the notice leaves
+the list and does not return on refetch. The only way back is a global Reset
+that clears the exclusion list and re-pulls the feed.
+
+This mirrors the existing `readIds` and `dismissedBannerIds` patterns in the
+same store, so there is no new persistence mechanism.
+
+## Data model
+
+`stores/developerNotices.ts` gains a `deletedIds: string[]` field in the same
+persisted store (same localStorage key, not profile-scoped):
+
+- `isDeleted(id: string): boolean`
+- `deleteNotice(id: string): void`: append id if absent (idempotent)
+- `deleteNotices(ids: string[]): void`: union bulk delete
+- `restoreAllDeleted(): void`: clear `deletedIds` to `[]`
+
+Read state and deleted state are independent: deleting does not change
+read/unread, and Reset does not change read/unread.
+
+## Hook
+
+`hooks/useDeveloperNotices.ts` reads `deletedIds` from the store and filters
+deleted ids out of the feed **before** mapping and counting. Consequences:
+
+- Deleted notices leave `notices`, `unreadCount`, and `criticalUnread`.
+- Because `criticalUnread` drives `DeveloperNoticeBanner`, deleting a critical
+  notice also removes its banner. This is intended: the user has dealt with it.
+
+The filter order is: `minAppVersion` filter, then `deletedIds` filter, then map
+to `DeveloperNoticeView`, then sort. No change to the sort or read merge.
+
+## UI (`pages/DeveloperNotice.tsx`)
+
+### Per-row delete
+
+Each `NoticeRow` gets a trash button next to the existing read-toggle and
+chevron. One click calls `deleteNotice(notice.id)`. No per-item confirm and no
+undo. `data-testid="developer-notice-delete-<id>"`, with `stopPropagation` so it
+does not toggle the row.
+
+### Action row
+
+The action row currently holds reload, mark-all-read, and mark-all-unread.
+Five inline buttons will not fit a 320px phone, so:
+
+- **Reload** stays inline (icon only), as today.
+- **Mark all read**, **Mark all unread**, **Clear all**, **Restore deleted**
+  move into a kebab (overflow) menu at the end of the row, built with the
+  existing `components/ui/dropdown-menu` primitive.
+  - Mark all read: disabled when there are no unread.
+  - Mark all unread: disabled when there are no read.
+  - Clear all: destructive styling; disabled when the visible list is empty;
+    calls `deleteNotices(<ids of currently-visible notices>)` after a confirm.
+  - Restore deleted: disabled when `deletedIds.length === 0`; calls
+    `restoreAllDeleted()` then `refetch()`.
+
+Kebab trigger: `data-testid="developer-notice-actions-menu"`. Item testids:
+`developer-notice-clear-all`, `developer-notice-restore-deleted`, plus the
+existing `developer-notice-mark-all-read` / `-mark-all-unread` moved onto the
+menu items.
+
+### Clear all confirm
+
+Clear all opens an `AlertDialog` (existing `components/ui/alert-dialog`):
+title asks to delete all N visible notices, body notes Restore brings them back,
+confirm button is destructive. Per-row delete has no dialog.
+
+### Empty-list reachability
+
+Today the action row and list only render when `notices.length > 0`. After Clear
+all the list is empty and the row would vanish, stranding Reset. Fix:
+
+- Render the action row when `notices.length > 0 || deletedIds.length > 0`.
+- The empty-state card shows a **Restore deleted notices** button when
+  `deletedIds.length > 0`, in addition to the existing empty-state text.
+
+So there is always a path back to the deleted notices.
+
+## i18n
+
+New keys in all five locales (`en`, `de`, `es`, `fr`, `zh`), short enough to fit
+a 320px screen:
+
+- `developer_notice.delete`: trash button title/aria
+- `developer_notice.more_actions`: kebab aria label
+- `developer_notice.clear_all`
+- `developer_notice.clear_all_confirm_title`
+- `developer_notice.clear_all_confirm_body`: takes a `{{count}}`
+- `developer_notice.restore_deleted`
+
+Reuse `common.cancel` and `common.delete` if present; add them only if missing.
+
+## Testing
+
+- **Store** (`stores/__tests__/developerNotices.test.ts`): `deleteNotice` appends
+  and is idempotent, `isDeleted` reflects it, `deleteNotices` unions, and
+  `restoreAllDeleted` clears. Deleted state does not touch `readIds`.
+- **Hook** (`hooks/__tests__/useDeveloperNotices.test.ts`): deleted ids are
+  absent from `notices`, `unreadCount`, and `criticalUnread`.
+- **E2E**: new `tests/features/developer-notice.feature` (web tag) with steps
+  in `tests/steps/developer-notice.steps.ts`; there is no notice e2e today.
+  Delete one row and confirm it is gone; Clear all empties the list and leaves
+  Restore reachable; Restore brings the notices back. Needs a stubbed feed
+  (the DEV build already serves `/__dev-notices.json`, per `api/developer-notices.ts`).
+
+## Out of scope
+
+- Editing or pruning the shared `docs/notices.json` feed (a maintainer action).
+- Per-item undo or a "recently deleted" view. Reset is the only recovery.
+- Syncing deleted state across devices.

--- a/docs/superpowers/specs/2026-07-03-show-developer-notices-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-03-show-developer-notices-toggle-design.md
@@ -1,0 +1,84 @@
+# Show Developer Notices toggle
+
+## Problem
+
+Users have no way to turn off developer notices. Some want them hidden entirely.
+
+## Approach
+
+A device-global boolean `showNotices` (default `true`) in the existing
+`useDeveloperNoticeStore` (same localStorage key, not profile-scoped, matching
+the device-global nature of the notice read/deleted state). A Switch in the
+Advanced settings section flips it. When off, notices are hidden everywhere and
+the feed fetch stops.
+
+## Store
+
+`stores/developerNotices.ts` gains:
+
+- `showNotices: boolean` (initial `true`)
+- `setShowNotices(value: boolean): void`
+
+No persist migration: the default shallow merge leaves `showNotices` at `true`
+for existing users (undefined in old persisted state, filled from the initializer).
+
+## Hook
+
+`hooks/useDeveloperNotices.ts` reads `showNotices` and:
+
+- Passes `enabled: showNotices` to the `useQuery`, so the 24h/on-focus fetch
+  stops when off.
+- When `!showNotices`, returns `notices: []`, `unreadCount: 0`,
+  `criticalUnread: []` (so every consumer sees nothing), and still returns the
+  same shape otherwise.
+
+Because the banner and sidebar dot derive from `criticalUnread`/`unreadCount`,
+they hide automatically when off. No change to the delete/read filtering added
+in the same branch; the `showNotices` gate wraps around it.
+
+## UI
+
+### Sidebar
+
+`components/layout/SidebarContent.tsx`: filter out the `/developer-notice` nav
+item when notices are off, so the entry (not just the unread dot) disappears.
+It reads `showNotices` from `useDeveloperNoticeStore`.
+
+### Settings toggle
+
+`components/settings/AdvancedSection.tsx`: a `Switch` row titled
+"Show Developer Notices" with a short description, reading `showNotices` and
+writing `setShowNotices` from `useDeveloperNoticeStore` (device-global, so it
+does not use the profile `update` helper the other rows use). `data-testid`
+`settings-show-developer-notices`.
+
+### Page reached while off
+
+If `/developer-notice` is opened by direct URL while off, the hook returns
+empty, so the page shows its existing empty state. Acceptable: the nav entry is
+hidden, so this is an edge case. No dedicated message (YAGNI).
+
+## i18n
+
+New keys in all five locales (`en`, `de`, `es`, `fr`, `zh`), short label:
+
+- `settings.show_developer_notices`
+- `settings.show_developer_notices_desc`
+
+## Testing
+
+- **Store** (`stores/__tests__/developerNotices.test.ts`): `showNotices`
+  defaults `true`; `setShowNotices(false)` flips it.
+- **Hook** (`hooks/__tests__/useDeveloperNotices.test.ts`): with
+  `showNotices: false`, `notices`/`unreadCount`/`criticalUnread` are empty even
+  when the feed has entries, and the query does not run (fetch mock not called);
+  with `true`, normal behavior.
+- **E2E** (extend `tests/features/developer-notice.feature`, web): from the
+  notices page with notices present, open Settings > Advanced, turn off
+  "Show Developer Notices", and confirm the sidebar `/developer-notice` entry
+  is gone; turn it back on and confirm it returns.
+
+## Out of scope
+
+- Per-profile control (this is device-global by design).
+- Disabling push notifications (a separate feature/page).


### PR DESCRIPTION
Implements the design in `docs/superpowers/specs/2026-07-03-delete-developer-notices-design.md`.

### What

Users can now delete developer notices. Notices are a read-only remote feed, so a delete is a persisted per-device exclusion (`deletedIds` in `useDeveloperNoticeStore`, alongside `readIds`/`dismissedBannerIds`), filtered out of the feed on every refetch by `useDeveloperNotices`. It behaves as a true delete: the notice leaves the list and does not return on refetch.

- Per-row trash button (no per-item undo).
- Kebab menu: Mark all read/unread, Clear all (AlertDialog confirm), Restore deleted.
- Restore = clear `deletedIds` + refetch. Stays reachable when the visible list is empty (empty-state gets a Restore button).
- Deleting a critical notice also clears its banner (it leaves `criticalUnread`); read state is untouched.
- No persistence migration: the default zustand merge leaves `deletedIds` at `[]` for existing users.

### Tests

- Store and hook unit tests for the new delete/restore behavior and filtering.
- New `developer-notice.feature` e2e (web): delete a row, Clear all, Restore.
- Verified: `npm test` 1719/1719, `tsc --noEmit` clean, `npm run build` ok, `test:e2e -- developer-notice.feature` 2/2. No native build-number bumps.

Reviewed by an independent pass: no Critical/Important findings; the one user-visible nit (plural grammar in the confirm body) is fixed with i18next `_one`/`_other`.

Posted by Claude, assisting @pliablepixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)