### PR TITLE
fix(assistant): stop the API key field collapsing under the reveal toggle on mobile refs #246

### DIFF
--- a/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
+++ b/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
@@ -427,7 +427,8 @@ export function MonitorSettingsDialog({
                     value={localPass}
                     onChange={(e) => setLocalPass(e.target.value)}
                     disabled={!editable || isSaving}
-                    className="w-40 h-8 text-xs"
+                    className="w-40"
+                    inputClassName="h-8 text-xs"
                     data-testid="settings-password-input"
                   />
                 </SettingsRow>

--- a/app/src/components/ui/password-input.tsx
+++ b/app/src/components/ui/password-input.tsx
@@ -19,6 +19,13 @@ export interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputE
    * @default true
    */
   showToggle?: boolean;
+  /**
+   * Classes for the inner `<input>` itself (height, text size, etc.). Width and
+   * layout classes belong on `className`, which sizes the positioned wrapper so
+   * the reveal toggle stays anchored to the field edge. Passing a width here
+   * would collapse the wrapper in a flex row and clip the value under the eye.
+   */
+  inputClassName?: string;
 }
 
 /**
@@ -26,18 +33,19 @@ export interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputE
  *
  * @param props - Component properties
  * @param props.showToggle - Whether to show the visibility toggle button
- * @param props.className - Additional CSS classes
+ * @param props.className - Wrapper classes (width/layout); sizes the field
+ * @param props.inputClassName - Inner input classes (height, text size)
  */
 const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ className, showToggle = true, ...props }, ref) => {
+  ({ className, inputClassName, showToggle = true, ...props }, ref) => {
     const [showPassword, setShowPassword] = React.useState(false);
     const { t } = useTranslation();
 
     return (
-      <div className="relative">
+      <div className={cn('relative', className)}>
         <Input
           type={showPassword ? 'text' : 'password'}
-          className={cn('pr-12', className)}
+          className={cn('w-full pr-12', inputClassName)}
           ref={ref}
           {...props}
         />


### PR DESCRIPTION
The Ollama API key field on mobile rendered narrower than its sibling inputs, and the "Leave blank if not required" placeholder ran under the eye toggle (see screenshot on the issue).

## Cause
`PasswordInput` applied the caller's width class (`w-full sm:w-64`) to the inner `<input>` while its positioned wrapper (`<div className="relative">`) stayed auto-width. In a flex row the wrapper collapsed to min-content, so `w-full` resolved against a collapsed parent and the field shrank.

## Fix
- Width/layout classes go on the wrapper (`className`), which sizes the field and anchors the toggle; the input always fills it (`w-full`).
- Added `inputClassName` for input-only styling. `MonitorSettingsDialog`'s fixed-width password field moves `h-8 text-xs` there while its `w-40` stays on the wrapper, so the eye stays anchored for both callers.

## Verification
- Affected unit tests: 15/15 pass
- `tsc -b`: clean
- `npm run build`: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)