### PR TITLE
feat(assistant): add Ollama health status

### DIFF
--- a/app/src/components/assistant/AssistantDesktopPanel.tsx
+++ b/app/src/components/assistant/AssistantDesktopPanel.tsx
@@ -17,6 +17,7 @@ import { ASSISTANT, ASSISTANT_PANEL } from '../../lib/zmninja-ng-constants';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { AskPanel } from './AskPanel';
+import { OllamaStatusDot } from './OllamaStatusDot';
 import { useAssistantChrome } from './useAssistantChrome';
 
 export function AssistantDesktopPanel() {
@@ -96,12 +97,15 @@ export function AssistantDesktopPanel() {
         <img src={ASSISTANT.logoPath} alt={t('assistant.title')} className="h-5 w-5 shrink-0 rounded object-contain" />
         <div className="flex-1 min-w-0">
           <div className="truncate text-sm font-medium leading-tight">{t('assistant.title')}</div>
-          <div
-            className="truncate text-[11px] leading-tight text-muted-foreground"
-            title={backendLabel}
-            data-testid="assistant-backend-label"
-          >
-            {backendLabel}
+          <div className="flex items-center gap-1.5">
+            <OllamaStatusDot />
+            <div
+              className="truncate text-[11px] leading-tight text-muted-foreground"
+              title={backendLabel}
+              data-testid="assistant-backend-label"
+            >
+              {backendLabel}
+            </div>
           </div>
         </div>
         <div className="flex items-center gap-1">

--- a/app/src/components/assistant/AssistantIntro.tsx
+++ b/app/src/components/assistant/AssistantIntro.tsx
@@ -20,6 +20,7 @@ export function AssistantIntro({ onExampleClick }: AssistantIntroProps) {
     t('assistant.intro_example_1'),
     t('assistant.intro_example_2'),
     t('assistant.intro_example_3'),
+    t('assistant.intro_example_4'),
   ];
 
   return (

--- a/app/src/components/assistant/AssistantMobileSheet.tsx
+++ b/app/src/components/assistant/AssistantMobileSheet.tsx
@@ -28,6 +28,7 @@ import { ASSISTANT_PANEL } from '../../lib/zmninja-ng-constants';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { AskPanel } from './AskPanel';
+import { OllamaStatusDot } from './OllamaStatusDot';
 import { useAssistantChrome } from './useAssistantChrome';
 
 export function AssistantMobileSheet() {
@@ -168,12 +169,15 @@ export function AssistantMobileSheet() {
 
       {/* Backend label as a slim strip, so the user knows which model answers
           even without the full desktop header. */}
-      <div
-        className="shrink-0 truncate px-3 pb-1 text-[11px] leading-tight text-muted-foreground"
-        title={backendLabel}
-        data-testid="assistant-mobile-backend-label"
-      >
-        {backendLabel}
+      <div className="flex shrink-0 items-center gap-1.5 px-3 pb-1">
+        <OllamaStatusDot />
+        <div
+          className="truncate text-[11px] leading-tight text-muted-foreground"
+          title={backendLabel}
+          data-testid="assistant-mobile-backend-label"
+        >
+          {backendLabel}
+        </div>
       </div>
 
       <div className="min-h-0 flex-1">

--- a/app/src/components/assistant/OllamaStatusDot.tsx
+++ b/app/src/components/assistant/OllamaStatusDot.tsx
@@ -1,0 +1,41 @@
+/**
+ * Ollama connection dot for the assistant header (refs #246).
+ *
+ * Renders nothing unless the Ollama backend is selected. Green = reachable,
+ * red = unreachable, amber (pulsing) = first probe in flight. Self-contained:
+ * it owns the `useOllamaHealth` query, so both the desktop header and the mobile
+ * sheet get the indicator by mounting this one element.
+ */
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../lib/utils';
+import { useOllamaHealth } from '../../hooks/useOllamaHealth';
+
+export function OllamaStatusDot({ className }: { className?: string }) {
+  const { t } = useTranslation();
+  const { enabled, status } = useOllamaHealth();
+  if (!enabled) return null;
+
+  const label =
+    status === 'connected'
+      ? t('assistant.ollama_status_connected')
+      : status === 'disconnected'
+        ? t('assistant.ollama_status_disconnected')
+        : t('assistant.ollama_status_checking');
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      data-testid="assistant-ollama-status"
+      data-status={status}
+      className={cn(
+        'inline-block h-2 w-2 shrink-0 rounded-full',
+        status === 'connected' && 'bg-green-500',
+        status === 'disconnected' && 'bg-red-500',
+        status === 'checking' && 'animate-pulse bg-amber-500',
+        className,
+      )}
+    />
+  );
+}

--- a/app/src/components/assistant/__tests__/AskPanel.test.tsx
+++ b/app/src/components/assistant/__tests__/AskPanel.test.tsx
@@ -68,7 +68,7 @@ describe('AskPanel', () => {
     expect(screen.getByAltText('assistant.title')).toHaveAttribute('src', '/ninjii.png');
     expect(intro).toHaveTextContent('assistant.intro_greeting');
     expect(intro).toHaveTextContent('assistant.intro_help');
-    expect(screen.getAllByTestId('assistant-example-prompt')).toHaveLength(3);
+    expect(screen.getAllByTestId('assistant-example-prompt')).toHaveLength(4);
   });
 
   it('fills the input (does not send) when an example prompt chip is clicked', async () => {

--- a/app/src/components/assistant/__tests__/AssistantMobileSheet.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantMobileSheet.test.tsx
@@ -18,6 +18,12 @@ vi.mock('../../../hooks/useCurrentProfile', () => ({
     settings: { assistantBackend: 'on-device', assistantModelId: 'x', assistantOllamaModel: '' },
   }),
 }));
+// The header dot owns a useQuery probe covered by useOllamaHealth's own test;
+// stub it here (on-device backend, so the dot is hidden) to avoid needing a
+// QueryClientProvider in this layout-focused test.
+vi.mock('../../../hooks/useOllamaHealth', () => ({
+  useOllamaHealth: () => ({ enabled: false, status: 'checking' }),
+}));
 // Stub AskPanel with a real input so focus-to-expand can be exercised.
 vi.mock('../AskPanel', () => ({
   AskPanel: () => (

--- a/app/src/components/assistant/__tests__/AssistantWidget.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantWidget.test.tsx
@@ -24,6 +24,12 @@ vi.mock('../../../hooks/useCurrentProfile', () => ({
 vi.mock('../AskPanel', () => ({
   AskPanel: () => <div data-testid="ask-panel-stub" />,
 }));
+// The header dot owns a useQuery probe covered by useOllamaHealth's own test;
+// stub it here so these chrome tests need no QueryClientProvider. Reflect the
+// selected backend so the dot still renders (or hides) as it would live.
+vi.mock('../../../hooks/useOllamaHealth', () => ({
+  useOllamaHealth: () => ({ enabled: mockSettings.assistantBackend === 'ollama', status: 'connected' }),
+}));
 // Mutable so a test can pick which shell the widget renders. jsdom has no
 // matchMedia, so the real hook returns false (desktop) anyway; this makes the
 // choice explicit and lets one test assert the mobile branch.

--- a/app/src/hooks/__tests__/useOllamaHealth.test.tsx
+++ b/app/src/hooks/__tests__/useOllamaHealth.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { useOllamaHealth } from '../useOllamaHealth';
+
+const mockProfile = vi.hoisted(() => ({
+  value: {
+    currentProfile: { id: 'p1' },
+    settings: {
+      assistantBackend: 'ollama' as string,
+      assistantOllamaBaseUrl: 'http://localhost:11434/v1',
+    },
+  },
+}));
+
+vi.mock('../useCurrentProfile', () => ({
+  useCurrentProfile: () => mockProfile.value,
+}));
+
+vi.mock('../useBandwidthSettings', () => ({
+  useBandwidthSettings: () => ({ assistantHealthInterval: 30000 }),
+}));
+
+vi.mock('../../lib/security/secureStorage', () => ({
+  getSecureValue: vi.fn(async () => undefined),
+}));
+
+const listOpenAiModels = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/assistant/providers/openai', () => ({
+  listOpenAiModels: (...args: unknown[]) => listOpenAiModels(...args),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useOllamaHealth', () => {
+  beforeEach(() => {
+    listOpenAiModels.mockReset();
+    mockProfile.value = {
+      currentProfile: { id: 'p1' },
+      settings: {
+        assistantBackend: 'ollama',
+        assistantOllamaBaseUrl: 'http://localhost:11434/v1',
+      },
+    };
+  });
+
+  it('reports connected when the reachability probe resolves', async () => {
+    listOpenAiModels.mockResolvedValue(['qwen3']);
+    const { result } = renderHook(() => useOllamaHealth(), { wrapper });
+
+    expect(result.current.enabled).toBe(true);
+    await waitFor(() => expect(result.current.status).toBe('connected'));
+  });
+
+  it('reports disconnected when the probe throws', async () => {
+    listOpenAiModels.mockRejectedValue(new Error('unreachable'));
+    const { result } = renderHook(() => useOllamaHealth(), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('disconnected'));
+  });
+
+  it('is disabled (dot hidden) when the backend is on-device', () => {
+    mockProfile.value.settings.assistantBackend = 'on-device';
+    const { result } = renderHook(() => useOllamaHealth(), { wrapper });
+
+    expect(result.current.enabled).toBe(false);
+    expect(listOpenAiModels).not.toHaveBeenCalled();
+  });
+
+  it('probes the configured base URL with the short reachability timeout', async () => {
+    listOpenAiModels.mockResolvedValue([]);
+    const { result } = renderHook(() => useOllamaHealth(), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('connected'));
+    // Reachable-but-empty is still connected, and the probe hits the base URL.
+    expect(listOpenAiModels).toHaveBeenCalledWith('http://localhost:11434/v1', undefined, 8000);
+  });
+});

--- a/app/src/hooks/useOllamaHealth.ts
+++ b/app/src/hooks/useOllamaHealth.ts
@@ -1,0 +1,60 @@
+/**
+ * Live Ollama reachability for the assistant header dot (refs #246).
+ *
+ * Only the Ollama backend has a "connection" to report: on-device WebLLM runs
+ * in-process, so this hook reports `enabled: false` for it and the dot hides.
+ * When Ollama is selected it reuses the same `GET /models` reachability probe as
+ * the settings Test-connection button, re-run on the bandwidth-scoped interval
+ * (rule 8) while the assistant panel is open. The query is mounted only with the
+ * header, so it stops polling when the panel closes.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useCurrentProfile } from './useCurrentProfile';
+import { useBandwidthSettings } from './useBandwidthSettings';
+import { getSecureValue } from '../lib/security/secureStorage';
+import { listOpenAiModels } from '../lib/assistant/providers/openai';
+import { queryKeys } from '../lib/query/query-keys';
+import { ASSISTANT } from '../lib/zmninja-ng-constants';
+
+export type OllamaHealthStatus = 'checking' | 'connected' | 'disconnected';
+
+export interface OllamaHealth {
+  /** True only when the Ollama backend is selected. The dot renders nothing
+   *  otherwise, so callers can mount it unconditionally. */
+  enabled: boolean;
+  status: OllamaHealthStatus;
+}
+
+export function useOllamaHealth(): OllamaHealth {
+  const { currentProfile, settings } = useCurrentProfile();
+  const bandwidth = useBandwidthSettings();
+  const baseUrl = (settings.assistantOllamaBaseUrl ?? '').replace(/\/+$/, '');
+  const enabled = settings.assistantBackend === 'ollama' && !!currentProfile && baseUrl.length > 0;
+
+  const query = useQuery({
+    queryKey: queryKeys.assistantOllamaHealth(currentProfile?.id, baseUrl),
+    queryFn: async () => {
+      const apiKey = currentProfile
+        ? ((await getSecureValue(`${ASSISTANT.apiKeyStoragePrefix}${currentProfile.id}`)) ?? undefined)
+        : undefined;
+      // Reachability only, with the short Test-connection timeout: a status dot
+      // has no reason to wait the 120s chat-turn timeout for an unreachable
+      // host. Resolving means reachable; a throw means down.
+      await listOpenAiModels(baseUrl, apiKey, ASSISTANT.testConnectionTimeoutMs);
+      return true;
+    },
+    enabled,
+    refetchInterval: bandwidth.assistantHealthInterval,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+
+  // First probe (no result yet) reads as checking. After that isSuccess /
+  // isError latch the last known state and stay put during a background
+  // refetch, so the dot never flickers to amber every interval.
+  let status: OllamaHealthStatus = 'checking';
+  if (query.isSuccess) status = 'connected';
+  else if (query.isError) status = 'disconnected';
+
+  return { enabled, status };
+}

--- a/app/src/lib/query/query-keys.ts
+++ b/app/src/lib/query/query-keys.ts
@@ -148,6 +148,12 @@ export const queryKeys = {
   timezone: (profileId: MaybeProfileId) => ['timezone', profileId] as const,
   storages: (profileId: MaybeProfileId) => ['storages', profileId] as const,
 
+  // --- Assistant ----------------------------------------------------------
+  /** Ollama backend reachability probe, keyed by base URL so a URL change
+   *  refetches instead of showing another server's status. */
+  assistantOllamaHealth: (profileId: MaybeProfileId, baseUrl: string) =>
+    ['assistant-ollama-health', profileId, baseUrl] as const,
+
   // --- App-level (not profile-scoped) -------------------------------------
   /** In-app developer notices. App-level, identical across profiles. */
   developerNotices: () => ['developer-notices'] as const,

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -852,6 +852,8 @@ export interface BandwidthSettings {
   timelineNowRefreshInterval: number;
   /** Monitor-detail recent-events list polling interval (ms) */
   monitorRecentEventsInterval: number;
+  /** Assistant Ollama reachability probe interval (ms), while the panel is open */
+  assistantHealthInterval: number;
 }
 
 /**
@@ -877,6 +879,7 @@ export const BANDWIDTH_SETTINGS: Record<BandwidthMode, BandwidthSettings> = {
     wsKeepaliveInterval: 60000, // 60 sec
     timelineNowRefreshInterval: 30000, // 30 sec
     monitorRecentEventsInterval: 30000, // 30 sec
+    assistantHealthInterval: 30000, // 30 sec
   },
   low: {
     monitorStatusInterval: 40000, // 40 sec
@@ -894,6 +897,7 @@ export const BANDWIDTH_SETTINGS: Record<BandwidthMode, BandwidthSettings> = {
     wsKeepaliveInterval: 120000, // 120 sec (2x slower)
     timelineNowRefreshInterval: 60000, // 60 sec (2x slower)
     monitorRecentEventsInterval: 60000, // 60 sec
+    assistantHealthInterval: 60000, // 60 sec (2x slower)
   },
 } as const;
 

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1286,6 +1286,10 @@
     "intro_example_1": "Ereignisse von heute zusammenfassen",
     "intro_example_2": "Ist der Server in Ordnung?",
     "intro_example_3": "Welcher Monitor war am aktivsten?",
+    "intro_example_4": "Fasse meinen Tag zusammen",
+    "ollama_status_connected": "Ollama verbunden",
+    "ollama_status_disconnected": "Ollama nicht erreichbar",
+    "ollama_status_checking": "Prüfe Ollama…",
     "card": {
       "open": "Öffnen"
     },

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1286,6 +1286,10 @@
     "intro_example_1": "Summarize events today",
     "intro_example_2": "Is the server healthy?",
     "intro_example_3": "Which monitor was most active?",
+    "intro_example_4": "Summarize my day",
+    "ollama_status_connected": "Ollama connected",
+    "ollama_status_disconnected": "Ollama not reachable",
+    "ollama_status_checking": "Checking Ollama…",
     "card": {
       "open": "Open"
     },

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1286,6 +1286,10 @@
     "intro_example_1": "Resumir eventos de hoy",
     "intro_example_2": "¿Está el servidor bien?",
     "intro_example_3": "¿Qué monitor fue el más activo?",
+    "intro_example_4": "Resume mi día",
+    "ollama_status_connected": "Ollama conectado",
+    "ollama_status_disconnected": "Ollama no accesible",
+    "ollama_status_checking": "Comprobando Ollama…",
     "card": {
       "open": "Abrir"
     },

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1286,6 +1286,10 @@
     "intro_example_1": "Résumer les événements du jour",
     "intro_example_2": "Le serveur est-il en bon état ?",
     "intro_example_3": "Quel moniteur a été le plus actif ?",
+    "intro_example_4": "Résume ma journée",
+    "ollama_status_connected": "Ollama connecté",
+    "ollama_status_disconnected": "Ollama injoignable",
+    "ollama_status_checking": "Vérification d'Ollama…",
     "card": {
       "open": "Ouvrir"
     },

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1286,6 +1286,10 @@
     "intro_example_1": "总结今天的事件",
     "intro_example_2": "服务器是否正常？",
     "intro_example_3": "哪个监视器最活跃？",
+    "intro_example_4": "总结我的一天",
+    "ollama_status_connected": "Ollama 已连接",
+    "ollama_status_disconnected": "无法连接 Ollama",
+    "ollama_status_checking": "正在检查 Ollama…",
     "card": {
       "open": "打开"
     },

--- a/app/tests/features/assistant.feature
+++ b/app/tests/features/assistant.feature
@@ -6,6 +6,15 @@ Feature: In-app assistant
     When I press the "?" key
     Then I should see the keyboard shortcuts help
 
+  Scenario: The intro suggests a "Summarize my day" example prompt
+    Given I am logged into zmNinjaNg
+    And the assistant is enabled with the mock backend
+    When I press the "?" key
+    Then the assistant panel should open
+    And I should see the example prompt "Summarize my day"
+    When I click the example prompt "Summarize my day"
+    Then the assistant input should contain "Summarize my day"
+
   Scenario: Ask a question that counts events
     Given I am logged into zmNinjaNg
     And the assistant is enabled with the mock backend

--- a/app/tests/steps/assistant.steps.ts
+++ b/app/tests/steps/assistant.steps.ts
@@ -126,6 +126,25 @@ Then('the assistant panel should open', async ({ page }) => {
   await expect(page.getByTestId('assistant-input')).toBeFocused({ timeout: testConfig.timeouts.transition });
 });
 
+Then('I should see the example prompt {string}', async ({ page }, text: string) => {
+  await expect(page.getByTestId('assistant-example-prompt').filter({ hasText: text })).toBeVisible({
+    timeout: testConfig.timeouts.element,
+  });
+});
+
+When('I click the example prompt {string}', async ({ page }, text: string) => {
+  await page.getByTestId('assistant-example-prompt').filter({ hasText: text }).click();
+});
+
+// Clicking a chip fills the input rather than sending (AssistantIntro), so the
+// user can edit before the turn starts. Assert the value landed, not that a
+// reply appeared.
+Then('the assistant input should contain {string}', async ({ page }, text: string) => {
+  await expect(page.getByTestId('assistant-input')).toHaveValue(text, {
+    timeout: testConfig.timeouts.transition,
+  });
+});
+
 When('I ask {string}', async ({ page }, text: string) => {
   await page.getByTestId('assistant-input').fill(text);
   await page.getByTestId('assistant-send').click();

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -1274,6 +1274,20 @@ share ``useAssistantChrome`` for the clear/minimize/close controls, so they
 differ only in layout. The shell stays mounted (hidden) while minimized, so a
 running turn survives collapsing to the button.
 
+**Empty state and connection dot.** With an empty thread ``AskPanel`` renders
+``AssistantIntro``: Ninjii's greeting plus a row of clickable example prompts
+(``assistant.intro_example_1..4``, one of them "Summarize my day") that teach
+the kind of question the assistant answers. A chip click fills the input rather
+than sending, so the user can edit before the turn starts. Next to the backend
+label in both shells sits ``OllamaStatusDot``, which renders nothing unless the
+Ollama backend is selected. When it is, ``useOllamaHealth`` runs the same
+``GET /models`` reachability probe as the Settings Test-connection button on the
+bandwidth-scoped ``assistantHealthInterval`` (30s normal, 60s low) and the dot
+shows green (reachable), red (unreachable), or a pulsing amber for the first
+probe. The query is mounted only with the header, so it stops polling when the
+panel closes; on-device WebLLM has no connection to report, so no dot appears
+for it.
+
 **Driving a turn.** ``AskPanel``'s ``handleSend`` appends the typed message to
 the per-profile thread in ``useAssistantStore``, builds a system prompt from
 the current profile's monitor list and ZM version (``buildSystemPrompt``),

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -13,7 +13,7 @@ Underneath, **Backend** picks where the model runs:
 
 On-device is not offered on phones or tablets: the models need more memory than a mobile app is allowed to use, so they crash it. On a phone or tablet the on-device option is greyed out with a note, and Ollama is the way to use the assistant there. On a desktop or in a browser, on-device is available whenever your GPU supports WebGPU.
 
-The chat window's header always names the model that is answering and where it runs, for example "Gemma 2 2B · On-device" or "qwen2.5:3b · Ollama", so you never have to open Settings to check which one you are talking to.
+The chat window's header always names the model that is answering and where it runs, for example "Gemma 2 2B · On-device" or "qwen2.5:3b · Ollama", so you never have to open Settings to check which one you are talking to. On the Ollama backend a coloured dot next to that label shows whether the server is reachable: green means connected, red means it cannot be reached (check the address, or that the server is running), and a pulsing amber dot means the app is still checking. The dot rechecks periodically while the window is open. On-device has no server to reach, so no dot appears.
 
 ## Asking a Question
 
@@ -22,6 +22,8 @@ Once enabled, there are three ways to start a conversation:
 - Press `?` on a keyboard (desktop, web).
 - Open the command palette (`/`, the sidebar button, or the mobile header icon) and tap **Ask**.
 - Type a leading `?` directly into the command palette's search field.
+
+Before you have typed anything, Ninjii shows a few example prompts as tappable chips (one of them "Summarize my day"). Tapping a chip drops its text into the input so you can send it as-is or edit it first.
 
 Type your question and press Enter (or tap Send). While the assistant is working, a spinner and the name of whatever it is doing (for example, looking up an event or checking a monitor) show above the input. Tap the stop button to cancel a request in progress.
 


### PR DESCRIPTION
## What changed
- Show Ollama connection status in assistant desktop and mobile panels.
- Add health polling, localized labels, tests, and docs.

## Why
The selected Ollama backend had no visible connection state.

## Verification
- npm test
- npx tsc -b
- npm run build
- npm run test:e2e -- assistant.feature

refs #246