### PR TITLE
fix(assistant): Ollama backend fixes for switched/native profiles refs #246

### DIFF
--- a/app/src/components/assistant/__tests__/AssistantWidget.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantWidget.test.tsx
@@ -212,6 +212,9 @@ describe('AssistantWidget', () => {
   });
 
   it('Clear resets the current profile thread and clears activities', async () => {
+    // Native runs the Ollama backend, so the cleared note must not claim an
+    // on-device model was unloaded (there is none to unload).
+    mockSettings = { assistantBackend: 'ollama' };
     useAssistantPanelStore.setState({ state: 'open' });
     useAssistantStore.getState().append('p1', { role: 'user', text: 'is the front door armed?' });
     useAssistantStore.setState({ activities: [{ toolName: 'list_monitors', status: 'done', input: {} }] });
@@ -228,7 +231,7 @@ describe('AssistantWidget', () => {
     // vanishing with no explanation reads as a bug. It is a contextBoundary,
     // so the model cannot see past it either (agent.ts slices there).
     expect(useAssistantStore.getState().getThread('p1')).toEqual([
-      { role: 'assistant', text: '__i18n:assistant.context_cleared_manual', contextBoundary: true },
+      { role: 'assistant', text: '__i18n:assistant.context_cleared_manual_remote', contextBoundary: true },
     ]);
     expect(useAssistantStore.getState().activities).toEqual([]);
   });

--- a/app/src/components/assistant/useAssistantChrome.ts
+++ b/app/src/components/assistant/useAssistantChrome.ts
@@ -15,8 +15,11 @@ import { ASSISTANT } from '../../lib/zmninja-ng-constants';
 import { Platform } from '../../lib/platform';
 
 /** Marks the point the model can no longer see (agent.ts's
- *  sliceAfterContextBoundary), and is rendered as a divider by AskPanel. */
+ *  sliceAfterContextBoundary), and is rendered as a divider by AskPanel. The
+ *  on-device variant tells the user memory was freed; the remote (Ollama)
+ *  variant must not, since no local model was ever loaded to unload. */
 const CONTEXT_CLEARED_MANUAL_KEY = 'assistant.context_cleared_manual';
+const CONTEXT_CLEARED_MANUAL_REMOTE_KEY = 'assistant.context_cleared_manual_remote';
 
 export interface AssistantChrome {
   /** Model + where it runs, e.g. "Qwen3 1.7B · On-device". Empty when nothing
@@ -67,7 +70,11 @@ export function useAssistantChrome(): AssistantChrome {
       // A note rather than an empty panel: a conversation vanishing with no
       // explanation reads as a bug, and this is also the boundary the model
       // cannot see past (agent.ts slices the history here).
-      append(profileId, { role: 'assistant', text: `__i18n:${CONTEXT_CLEARED_MANUAL_KEY}`, contextBoundary: true });
+      const clearedKey =
+        settings.assistantBackend === 'on-device'
+          ? CONTEXT_CLEARED_MANUAL_KEY
+          : CONTEXT_CLEARED_MANUAL_REMOTE_KEY;
+      append(profileId, { role: 'assistant', text: `__i18n:${clearedKey}`, contextBoundary: true });
     },
     minimize,
     close,

--- a/app/src/components/settings/AssistantOllamaSection.tsx
+++ b/app/src/components/settings/AssistantOllamaSection.tsx
@@ -279,8 +279,13 @@ export function AssistantOllamaSection({ settings, update, currentProfile }: Ass
             label={t('settings.assistant.ollama_url')}
             desc={t('settings.assistant.ollama_url_hint')}
           />
+        {/* Show the ZM-derived suggestion as real editable text, not a grey
+            placeholder the user would have to retype from scratch to tweak.
+            Empty stored value still resolves the same way at use time
+            (effectiveBaseUrl below), so clearing the field re-shows the
+            suggestion. */}
         <Input
-          value={settings.assistantOllamaBaseUrl}
+          value={settings.assistantOllamaBaseUrl || suggestedBaseUrl}
           onChange={(e) => update('assistantOllamaBaseUrl', e.target.value)}
           onBlur={() => void loadModels()}
           placeholder={suggestedBaseUrl}

--- a/app/src/components/ui/password-input.tsx
+++ b/app/src/components/ui/password-input.tsx
@@ -37,7 +37,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
       <div className="relative">
         <Input
           type={showPassword ? 'text' : 'password'}
-          className={cn('pr-10', className)}
+          className={cn('pr-12', className)}
           ref={ref}
           {...props}
         />

--- a/app/src/hooks/__tests__/useCurrentProfile.test.ts
+++ b/app/src/hooks/__tests__/useCurrentProfile.test.ts
@@ -9,9 +9,8 @@ vi.mock('../../stores/profile', () => ({
   useProfileStore: vi.fn(),
 }));
 
-vi.mock('../../stores/settings', () => ({
-  useSettingsStore: vi.fn(),
-  DEFAULT_SETTINGS: {
+vi.mock('../../stores/settings', () => {
+  const DEFAULT_SETTINGS = {
     viewMode: 'snapshot',
     displayMode: 'normal',
     theme: 'system',
@@ -25,8 +24,13 @@ vi.mock('../../stores/settings', () => ({
     eventsThumbnailFit: 'contain',
     disableLogRedaction: false,
     dashboardRefreshInterval: 30,
-  },
-}));
+  };
+  return {
+    useSettingsStore: vi.fn(),
+    DEFAULT_SETTINGS,
+    mergeProfileSettings: (raw: Record<string, unknown> | undefined) => ({ ...DEFAULT_SETTINGS, ...raw }),
+  };
+});
 
 vi.mock('zustand/react/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/app/src/hooks/useCurrentProfile.ts
+++ b/app/src/hooks/useCurrentProfile.ts
@@ -17,7 +17,7 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useProfileStore } from '../stores/profile';
-import { useSettingsStore, DEFAULT_SETTINGS } from '../stores/settings';
+import { useSettingsStore, mergeProfileSettings } from '../stores/settings';
 import type { Profile } from '../api/types';
 import type { ProfileSettings } from '../stores/settings';
 
@@ -65,9 +65,12 @@ export function useCurrentProfile(): UseCurrentProfileReturn {
     useShallow((state) => state.profileSettings?.[currentProfileId ?? ''])
   );
 
-  // Merge with defaults in useMemo - only recreates when rawProfileSettings changes
+  // Merge with defaults in useMemo - only recreates when rawProfileSettings
+  // changes. Goes through mergeProfileSettings (not a raw spread) so native
+  // profiles get coerced off the on-device backend here too, since this is the
+  // reactive path the assistant chat and header actually read (refs #246).
   const settings = useMemo(
-    (): ProfileSettings => ({ ...DEFAULT_SETTINGS, ...rawProfileSettings }),
+    (): ProfileSettings => mergeProfileSettings(rawProfileSettings),
     [rawProfileSettings]
   );
 

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1324,6 +1324,7 @@
       "open": "Öffnen"
     },
     "context_cleared_manual": "Unterhaltung gelöscht. Das Modell auf dem Gerät wurde entladen, um Speicher freizugeben; es wird bei deiner nächsten Frage neu geladen.",
+    "context_cleared_manual_remote": "Unterhaltung gelöscht.",
     "model_unavailable_native": "Dieses Modell läuft nicht auf deinem Gerät. Wähle in den Einstellungen ein Modell für das Gerät.",
     "english_only_notice": "Bitte auf Englisch fragen. In anderen Sprachen funktioniert der Assistent nicht zuverlässig: Fragen können falsch verstanden oder ohne Prüfung der Kameras beantwortet werden."
   }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1324,6 +1324,7 @@
       "open": "Open"
     },
     "context_cleared_manual": "Conversation cleared. The on-device model was unloaded to free memory; it will load again on your next question.",
+    "context_cleared_manual_remote": "Conversation cleared.",
     "model_unavailable_native": "This model cannot run on your device. Choose an on-device model in Settings.",
     "english_only_notice": "Ask in English. The assistant does not work reliably in other languages: questions may be misunderstood or answered without checking your cameras."
   }

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1324,6 +1324,7 @@
       "open": "Abrir"
     },
     "context_cleared_manual": "Conversación borrada. El modelo del dispositivo se descargó para liberar memoria; se cargará de nuevo con tu próxima pregunta.",
+    "context_cleared_manual_remote": "Conversación borrada.",
     "model_unavailable_native": "Este modelo no funciona en tu dispositivo. Elige un modelo del dispositivo en Ajustes.",
     "english_only_notice": "Pregunta en inglés. El asistente no funciona de forma fiable en otros idiomas: las preguntas pueden malinterpretarse o responderse sin consultar tus cámaras."
   }

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1324,6 +1324,7 @@
       "open": "Ouvrir"
     },
     "context_cleared_manual": "Conversation effacée. Le modèle sur l'appareil a été déchargé pour libérer de la mémoire ; il se rechargera à votre prochaine question.",
+    "context_cleared_manual_remote": "Conversation effacée.",
     "model_unavailable_native": "Ce modèle ne fonctionne pas sur votre appareil. Choisissez un modèle sur l'appareil dans les Réglages.",
     "english_only_notice": "Posez vos questions en anglais. L'assistant ne fonctionne pas de manière fiable dans d'autres langues : les questions peuvent être mal comprises ou traitées sans consulter vos caméras."
   }

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1324,6 +1324,7 @@
       "open": "打开"
     },
     "context_cleared_manual": "对话已清除。设备端模型已卸载以释放内存，下次提问时会重新加载。",
+    "context_cleared_manual_remote": "对话已清除。",
     "model_unavailable_native": "此模型无法在你的设备上运行。请在设置中选择设备端模型。",
     "english_only_notice": "请用英语提问。助手在其他语言下无法可靠工作：问题可能被误解，或在未查询摄像头的情况下作答。"
   }

--- a/app/src/pages/__tests__/Events.test.tsx
+++ b/app/src/pages/__tests__/Events.test.tsx
@@ -35,10 +35,8 @@ vi.mock('../../stores/auth', () => ({
     }),
 }));
 
-vi.mock('../../stores/settings', () => ({
-  ALL_GROUPS_KEY: '__all__',
-  DEFAULT_EVENT_MONTAGE_GROUP_LAYOUT: { gridCols: 3 },
-  DEFAULT_SETTINGS: {
+vi.mock('../../stores/settings', () => {
+  const DEFAULT_SETTINGS = {
     viewMode: 'snapshot',
     displayMode: 'normal',
     theme: 'light',
@@ -46,14 +44,20 @@ vi.mock('../../stores/settings', () => ({
     eventsViewMode: 'list',
     eventMontageByGroup: { '__all__': { gridCols: 3 } },
     excludedMonitorIds: [],
-  },
-  useSettingsStore: (selector: (state: { getProfileSettings: (id: string) => { defaultEventLimit: number; eventsViewMode: 'list'; eventMontageByGroup: Record<string, { gridCols: number }> }; updateProfileSettings: () => void; updateEventMontageGroupLayout: () => void }) => unknown) =>
-    selector({
-      getProfileSettings: () => ({ defaultEventLimit: 50, eventsViewMode: 'list', eventMontageByGroup: { '__all__': { gridCols: 3 } }, excludedMonitorIds: [] }),
-      updateProfileSettings: vi.fn(),
-      updateEventMontageGroupLayout: vi.fn(),
-    }),
-}));
+  };
+  return {
+    ALL_GROUPS_KEY: '__all__',
+    DEFAULT_EVENT_MONTAGE_GROUP_LAYOUT: { gridCols: 3 },
+    DEFAULT_SETTINGS,
+    mergeProfileSettings: (raw: Record<string, unknown> | undefined) => ({ ...DEFAULT_SETTINGS, ...raw }),
+    useSettingsStore: (selector: (state: { getProfileSettings: (id: string) => { defaultEventLimit: number; eventsViewMode: 'list'; eventMontageByGroup: Record<string, { gridCols: number }> }; updateProfileSettings: () => void; updateEventMontageGroupLayout: () => void }) => unknown) =>
+      selector({
+        getProfileSettings: () => ({ defaultEventLimit: 50, eventsViewMode: 'list', eventMontageByGroup: { '__all__': { gridCols: 3 } }, excludedMonitorIds: [] }),
+        updateProfileSettings: vi.fn(),
+        updateEventMontageGroupLayout: vi.fn(),
+      }),
+  };
+});
 
 const applyFilters = vi.fn();
 const clearFilters = vi.fn();

--- a/app/src/stores/__tests__/settings.test.ts
+++ b/app/src/stores/__tests__/settings.test.ts
@@ -322,4 +322,14 @@ describe('assistant backend migration for mobile', () => {
       assistantOllamaModel: 'llama3.2',
     });
   });
+
+  it('coerces a native profile that only inherits on-device from the default', () => {
+    // The migration rewrites profiles that already STORED 'on-device'. A newly
+    // created profile stores no backend and inherits the default, which the
+    // migration never sees, so the merge itself must coerce it (refs #246).
+    isNative = true;
+    const s = useSettingsStore.getState().getProfileSettings('brand-new');
+    expect(s.assistantBackend).toBe('ollama');
+    isNative = false;
+  });
 });

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -492,7 +492,17 @@ export const useSettingsStore = create<SettingsState>()(
 
       getProfileSettings: (profileId) => {
         const settings = get().profileSettings[profileId];
-        return { ...DEFAULT_SETTINGS, ...settings };
+        const merged = { ...DEFAULT_SETTINGS, ...settings };
+        // On-device (WebGPU/WebLLM) has no runtime on phones/tablets, so a
+        // native profile must never sit on it: the chat would read 'on-device',
+        // find no runtime, and report "not configured" even though Settings
+        // only exposes Ollama there. moveNativeOffOnDevice() rewrites profiles
+        // that already stored 'on-device'; this also covers ones created after
+        // migration and the default merged in above (refs #246).
+        if (Platform.isNative && merged.assistantBackend === 'on-device') {
+          merged.assistantBackend = 'ollama';
+        }
+        return merged;
       },
 
       updateProfileSettings: (profileId, updates) => {

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -376,6 +376,27 @@ export const DEFAULT_SETTINGS: ProfileSettings = {
 };
 
 /**
+ * Merge a profile's stored (partial) settings over the defaults. The single
+ * resolver for every consumer, reactive (`useCurrentProfile`) and imperative
+ * (`getProfileSettings`) alike, so the coercions below apply everywhere.
+ *
+ * On-device (WebGPU/WebLLM) has no runtime on phones/tablets, so a native
+ * profile must never sit on it: the chat would read 'on-device', find no
+ * runtime, and report "not configured" even though Settings only exposes Ollama
+ * there. moveNativeOffOnDevice() rewrites profiles that already stored
+ * 'on-device'; this also covers ones that only inherit it from the default
+ * merged in here. Platform.isNative is read at call time, not module load, to
+ * avoid a temporal-dead-zone on the mocked Platform in tests (refs #246).
+ */
+export function mergeProfileSettings(raw: Partial<ProfileSettings> | undefined): ProfileSettings {
+  const merged = { ...DEFAULT_SETTINGS, ...raw };
+  if (Platform.isNative && merged.assistantBackend === 'on-device') {
+    merged.assistantBackend = 'ollama';
+  }
+  return merged;
+}
+
+/**
  * Persisted shape version. BUMP THIS whenever `ASSISTANT.retiredModelIds`
  * gains an entry: zustand only calls `migrate` when the stored version is below
  * this number, so a retirement added without a bump never reaches anyone who
@@ -490,20 +511,7 @@ export const useSettingsStore = create<SettingsState>()(
     (set, get) => ({
       profileSettings: {},
 
-      getProfileSettings: (profileId) => {
-        const settings = get().profileSettings[profileId];
-        const merged = { ...DEFAULT_SETTINGS, ...settings };
-        // On-device (WebGPU/WebLLM) has no runtime on phones/tablets, so a
-        // native profile must never sit on it: the chat would read 'on-device',
-        // find no runtime, and report "not configured" even though Settings
-        // only exposes Ollama there. moveNativeOffOnDevice() rewrites profiles
-        // that already stored 'on-device'; this also covers ones created after
-        // migration and the default merged in above (refs #246).
-        if (Platform.isNative && merged.assistantBackend === 'on-device') {
-          merged.assistantBackend = 'ollama';
-        }
-        return merged;
-      },
+      getProfileSettings: (profileId) => mergeProfileSettings(get().profileSettings[profileId]),
 
       updateProfileSettings: (profileId, updates) => {
         set((state) => ({


### PR DESCRIPTION
Fixes four issues surfaced while testing on iOS across profiles (refs #246).

## Issues
- **b) Ollama configured but chat loaded a local model and said "not configured"** — a profile that never explicitly picked a backend merged to the `on-device` default, which has no runtime on phones/tablets. Chat read `on-device`, found nothing. Fixed by coercing native profiles off `on-device` in `getProfileSettings` (the single read path), covering new and post-migration profiles.
- **a) Ollama base URL was a grey placeholder, not editable** — the ZoneMinder-derived suggestion now shows as the editable value; an empty stored value still resolves the same way at use time.
- **d) Clearing an Ollama chat claimed "the on-device model was unloaded to free memory"** — no local model exists on that backend; the cleared notice is now backend-appropriate (new `context_cleared_manual_remote`, all 5 locales).
- **c) API key value ran under the reveal (eye) toggle** — `PasswordInput` `pr-10` equalled the toggle width; bumped to `pr-12` (shared fix).

## Verification
- Affected unit tests: 62/62 pass (widget clear-message test updated)
- `tsc -b`: clean
- `npm run build`: success
- `assistant.feature` e2e: 3 fail / 3 pass — the 3 failures are pre-existing (reproduced identically on a clean baseline; mock backend cannot load ZM data), unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)