### PR TITLE
Assistant UX: Ollama model warmup, human day phrases, app-formatted times

### DIFF
--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -82,6 +82,9 @@ const TOOL_CASES: ToolCase[] = [
       return a.when === 'yesterday' && t.includes('car') && t.includes('truck');
     },
   },
+  // count_events measures ONE rolling window and cannot rank hours; the
+  // list_events result carries the app-computed busiest-hour clause (refs #264).
+  { q: 'what was my busiest hour yesterday', tool: 'list_events', args: (a) => a.when === 'yesterday' },
   { q: 'is the server ok', tool: 'get_server_health' },
   { q: 'what cameras do I have', tool: 'list_monitors' },
   { q: 'how many events in the last 24 hours', tool: 'count_events', args: (a) => /day|24/.test(String(a.interval)) },

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -504,9 +504,71 @@ async function scoreInterpreter(runs: number) {
   return { pass, total, failures };
 }
 
+
+/** Triage cases (refs #265): the classifier is scored over a MATRIX of
+ *  intents, time spans, and languages, because its historical failures were
+ *  all combinations outside its example list ("summarize" + any range). */
+const TRIAGE_CASES: Array<{ q: string; kind: 'ZONEMINDER' | 'ACTION' | 'CHAT' }> = [
+  // summarize/recap intent across time spans, question and imperative forms
+  { q: 'summarize today', kind: 'ZONEMINDER' },
+  { q: 'summarize last week', kind: 'ZONEMINDER' },
+  { q: 'summarize this month for me please', kind: 'ZONEMINDER' },
+  { q: 'give me a recap of the past 3 days', kind: 'ZONEMINDER' },
+  { q: 'what happened between june 1 and june 15', kind: 'ZONEMINDER' },
+  { q: 'was war letzte Woche bei mir los', kind: 'ZONEMINDER' },
+  { q: 'how many people came by today', kind: 'ZONEMINDER' },
+  { q: 'is the server ok', kind: 'ZONEMINDER' },
+  { q: 'show me the front camera', kind: 'ZONEMINDER' },
+  // actions
+  { q: 'arm the backyard camera', kind: 'ACTION' },
+  { q: 'delete all events from last month', kind: 'ACTION' },
+  // chat, including summarize-verbs about NON-system things
+  { q: 'hello', kind: 'CHAT' },
+  { q: 'thanks!', kind: 'CHAT' },
+  { q: 'what is the capital of France', kind: 'CHAT' },
+  { q: 'summarize the plot of Blade Runner', kind: 'CHAT' },
+];
+
+async function scoreTriage(runs: number) {
+  const { TRIAGE_PROMPT_FOR_EVAL, TRIAGE_SCHEMA } = await import('../src/lib/assistant/triage');
+  let pass = 0;
+  let total = 0;
+  const failures: string[] = [];
+  for (const c of TRIAGE_CASES) {
+    for (let i = 0; i < runs; i++) {
+      total++;
+      try {
+        const r = await chat({
+          model: MODEL,
+          messages: [{ role: 'system', content: TRIAGE_PROMPT_FOR_EVAL }, { role: 'user', content: c.q }],
+          stream: false,
+          max_tokens: 60,
+          ...(TEMP === undefined ? {} : { temperature: TEMP }),
+          ...REASONING,
+          response_format: { type: 'json_schema', json_schema: { name: 'result', schema: TRIAGE_SCHEMA, strict: true } },
+        });
+        const text = r.choices?.[0]?.message?.content ?? '';
+        const kind = JSON.parse(text)?.kind;
+        if (kind === c.kind) pass++;
+        else failures.push(`[triage] "${c.q}" -> ${kind}, expected ${c.kind}`);
+      } catch (e) {
+        failures.push(`[triage] "${c.q}" error: ${(e as Error).message}`);
+      }
+    }
+  }
+  return { pass, total, failures };
+}
+
 const variant = process.argv[2] ?? 'baseline';
 const runs = Number(process.argv[3] ?? 2);
 const started = Date.now();
+if (variant === 'triage') {
+  const w = await scoreTriage(runs);
+  console.log(`\n=== triage via ${MODEL}, temp ${TEMP ?? 'default'} ===`);
+  console.log(`triage: ${w.pass}/${w.total}`);
+  for (const f of w.failures) console.log(`  ${f}`);
+  process.exit(0);
+}
 if (variant === 'interpret') {
   const w = await scoreInterpreter(runs);
   console.log(`\n=== interpreter via ${MODEL}, temp ${TEMP ?? 'default'} ===`);

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -84,6 +84,9 @@ const TOOL_CASES: ToolCase[] = [
   { q: 'summarize last week', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('last week') },
   { q: 'what happened in the past 2 weeks', tool: 'list_events', args: (a) => /past 2 weeks|2 weeks/.test(String(a.when).toLowerCase()) },
   { q: 'was war gestern bei mir los', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('gestern') },
+  // A summary must not grow an objectType: observed live on "summarize april",
+  // which attached every known label and silently excluded no-detection events.
+  { q: 'summarize april', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('april') && a.objectType === undefined },
   { q: 'how many people came today', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('today') && String(a.objectType).includes('person') },
   // Triage answers these with NO tools in production (see triage.ts), so the
   // prompt is not what decides them. Kept visible, scored separately.
@@ -450,32 +453,30 @@ const INTERPRET_CASES: Array<{ phrase: string; ok: (f: Record<string, unknown>) 
   { phrase: '2 days ago', ok: (f) => f.daysAgo === 2 },
   { phrase: 'last week', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) },
   { phrase: 'past 2 weeks', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 2) || (f.lastUnit === 'day' && f.lastCount === 14) },
-  { phrase: 'previous month', ok: (f) => (f.lastUnit === 'month' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 30) },
+  // "previous month" is legitimately either a rolling month or calendar June
+  // (from a July run date); both resolve to a sane window.
+  { phrase: 'previous month', ok: (f) => (f.lastUnit === 'month' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 30) || (f.fromDate === '2026-06-01' && f.toDate === '2026-06-30') },
   { phrase: 'last 3 hours', ok: (f) => f.lastUnit === 'hour' && f.lastCount === 3 },
   { phrase: 'on sunday', ok: (f) => f.weekday === 'sunday' },
   { phrase: 'yesterday from 4pm to 10pm', ok: (f) => f.daysAgo === 1 && f.fromTime === '16:00' && f.toTime === '22:00' },
+  // Calendar spans (refs #265): "summarize april" once queried April 1 only.
+  { phrase: 'april', ok: (f) => f.fromDate === '2026-04-01' && f.toDate === '2026-04-30' },
+  { phrase: 'february', ok: (f) => f.fromDate === '2026-02-01' && f.toDate === '2026-02-28' },
+  { phrase: 'this month', ok: (f) => String(f.fromDate ?? '').endsWith('-01') && f.fromDate === new Date().toISOString().slice(0, 8) + '01' },
+  { phrase: 'june 1 to june 15', ok: (f) => f.fromDate === '2026-06-01' && f.toDate === '2026-06-15' },
+  // A gratuitous month-end toDate is fine: resolveWindow caps the end at now,
+  // so the effective window is identical to the open-ended form.
+  { phrase: 'since july 1', ok: (f) => f.fromDate === '2026-07-01' && (f.toDate === undefined || String(f.toDate) >= new Date().toISOString().slice(0, 10)) },
   { phrase: 'letzte Woche', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) },
   { phrase: 'ayer', ok: (f) => f.daysAgo === 1 },
   { phrase: 'hier soir', ok: (f) => f.daysAgo === 1 },
 ];
 
 async function scoreInterpreter(runs: number) {
-  const { WINDOW_SCHEMA } = await import('../src/lib/assistant/window-interpreter');
-  const { format } = await import('date-fns');
-  const today = format(new Date(), 'EEEE, yyyy-MM-dd');
-  const system = [
-    'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
-    `Today is ${today} (timezone America/New_York).`,
-    'Fields (use the fewest that express the phrase):',
-    '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}.',
-    '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}.',
-    '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}.',
-    '- date: an explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
-    '- fromTime/toTime: 24h "HH:MM", narrowing a single day. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
-    '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
-    'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}.',
-    'A calendar day word is never a rolling span: "today" is daysAgo 0, NOT lastCount 1 day.',
-  ].join('\n');
+  const { WINDOW_SCHEMA, buildInterpreterPrompt } = await import('../src/lib/assistant/window-interpreter');
+  // The REAL production prompt: a hand-copied version here drifted behind a
+  // schema change and measured a bug the app did not have.
+  const system = buildInterpreterPrompt(new Date(), 'America/New_York');
   let pass = 0;
   let total = 0;
   const failures: string[] = [];

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -74,6 +74,10 @@ interface ToolCase {
   args?: (a: Record<string, unknown>) => boolean;
   /** Handled by triage before the prompt sees it; reported, not scored. */
   triaged?: boolean;
+  /** Check `tool` and `args` against EVERY call in the reply, not just the
+   *  first. For multi-window questions where a fault on any call corrupts
+   *  the answer ("compare X to Y" creeping objectType onto both calls). */
+  allCalls?: boolean;
 }
 
 const TOOL_CASES: ToolCase[] = [
@@ -87,6 +91,14 @@ const TOOL_CASES: ToolCase[] = [
   // A summary must not grow an objectType: observed live on "summarize april",
   // which attached every known label and silently excluded no-detection events.
   { q: 'summarize april', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('april') && a.objectType === undefined },
+  // Observed live (refs #246): "compare may to june" attached the whole known
+  // vocabulary to BOTH calls, silently excluding no-detection events.
+  {
+    q: 'compare may to june',
+    tool: 'list_events',
+    allCalls: true,
+    args: (a) => /may|june/.test(String(a.when).toLowerCase()) && a.objectType === undefined,
+  },
   { q: 'how many people came today', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('today') && String(a.objectType).includes('person') },
   // Triage answers these with NO tools in production (see triage.ts), so the
   // prompt is not what decides them. Kept visible, scored separately.
@@ -273,7 +285,8 @@ async function scoreTools(system: string, runs: number) {
           ...(TEMP === undefined ? {} : { temperature: TEMP }),
           ...REASONING,
         });
-        const call = r.choices?.[0]?.message?.tool_calls?.[0];
+        const allReplyCalls = r.choices?.[0]?.message?.tool_calls ?? [];
+        const call = allReplyCalls[0];
         if (c.tool === null) {
           // Counted against the triaged tally, not the scored one: incrementing
           // `pass` here made the score exceed its own total (30/24).
@@ -289,31 +302,41 @@ async function scoreTools(system: string, runs: number) {
           failures.push(`[tool] "${c.q}" called nothing, expected ${c.tool}`);
           continue;
         }
-        if (call.function.name !== c.tool) {
-          failures.push(`[tool] "${c.q}" called ${call.function.name}, expected ${c.tool}`);
-          continue;
+        // allCalls cases check every call in the reply; a fault on any one
+        // corrupts the answer. Others check the first only.
+        const toCheck = c.allCalls ? allReplyCalls : [call];
+        let failed = false;
+        for (const checked of toCheck) {
+          if (checked.function.name !== c.tool) {
+            failures.push(`[tool] "${c.q}" called ${checked.function.name}, expected ${c.tool}`);
+            failed = true;
+            break;
+          }
+          let args: Record<string, unknown> = {};
+          try {
+            args = JSON.parse(checked.function.arguments || '{}');
+          } catch {
+            failures.push(`[tool] "${c.q}" arguments were not JSON`);
+            failed = true;
+            break;
+          }
+          // The SAME repairs the app applies before a tool runs, so a fault it
+          // already fixes is not counted against the prompt. A stringified array
+          // argument is llama3.2's known habit and coerceLabelList handles it.
+          args = stripOmittedArgs(args);
+          if (args.objectType !== undefined) args.objectType = coerceLabelList(args.objectType);
+          // Same repair the executor applies (refs #265): numeric window fields
+          // arrive as strings from llama3.2 and Number() them before use.
+          for (const key of ['lastCount', 'daysAgo']) {
+            if (typeof args[key] === 'string' && args[key] !== '' && !Number.isNaN(Number(args[key]))) args[key] = Number(args[key]);
+          }
+          if (c.args && !c.args(args)) {
+            failures.push(`[tool] "${c.q}" args ${JSON.stringify(args)}`);
+            failed = true;
+            break;
+          }
         }
-        let args: Record<string, unknown> = {};
-        try {
-          args = JSON.parse(call.function.arguments || '{}');
-        } catch {
-          failures.push(`[tool] "${c.q}" arguments were not JSON`);
-          continue;
-        }
-        // The SAME repairs the app applies before a tool runs, so a fault it
-        // already fixes is not counted against the prompt. A stringified array
-        // argument is llama3.2's known habit and coerceLabelList handles it.
-        args = stripOmittedArgs(args);
-        if (args.objectType !== undefined) args.objectType = coerceLabelList(args.objectType);
-        // Same repair the executor applies (refs #265): numeric window fields
-        // arrive as strings from llama3.2 and Number() them before use.
-        for (const key of ['lastCount', 'daysAgo']) {
-          if (typeof args[key] === 'string' && args[key] !== '' && !Number.isNaN(Number(args[key]))) args[key] = Number(args[key]);
-        }
-        if (c.args && !c.args(args)) {
-          failures.push(`[tool] "${c.q}" args ${JSON.stringify(args)}`);
-          continue;
-        }
+        if (failed) continue;
         if (c.triaged) triagedPass++; else pass++;
       } catch (e) {
         failures.push(`[tool] "${c.q}" error: ${(e as Error).message}`);

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -55,6 +55,14 @@ const OBJECT_LABELS = ['car', 'carrot', 'person', 'truck'];
 const TODAY_RESULT =
   '{"summary":"5 events between 2026-07-20 00:00:00 and 2026-07-20 09:31:51. By monitor: FrontDoor 2, Front Yard 2, Garage Outdoor 1. Detected: person 4, car 1.","window":{"from":"2026-07-20 00:00:00","to":"2026-07-20 09:31:51"},"matchCount":5,"countsByMonitor":{"FrontDoor":2,"Front Yard":2,"Garage Outdoor":1},"objectCounts":{"person":4,"car":1},"events":[{"id":"253363","monitor":"FrontDoor","start":"2026-07-20 08:36:33","durationSec":30.02,"objects":["person"]},{"id":"253362","monitor":"Front Yard","start":"2026-07-20 08:36:21","durationSec":30.06,"objects":["person"]},{"id":"253361","monitor":"Front Yard","start":"2026-07-20 08:35:45","durationSec":30.03,"objects":["person"]},{"id":"253360","monitor":"FrontDoor","start":"2026-07-20 08:35:19","durationSec":30,"objects":["person"]},{"id":"253359","monitor":"Garage Outdoor","start":"2026-07-20 08:20:59","durationSec":30,"objects":["car"]}]}';
 
+// TODAY_RESULT with the busiestHour/countsByHour fields list_events now
+// reports (refs #264), and one row moved out of the busy hour so the SHOW
+// directive has a real subset to select: four rows in 08:00, one in 09:00.
+const BUSIEST_RESULT = TODAY_RESULT.replace(
+  '"matchCount":5,',
+  '"matchCount":5,"busiestHour":{"label":"2026-07-20 08:00:00","count":4},"countsByHour":{"2026-07-20 08:00:00":4,"2026-07-20 09:00:00":1},',
+).replace('"start":"2026-07-20 08:20:59"', '"start":"2026-07-20 09:31:00"');
+
 const EMPTY_RESULT =
   '{"summary":"No events between 2026-07-20 00:00:00 and 2026-07-20 09:31:51.","window":{"from":"2026-07-20 00:00:00","to":"2026-07-20 09:31:51"},"matchCount":0,"countsByMonitor":{},"objectCounts":{},"events":[]}';
 
@@ -124,6 +132,21 @@ const ANSWER_CASES: AnswerCase[] = [
       { name: 'person-count', ok: (a) => /\b4\b/.test(a) },
       { name: 'no-denial', ok: (a) => !deniesData(a) },
       { name: 'not-json', ok: (a) => !a.trim().startsWith('{') },
+    ],
+  },
+  {
+    q: 'what was my busiest hour today',
+    result: BUSIEST_RESULT,
+    checks: [
+      // The hour itself, however phrased: card narrowing is id-driven (SHOW),
+      // so exact label quoting stopped being load-bearing.
+      { name: 'names-hour', ok: (a) => /8:00|08:00|8 ?am/i.test(a) },
+      { name: 'count', ok: (a) => /\b4\b/.test(a) },
+      { name: 'no-denial', ok: (a) => !deniesData(a) },
+      { name: 'not-json', ok: (a) => !a.trim().startsWith('{') },
+      // The SHOW directive (refs #264): the busy hour's ids selected, the
+      // 09:00 stray excluded, so only the answer's cards render.
+      { name: 'show-subset', ok: (a) => /SHOW: ?events=/.test(a) && a.includes('253363') && !/SHOW:[^\n]*253359/.test(a) },
     ],
   },
   {

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -77,9 +77,14 @@ interface ToolCase {
 }
 
 const TOOL_CASES: ToolCase[] = [
-  { q: 'summarize today', tool: 'list_events', args: (a) => a.when === 'today' && a.objectType === undefined },
-  { q: 'what happened yesterday', tool: 'list_events', args: (a) => a.when === 'yesterday' && a.objectType === undefined },
-  { q: 'how many people came today', tool: 'list_events', args: (a) => a.when === 'today' && String(a.objectType).includes('person') },
+  { q: 'summarize today', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('today') && a.objectType === undefined },
+  { q: 'what happened yesterday', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('yesterday') && a.objectType === undefined },
+  // The phrasings the old English phrase grammar could not read (refs #265):
+  // the model interprets them into structured fields, in any language.
+  { q: 'summarize last week', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('last week') },
+  { q: 'what happened in the past 2 weeks', tool: 'list_events', args: (a) => /past 2 weeks|2 weeks/.test(String(a.when).toLowerCase()) },
+  { q: 'was war gestern bei mir los', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('gestern') },
+  { q: 'how many people came today', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('today') && String(a.objectType).includes('person') },
   // Triage answers these with NO tools in production (see triage.ts), so the
   // prompt is not what decides them. Kept visible, scored separately.
   {
@@ -87,15 +92,15 @@ const TOOL_CASES: ToolCase[] = [
     tool: 'list_events',
     args: (a) => {
       const t = (a.objectType ?? []) as string[];
-      return a.when === 'yesterday' && t.includes('car') && t.includes('truck');
+      return String(a.when).toLowerCase().includes('yesterday') && t.includes('car') && t.includes('truck');
     },
   },
   // count_events measures ONE rolling window and cannot rank hours; the
   // list_events result carries the app-computed busiest-hour clause (refs #264).
-  { q: 'what was my busiest hour yesterday', tool: 'list_events', args: (a) => a.when === 'yesterday' },
+  { q: 'what was my busiest hour yesterday', tool: 'list_events', args: (a) => String(a.when).toLowerCase().includes('yesterday') },
   { q: 'is the server ok', tool: 'get_server_health' },
   { q: 'what cameras do I have', tool: 'list_monitors' },
-  { q: 'how many events in the last 24 hours', tool: 'count_events', args: (a) => /day|24/.test(String(a.interval)) },
+  { q: 'how many events in the last 24 hours', tool: 'count_events', args: (a) => (a.lastUnit === 'hour' && a.lastCount === 24) || (a.lastUnit === 'day' && a.lastCount === 1) },
   { q: 'what tags are available', tool: 'list_tags' },
   { q: 'hello', tool: null, triaged: true },
   { q: 'what is the capital of France', tool: null, triaged: true },
@@ -297,6 +302,11 @@ async function scoreTools(system: string, runs: number) {
         // argument is llama3.2's known habit and coerceLabelList handles it.
         args = stripOmittedArgs(args);
         if (args.objectType !== undefined) args.objectType = coerceLabelList(args.objectType);
+        // Same repair the executor applies (refs #265): numeric window fields
+        // arrive as strings from llama3.2 and Number() them before use.
+        for (const key of ['lastCount', 'daysAgo']) {
+          if (typeof args[key] === 'string' && args[key] !== '' && !Number.isNaN(Number(args[key]))) args[key] = Number(args[key]);
+        }
         if (c.args && !c.args(args)) {
           failures.push(`[tool] "${c.q}" args ${JSON.stringify(args)}`);
           continue;
@@ -328,7 +338,7 @@ async function scoreAnswers(system: string, runs: number) {
               role: 'assistant',
               content: '',
               tool_calls: [
-                { id: 'c1', type: 'function', function: { name: 'list_events', arguments: '{"when":"today"}' } },
+                { id: 'c1', type: 'function', function: { name: 'list_events', arguments: '{"daysAgo":0}' } },
               ],
             },
             { role: 'tool', tool_call_id: 'c1', content: c.result },
@@ -429,9 +439,81 @@ async function scoreWebLlmContract(runs: number) {
   return { pass, total, failures };
 }
 
+
+/** Interpreter cases (refs #265): phrase in, structured fields out, measured
+ *  against the live model under the same constrained schema production uses.
+ *  The variants here are exactly what the deleted phrase grammar could not
+ *  read and what the direct-DSL contract got wrong. */
+const INTERPRET_CASES: Array<{ phrase: string; ok: (f: Record<string, unknown>) => boolean }> = [
+  { phrase: 'today', ok: (f) => f.daysAgo === 0 },
+  { phrase: 'yesterday', ok: (f) => f.daysAgo === 1 },
+  { phrase: '2 days ago', ok: (f) => f.daysAgo === 2 },
+  { phrase: 'last week', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) },
+  { phrase: 'past 2 weeks', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 2) || (f.lastUnit === 'day' && f.lastCount === 14) },
+  { phrase: 'previous month', ok: (f) => (f.lastUnit === 'month' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 30) },
+  { phrase: 'last 3 hours', ok: (f) => f.lastUnit === 'hour' && f.lastCount === 3 },
+  { phrase: 'on sunday', ok: (f) => f.weekday === 'sunday' },
+  { phrase: 'yesterday from 4pm to 10pm', ok: (f) => f.daysAgo === 1 && f.fromTime === '16:00' && f.toTime === '22:00' },
+  { phrase: 'letzte Woche', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) },
+  { phrase: 'ayer', ok: (f) => f.daysAgo === 1 },
+  { phrase: 'hier soir', ok: (f) => f.daysAgo === 1 },
+];
+
+async function scoreInterpreter(runs: number) {
+  const { WINDOW_SCHEMA } = await import('../src/lib/assistant/window-interpreter');
+  const { format } = await import('date-fns');
+  const today = format(new Date(), 'EEEE, yyyy-MM-dd');
+  const system = [
+    'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
+    `Today is ${today} (timezone America/New_York).`,
+    'Fields (use the fewest that express the phrase):',
+    '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}.',
+    '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}.',
+    '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}.',
+    '- date: an explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
+    '- fromTime/toTime: 24h "HH:MM", narrowing a single day. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
+    '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
+    'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}.',
+    'A calendar day word is never a rolling span: "today" is daysAgo 0, NOT lastCount 1 day.',
+  ].join('\n');
+  let pass = 0;
+  let total = 0;
+  const failures: string[] = [];
+  for (const c of INTERPRET_CASES) {
+    for (let i = 0; i < runs; i++) {
+      total++;
+      try {
+        const r = await chat({
+          model: MODEL,
+          messages: [{ role: 'system', content: system }, { role: 'user', content: c.phrase }],
+          stream: false,
+          max_tokens: 300,
+          ...(TEMP === undefined ? {} : { temperature: TEMP }),
+          ...REASONING,
+          response_format: { type: 'json_schema', json_schema: { name: 'window', schema: WINDOW_SCHEMA, strict: true } },
+        });
+        const text = r.choices?.[0]?.message?.content ?? '';
+        const fields = JSON.parse(/\{[\s\S]*\}/.exec(text)?.[0] ?? '{}');
+        if (c.ok(fields)) pass++;
+        else failures.push(`[interpret] "${c.phrase}" -> ${JSON.stringify(fields)}`);
+      } catch (e) {
+        failures.push(`[interpret] "${c.phrase}" error: ${(e as Error).message}`);
+      }
+    }
+  }
+  return { pass, total, failures };
+}
+
 const variant = process.argv[2] ?? 'baseline';
 const runs = Number(process.argv[3] ?? 2);
 const started = Date.now();
+if (variant === 'interpret') {
+  const w = await scoreInterpreter(runs);
+  console.log(`\n=== interpreter via ${MODEL}, temp ${TEMP ?? 'default'} ===`);
+  console.log(`interpret: ${w.pass}/${w.total}`);
+  for (const f of w.failures) console.log(`  ${f}`);
+  process.exit(0);
+}
 if (variant === 'webllm') {
   const w = await scoreWebLlmContract(runs);
   console.log(`\n=== webllm contract via ${MODEL}, temp ${TEMP ?? 'default'} (PROXY: no WebGPU here) ===`);

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -27,7 +27,7 @@ import { getVersion } from '../../api/auth';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { useFreshAccessToken } from '../../hooks/useFreshAccessToken';
 import { resolveMinStreamingPort } from '../../lib/monitor/multiport';
-import { runAssistantTurn, isContextNearlyFull, requiresLiveData } from '../../lib/assistant/agent';
+import { runAssistantTurn, isContextNearlyFull } from '../../lib/assistant/agent';
 import {
   getAssistantProvider,
   isAssistantTestMode,
@@ -36,6 +36,7 @@ import {
 import { sharedMockProvider } from '../../lib/assistant/providers/mock';
 import { buildSystemPrompt } from '../../lib/assistant/system-prompt';
 import { getObjectLabels } from '../../lib/assistant/object-labels';
+import { interpretWhen } from '../../lib/assistant/window-interpreter';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
 import { classifyRequest, buildNoToolPrompt, type RequestKind } from '../../lib/assistant/triage';
 import type { AssistantMessage, AssistantTurn, ProviderConfig, ToolActivity, ToolContext, TraceEntry } from '../../lib/assistant/types';
@@ -287,12 +288,10 @@ export function AskPanel() {
   const setRunning = useAssistantStore((s) => s.setRunning);
   const clearActivities = useAssistantStore((s) => s.clearActivities);
 
-  // Every backend, not just on-device. The on-device model's answer quality is
-  // the smaller half of this: `requiredReadTool` (agent.ts) matches English
-  // words to decide when live data is mandatory, the triage prompt is English,
-  // and `resolveWhen` parses English time phrases. Asked in another language
-  // those guards silently do not fire, which is just as true of a GPU-backed
-  // Ollama server as of a phone.
+  // Every backend, not just on-device. The remaining English surface is the
+  // triage prompt and the grounding regexes; time interpretation and tool
+  // routing are language-neutral since refs #265 (the model interprets, the
+  // loop fails open).
   // `startsWith`, not equality: i18next reports regional variants like "en-GB".
   const assistantInNonEnglish = !i18n.language.toLowerCase().startsWith('en');
 
@@ -462,10 +461,19 @@ export function AskPanel() {
         // zone the system prompt already told the model "today" means.
         timezone: currentProfile?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
         question: text,
-        // Gates English-only text heuristics (ungroundedWhenWords) off for
-        // other locales; same source as `system`'s locale line (refs #259).
         locale: i18n.language,
         objectLabels,
+        // The `when` phrase interpreter (refs #265): the session's own model
+        // maps the user's time words to structured fields under a constrained
+        // schema, so no app-side phrase grammar exists.
+        interpretWhen: (phrase: string) =>
+          interpretWhen(
+            phrase,
+            provider,
+            new Date(),
+            currentProfile?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+            controller.signal,
+          ),
       };
       const history = useAssistantStore.getState().getThread(profileId);
 
@@ -486,26 +494,15 @@ export function AskPanel() {
         initialTrace.push(entry);
         host.onTrace?.(entry);
       };
-      // The deterministic check runs FIRST, and when it fires there is no
-      // triage call at all. Triage is one small model's opinion and it gets
-      // this wrong: it answered CHAT for both "summarize yesterday" and
-      // "summarize today", the second being near-identical to an example in
-      // its own prompt. Its verdict was then overruled anyway, so the round
-      // trip bought a wrong answer and ~400ms. Asking a model what this
-      // function already knows is the part worth removing, not just the part
-      // where we ignore the reply.
-      //
-      // Triage still decides everything the heuristic is silent on, which is
-      // what it is good at: greetings, small talk, and change-requests it
-      // routes to a tool-less refusal.
-      const needsLiveData = requiresLiveData(text);
-      const kind: RequestKind =
-        needsLiveData || isAssistantTestMode()
-          ? 'zoneminder'
-          : await classifyRequest(provider, text, controller.signal, collectTrace);
-      if (needsLiveData) {
-        log.assistant('Triage skipped: the question needs live data', LogLevel.DEBUG, {});
-      }
+      // Triage is ADVISORY (refs #265): a misclassified data question is no
+      // longer refused, because the loop fails open: a tool-less turn whose
+      // model calls a real registry read tool flips to the full registry and
+      // runs it. That made the old English keyword overrule (requiresLiveData)
+      // deletable: it was a hardcoded vocabulary in front of exactly the
+      // language interpretation the model does better.
+      const kind: RequestKind = isAssistantTestMode()
+        ? 'zoneminder'
+        : await classifyRequest(provider, text, controller.signal, collectTrace);
       log.assistant('Request classified', LogLevel.DEBUG, { kind });
 
       // Already only this turn's new messages (see runAssistantTurn): the
@@ -589,12 +586,11 @@ export function AskPanel() {
             and a lone notice is still an empty conversation. */}
         {thread.every((m) => m.contextBoundary) && <AssistantIntro onExampleClick={handleExampleClick} />}
 
-        {/* The on-device model is a small English-first model, and its job here
-            (reason, then emit a strict reply format) is where a small model
-            degrades most in other languages. Saying so is honest; the
-            alternative was pretending every language works equally well.
-            Ollama runs whatever model the user chose, so this does not apply
-            there. */}
+        {/* Honest, not alarmist (refs #265): time interpretation and tool
+            routing are language-neutral now (the model interprets, the loop
+            fails open), but the grounding safeguards only recognize English
+            replies and English is the measured path, so a non-English app
+            language still gets a note saying English works best. */}
         {assistantInNonEnglish && (
           <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground" data-testid="assistant-english-notice">
             {t('assistant.english_only_notice')}

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -36,7 +36,7 @@ import {
 import { sharedMockProvider } from '../../lib/assistant/providers/mock';
 import { buildSystemPrompt } from '../../lib/assistant/system-prompt';
 import { getObjectLabels } from '../../lib/assistant/object-labels';
-import { suggestOllamaBaseUrl } from '../../lib/assistant/providers/openai';
+import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
 import { classifyRequest, buildNoToolPrompt, type RequestKind } from '../../lib/assistant/triage';
 import type { AssistantMessage, AssistantTurn, ProviderConfig, ToolActivity, ToolContext, TraceEntry } from '../../lib/assistant/types';
 import { log, LogLevel } from '../../lib/logger';
@@ -299,6 +299,9 @@ export function AskPanel() {
   const [input, setInput] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [notConfigured, setNotConfigured] = useState(false);
+  /** The model a warmup is loading right now, for the status line below the
+   *  thread; null when no warmup is in flight (refs #261). */
+  const [warmingModel, setWarmingModel] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const prevThreadLengthRef = useRef(thread.length);
@@ -318,6 +321,35 @@ export function AskPanel() {
       abortControllerRef.current?.abort();
     };
   }, []);
+
+  // Warm the Ollama model as soon as the panel opens, instead of letting the
+  // FIRST question pay for it: measured live, a cold first question cost ~36s
+  // (VRAM load plus one full thinking chain, since reasoning is only disabled
+  // once the server is confirmed) while every later one took ~2s (refs #261).
+  // warmOllamaModel de-dupes per session, so reopening the panel is free, and
+  // it never throws; a server that is down surfaces on the real turn instead.
+  // Not in test mode: the mock backend has no server to warm, and a stray
+  // request would fail noisily in e2e logs.
+  useEffect(() => {
+    if (settings.assistantBackend !== 'ollama' || !profileId || isAssistantTestMode()) return;
+    const model = settings.assistantOllamaModel;
+    if (!model) return;
+    let cancelled = false;
+    void (async () => {
+      const apiKey = await getSecureValue(`${ASSISTANT.apiKeyStoragePrefix}${profileId}`);
+      const baseUrl =
+        settings.assistantOllamaBaseUrl ||
+        suggestOllamaBaseUrl(currentProfile?.apiUrl) ||
+        ASSISTANT.defaultOllamaBaseUrl;
+      if (cancelled) return;
+      setWarmingModel(model);
+      await warmOllamaModel({ baseUrl, model, apiKey: apiKey ?? undefined });
+      if (!cancelled) setWarmingModel(null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.assistantBackend, settings.assistantOllamaModel, settings.assistantOllamaBaseUrl, profileId, currentProfile?.apiUrl]);
 
   // The Clear button now lives in AssistantWidget.tsx, which resets the
   // shared store (`reset(profileId)` + `clearActivities()`). This component
@@ -651,6 +683,16 @@ export function AskPanel() {
           <p className="flex items-center gap-1 text-xs text-muted-foreground" data-testid="assistant-status">
             <Loader2 className="h-3 w-3 animate-spin" />
             {t('assistant.thinking')}
+          </p>
+        )}
+
+        {/* The warmup started when the panel opened (refs #261). Shown even
+            while a turn runs on a cold server: the "Thinking" line above would
+            otherwise claim progress while the real wait is the model load. */}
+        {warmingModel && (
+          <p className="flex items-center gap-1 text-xs text-muted-foreground" data-testid="assistant-model-loading">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('assistant.loading_model', { model: warmingModel })}
           </p>
         )}
 

--- a/app/src/components/assistant/AssistantResultCards.tsx
+++ b/app/src/components/assistant/AssistantResultCards.tsx
@@ -7,10 +7,18 @@
  * (`EventThumbnail`) are for the user only and never touch the model, and
  * "Open" just calls the host's `navigate`, which closes the palette and
  * routes (see useAssistantHost.ts).
+ *
+ * Monitor cards carry a LIVE preview (refs #264) when the answer is about a
+ * few monitors; above `ASSISTANT.maxLiveMonitorCards` they fall back to
+ * text, since each preview is a real stream with real cost.
  */
 import { useTranslation } from 'react-i18next';
 import { EventThumbnail } from '../events/EventThumbnail';
+import { LiveMonitorPlayer } from '../monitors/LiveMonitorPlayer';
+import { useMonitors } from '../../hooks/useMonitors';
+import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { Button } from '../ui/button';
+import { ASSISTANT } from '../../lib/zmninja-ng-constants';
 import type { AssistantHost, DisplayEntity } from '../../lib/assistant/types';
 
 export interface AssistantResultCardsProps {
@@ -20,11 +28,22 @@ export interface AssistantResultCardsProps {
 
 export function AssistantResultCards({ entities, host }: AssistantResultCardsProps) {
   const { t } = useTranslation();
+  // The shared monitors query (cached, bandwidth-managed polling): cards only
+  // READ it to resolve a card's monitor id to the stream-capable Monitor
+  // object; no extra requests when the cache is warm.
+  const { monitors } = useMonitors();
+  const { currentProfile } = useCurrentProfile();
+  const monitorCardCount = entities.filter((e) => e.kind === 'monitor').length;
+  const livePreviews = monitorCardCount > 0 && monitorCardCount <= ASSISTANT.maxLiveMonitorCards;
 
   return (
     <div className="flex flex-wrap gap-2" data-testid="assistant-result-cards">
       {entities.map((entity) => {
         const open = () => host.navigate(entity.navigatePath);
+        const liveMonitor =
+          entity.kind === 'monitor' && livePreviews
+            ? monitors.find((m) => m.Monitor.Id === entity.id)?.Monitor
+            : undefined;
         return (
           <div
             key={`${entity.kind}-${entity.id}`}
@@ -40,6 +59,20 @@ export function AssistantResultCards({ entities, host }: AssistantResultCardsPro
             data-testid={`assistant-card-${entity.kind}`}
             className="flex w-full min-w-0 max-w-full items-center gap-2 rounded-md border border-border/60 bg-background p-2 text-left cursor-pointer hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-primary sm:w-64"
           >
+            {liveMonitor && (
+              <div
+                className="h-14 w-24 shrink-0 overflow-hidden rounded bg-card border border-border/40"
+                data-testid="assistant-card-monitor-live"
+              >
+                <LiveMonitorPlayer
+                  monitor={liveMonitor}
+                  profile={currentProfile}
+                  className="h-full w-full"
+                  objectFit="cover"
+                  muted
+                />
+              </div>
+            )}
             {entity.kind === 'event' && (
               <div className="h-12 w-12 shrink-0 overflow-hidden rounded bg-card border border-border/40">
                 <EventThumbnail

--- a/app/src/components/assistant/__tests__/AskPanel.test.tsx
+++ b/app/src/components/assistant/__tests__/AskPanel.test.tsx
@@ -62,6 +62,12 @@ vi.mock('../../../lib/assistant/tools', () => ({
   getToolByName: (name: string) => ({ name, description: `${name} description` }),
 }));
 vi.mock('../../../api/auth', () => ({ getVersion: vi.fn() }));
+// Monitor result cards resolve their live preview through the shared monitors
+// query; neither the query nor a real stream belongs in this test (refs #264).
+vi.mock('../../../hooks/useMonitors', () => ({ useMonitors: () => ({ monitors: [] }) }));
+vi.mock('../../monitors/LiveMonitorPlayer', () => ({
+  LiveMonitorPlayer: () => <div data-testid="assistant-live-player-stub" />,
+}));
 // Rendering the real EventThumbnail would need <img> load/error events jsdom
 // never fires; a stub keeps this test focused on the card, not the thumbnail
 // component (which has its own tests in EventThumbnail.test.tsx).

--- a/app/src/components/assistant/__tests__/AskPanel.test.tsx
+++ b/app/src/components/assistant/__tests__/AskPanel.test.tsx
@@ -9,7 +9,7 @@
  * mocked following the pattern in components/__tests__/CommandPalette.test.tsx
  * to avoid transitively loading stores/profile via log-sanitizer -> client.
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AskPanel } from '../AskPanel';
@@ -30,11 +30,26 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ getQueryData: () => undefined }),
 }));
 const mockBackend = { current: 'on-device' };
+const mockOllamaModel = { current: '' };
 vi.mock('../../../hooks/useCurrentProfile', () => ({
   useCurrentProfile: () => ({
     currentProfile: { id: 'p1', timezone: 'UTC' },
-    settings: { assistantModelId: 'test-model', get assistantBackend() { return mockBackend.current; } },
+    settings: {
+      assistantModelId: 'test-model',
+      get assistantBackend() { return mockBackend.current; },
+      get assistantOllamaModel() { return mockOllamaModel.current; },
+      assistantOllamaBaseUrl: 'http://zm:11434/v1',
+    },
   }),
+}));
+// The warmup effect (refs #261) resolves the stored API key and fires
+// warmOllamaModel on mount for the Ollama backend; both are stubbed so the
+// test controls when the warmup settles and no request leaves jsdom.
+vi.mock('../../../lib/security/secureStorage', () => ({ getSecureValue: vi.fn().mockResolvedValue(null) }));
+const warmResolvers: Array<(v: boolean) => void> = [];
+vi.mock('../../../lib/assistant/providers/openai', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  warmOllamaModel: vi.fn(() => new Promise<boolean>((resolve) => warmResolvers.push(resolve))),
 }));
 vi.mock('../../../hooks/useFreshAccessToken', () => ({
   useFreshAccessToken: () => ({ token: null, isFresh: false }),
@@ -57,6 +72,9 @@ vi.mock('../../events/EventThumbnail', () => ({
 describe('AskPanel', () => {
   beforeEach(() => {
     useAssistantStore.setState({ threads: {}, running: false, activities: [] });
+    mockBackend.current = 'on-device';
+    mockOllamaModel.current = '';
+    warmResolvers.length = 0;
   });
 
   it('renders Ninjii\'s self-introduction when the thread is empty (refs #246)', () => {
@@ -80,6 +98,26 @@ describe('AskPanel', () => {
     expect(input.value).toBe('assistant.intro_example_1');
     // No turn was sent: the thread is still empty and the intro still shows.
     expect(screen.getByTestId('assistant-intro')).toBeInTheDocument();
+  });
+
+  // The warmup starts when the panel opens with the Ollama backend, and the
+  // chat says so while it runs (refs #261): without the line, a cold server's
+  // ~36s load looked like a hang or hid behind a misleading "Thinking".
+  it('shows the model-loading line while the Ollama warmup runs, then hides it', async () => {
+    mockBackend.current = 'ollama';
+    mockOllamaModel.current = 'qwen3:8b';
+
+    render(<AskPanel />);
+
+    expect(await screen.findByTestId('assistant-model-loading')).toHaveTextContent('assistant.loading_model');
+    warmResolvers.pop()?.(true);
+    await waitFor(() => expect(screen.queryByTestId('assistant-model-loading')).not.toBeInTheDocument());
+  });
+
+  it('starts no warmup on the on-device backend', () => {
+    render(<AskPanel />);
+    expect(screen.queryByTestId('assistant-model-loading')).not.toBeInTheDocument();
+    expect(warmResolvers).toHaveLength(0);
   });
 
   it('does not render the self-introduction once the thread has messages', () => {

--- a/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Monitor result cards carry a live preview when the answer is about a few
+ * monitors, and fall back to text above ASSISTANT.maxLiveMonitorCards, since
+ * every preview is a real stream (refs #264).
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AssistantResultCards } from '../AssistantResultCards';
+import { ASSISTANT } from '../../../lib/zmninja-ng-constants';
+import type { AssistantHost, DisplayEntity } from '../../../lib/assistant/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('../../../hooks/useMonitors', () => ({
+  useMonitors: () => ({
+    monitors: [
+      { Monitor: { Id: '3', Name: 'Garage', Function: 'Modect', Enabled: '1' } },
+      { Monitor: { Id: '4', Name: 'Front', Function: 'Modect', Enabled: '1' } },
+    ],
+  }),
+}));
+vi.mock('../../../hooks/useCurrentProfile', () => ({
+  useCurrentProfile: () => ({ currentProfile: { id: 'p1' } }),
+}));
+vi.mock('../../monitors/LiveMonitorPlayer', () => ({
+  LiveMonitorPlayer: () => <div data-testid="live-player-stub" />,
+}));
+
+const host: AssistantHost = { navigate: vi.fn(), onActivity: vi.fn() };
+const monitorCard = (id: string): DisplayEntity => ({
+  kind: 'monitor',
+  id,
+  title: `Monitor ${id}`,
+  navigatePath: `/monitors/${id}`,
+});
+
+describe('AssistantResultCards live previews', () => {
+  it('renders a live preview on a monitor card whose monitor is known', () => {
+    render(<AssistantResultCards entities={[monitorCard('3')]} host={host} />);
+    expect(screen.getByTestId('assistant-card-monitor-live')).toBeInTheDocument();
+    expect(screen.getByTestId('live-player-stub')).toBeInTheDocument();
+  });
+
+  it('renders no preview for a monitor the query does not know', () => {
+    render(<AssistantResultCards entities={[monitorCard('99')]} host={host} />);
+    expect(screen.queryByTestId('assistant-card-monitor-live')).not.toBeInTheDocument();
+  });
+
+  it('falls back to text cards above the live-preview cap', () => {
+    const many = Array.from({ length: ASSISTANT.maxLiveMonitorCards + 1 }, (_, i) => monitorCard(String(i)));
+    render(<AssistantResultCards entities={many} host={host} />);
+    expect(screen.queryByTestId('assistant-card-monitor-live')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/lib/assistant/__tests__/agent-failopen.test.ts
+++ b/app/src/lib/assistant/__tests__/agent-failopen.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The fail-open gate (refs #265): a turn routed with NO tools (triage said
+ * chat/action) whose model calls a real registry read tool flips to the full
+ * registry and runs the call, instead of refusing it. The model's own attempt
+ * is better routing evidence than the classifier: "summarize last week" was
+ * triaged CHAT, the model called list_events anyway, and the refusal turned a
+ * correct instinct into an apology. Separate file because executing the REAL
+ * registry tool needs the full api mock set (mirroring tools.test.ts).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runAssistantTurn } from '../agent';
+import { MockProvider } from '../providers/mock';
+import type { AssistantHost } from '../types';
+import { asProfileId } from '../../../api/types';
+import { getEvents } from '../../../api/events';
+
+vi.mock('../../../api/monitors', () => ({
+  getMonitors: vi.fn().mockResolvedValue({ monitors: [{ Monitor: { Id: '1', Name: 'Front Door' } }] }),
+  getMonitor: vi.fn(),
+  getAlarmStatus: vi.fn(),
+}));
+vi.mock('../../../api/events', () => ({
+  getEvents: vi.fn().mockResolvedValue({
+    events: [],
+    pagination: { page: 1, pageCount: 1, current: 1, count: 0, prevPage: false, nextPage: false, limit: 25, totalCount: 0 },
+  }),
+  getEvent: vi.fn(),
+  getConsoleEvents: vi.fn(),
+  getEventImageUrl: vi.fn(() => ''),
+}));
+vi.mock('../../../api/server', () => ({
+  getLoad: vi.fn(),
+  getDiskPercent: vi.fn(),
+  getDaemonCheck: vi.fn(),
+  getStorages: vi.fn(),
+  getServers: vi.fn(),
+}));
+vi.mock('../../../api/auth', () => ({ getVersion: vi.fn() }));
+vi.mock('../../../api/groups', () => ({ getGroups: vi.fn() }));
+vi.mock('../../../api/tags', () => ({ getTags: vi.fn(), getEventTags: vi.fn(), extractUniqueTags: vi.fn() }));
+
+const host: AssistantHost = { navigate: vi.fn(), onActivity: vi.fn() };
+
+describe('fail-open tool routing', () => {
+  it('runs a registry read tool the model calls on a tool-less turn', async () => {
+    const p = new MockProvider();
+    p.setScript([
+      { toolCalls: [{ id: 'c1', name: 'list_events', input: { when: 'last week' } }] },
+      { text: 'No events in the last week.', toolCalls: [] },
+    ]);
+
+    const out = await runAssistantTurn({
+      provider: p,
+      host,
+      ctx: {
+        profileId: asProfileId('p1'),
+        queryClient: {} as never,
+        host,
+        interpretWhen: async () => ({ lastCount: 1, lastUnit: 'week' }),
+      },
+      history: [{ role: 'user', text: 'summarize last week' }],
+      system: 'sys',
+      signal: new AbortController().signal,
+      tools: [],
+    });
+
+    // The call executed (the query went out) instead of being refused.
+    expect(vi.mocked(getEvents)).toHaveBeenCalledWith(
+      expect.objectContaining({ startDateTime: expect.any(String), endDateTime: expect.any(String) }),
+    );
+    const toolMsg = out.find((m) => m.role === 'tool');
+    expect(toolMsg?.toolResults?.[0]?.output).not.toContain('No tools are available');
+    expect(out[out.length - 1].text).toBe('No events in the last week.');
+  });
+
+  it('still refuses a withheld action on a tool-less turn', async () => {
+    const p = new MockProvider();
+    p.setScript([
+      { toolCalls: [{ id: 'c1', name: 'trigger_alarm', input: { monitorId: '1' } }] },
+      { text: 'I cannot trigger alarms.', toolCalls: [] },
+    ]);
+
+    const out = await runAssistantTurn({
+      provider: p,
+      host,
+      ctx: { profileId: asProfileId('p1'), queryClient: {} as never, host },
+      history: [{ role: 'user', text: 'trigger the alarm' }],
+      system: 'sys',
+      signal: new AbortController().signal,
+      tools: [],
+    });
+
+    const toolMsg = out.find((m) => m.role === 'tool');
+    expect(toolMsg?.toolResults?.[0]?.isError).toBe(true);
+    expect(toolMsg?.toolResults?.[0]?.output).toContain('not something this assistant can do');
+  });
+});

--- a/app/src/lib/assistant/__tests__/agent.test.ts
+++ b/app/src/lib/assistant/__tests__/agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { runAssistantTurn, truncateHistory, sliceAfterContextBoundary, isContextNearlyFull, requiresLiveData } from '../agent';
+import { runAssistantTurn, truncateHistory, sliceAfterContextBoundary, isContextNearlyFull } from '../agent';
 import { MockProvider } from '../providers/mock';
 import type { AssistantHost, AssistantMessage } from '../types';
 import { asProfileId } from '../../../api/types';
@@ -67,9 +67,10 @@ describe('a turn given no tools', () => {
     expect(out[0].text).toBe('Here is a plain answer.');
   });
 
-  // The same question WITH tools must still be held to the requirement, or the
-  // fix above would have quietly disabled the live-data guard everywhere.
-  it('still demands live data when tools are available', async () => {
+  // The English keyword requirement is gone (refs #265); what remains is the
+  // language-neutral nudge: one reminder for a tool-less answer, then the
+  // second answer is accepted rather than replaced.
+  it('nudges once, then accepts, when the model answers a data question without tools', async () => {
     const p = new MockProvider();
     p.setScript([
       { text: 'I think nothing happened.', toolCalls: [] },
@@ -78,7 +79,7 @@ describe('a turn given no tools', () => {
 
     const out = await runAssistantTurn(baseOpts(p, host(), [{ role: 'user', text: 'summarize yesterday' }]));
 
-    expect(out[out.length - 1].text).toBe('__i18n:assistant.live_data_required');
+    expect(out[out.length - 1].text).toBe('Still nothing.');
   });
 
   // The English regexes cannot see a German question, so a tool-less answer to
@@ -99,25 +100,6 @@ describe('a turn given no tools', () => {
     // Two provider calls: answer, reminder, same answer accepted.
     expect(chatSpy).toHaveBeenCalledTimes(2);
     vi.restoreAllMocks();
-  });
-});
-
-describe('requiresLiveData', () => {
-  it('recognises the questions the loop would demand a tool for', () => {
-    expect(requiresLiveData('summarize yesterday')).toBe(true);
-    // Both of the questions triage misclassified as CHAT in live transcripts.
-    // This function now decides these outright and the triage call is skipped,
-    // so a wrong classification cannot reach them at all.
-    expect(requiresLiveData('summarize today')).toBe(true);
-    expect(requiresLiveData('how many people came today')).toBe(true);
-    expect(requiresLiveData('is the server ok')).toBe(true);
-    expect(requiresLiveData('what cameras do I have')).toBe(true);
-  });
-
-  it('leaves genuine small talk alone', () => {
-    expect(requiresLiveData('hello')).toBe(false);
-    expect(requiresLiveData('thanks!')).toBe(false);
-    expect(requiresLiveData('what is the capital of France')).toBe(false);
   });
 });
 

--- a/app/src/lib/assistant/__tests__/agent.test.ts
+++ b/app/src/lib/assistant/__tests__/agent.test.ts
@@ -756,6 +756,31 @@ describe('runAssistantTurn', () => {
     expect(finalMsg.display).toEqual(display);
   });
 
+  // The SHOW directive (refs #264): the model names the ids its answer is
+  // about, the line comes off the text, and only those cards render.
+  it('strips a SHOW directive from the answer and narrows the cards to its ids', async () => {
+    const display = [
+      { kind: 'event', id: '101', title: 'a', navigatePath: '/events/101' },
+      { kind: 'event', id: '102', title: 'b', navigatePath: '/events/102' },
+      { kind: 'event', id: '103', title: 'c', navigatePath: '/events/103' },
+    ];
+    const stubTool = {
+      name: 'list_events', description: '', schema: {},
+      execute: async () => ({ output: '{"matchCount":3}', display }),
+    } as never;
+    const p = new MockProvider();
+    p.setScript([
+      { toolCalls: [{ id: 'c1', name: 'list_events', input: { when: 'today' } }] },
+      { text: 'The two that matter happened at 8 AM.\nSHOW: events=101,103', toolCalls: [] },
+    ]);
+
+    const out = await runAssistantTurn({ ...baseOpts(p, host(), [{ role: 'user', text: 'summarize today' }]), tools: [stubTool] });
+
+    const finalMsg = out[out.length - 1];
+    expect(finalMsg.text).toBe('The two that matter happened at 8 AM.');
+    expect(finalMsg.display?.map((d) => d.id)).toEqual(['101', '103']);
+  });
+
   it('leaves display undefined on the final message when no tool call returned display', async () => {
     const p = new MockProvider();
     p.setScript([

--- a/app/src/lib/assistant/__tests__/display.test.ts
+++ b/app/src/lib/assistant/__tests__/display.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The SHOW directive (refs #264): the model ends its answer with
+ * `SHOW: events=<ids> monitors=<ids>` to say which result cards its answer
+ * is about; the app strips the line and renders only those cards. The ids
+ * can only select among cards the turn's tools actually produced, so the
+ * model cannot conjure a card, and a directive that selects nothing falls
+ * back to every card rather than hiding the answer's evidence.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractShowDirective, filterDisplayByShow } from '../display';
+import type { DisplayEntity } from '../types';
+
+const event = (id: string): DisplayEntity => ({ kind: 'event', id, title: id, navigatePath: `/events/${id}` });
+const monitor = (id: string): DisplayEntity => ({ kind: 'monitor', id, title: id, navigatePath: `/monitors/${id}` });
+
+describe('extractShowDirective', () => {
+  it('splits a final SHOW line off the answer and parses both id lists', () => {
+    const { text, show } = extractShowDirective('Busiest hour was 7 PM with 9 events.\nSHOW: events=101,102 monitors=3');
+    expect(text).toBe('Busiest hour was 7 PM with 9 events.');
+    expect(show).toEqual({ events: ['101', '102'], monitors: ['3'] });
+  });
+
+  it('parses a directive with only one list present', () => {
+    const { show } = extractShowDirective('Answer.\nSHOW: events=5');
+    expect(show).toEqual({ events: ['5'], monitors: [] });
+  });
+
+  it('leaves an answer without a directive untouched', () => {
+    const { text, show } = extractShowDirective('There were 21 events yesterday.');
+    expect(text).toBe('There were 21 events yesterday.');
+    expect(show).toBeUndefined();
+  });
+
+  // Prose ABOUT the mechanism must not trigger it.
+  it('ignores a SHOW mention that is not the final line', () => {
+    const { text, show } = extractShowDirective('SHOW: events=1 is the machine line.\nThe answer is 42.');
+    expect(text).toContain('The answer is 42.');
+    expect(show).toBeUndefined();
+  });
+
+  it('tolerates trailing whitespace and empty id lists', () => {
+    const { text, show } = extractShowDirective('Answer.\nSHOW: events= monitors=  \n');
+    expect(text).toBe('Answer.');
+    expect(show).toEqual({ events: [], monitors: [] });
+  });
+});
+
+describe('filterDisplayByShow', () => {
+  const cards = [event('101'), event('102'), event('103'), monitor('3')];
+
+  it('keeps only the selected cards, by kind and id', () => {
+    const kept = filterDisplayByShow(cards, { events: ['101', '103'], monitors: [] });
+    expect(kept.map((c) => c.id)).toEqual(['101', '103']);
+  });
+
+  it('selects monitors independently of events', () => {
+    const kept = filterDisplayByShow(cards, { events: [], monitors: ['3'] });
+    expect(kept.map((c) => `${c.kind}:${c.id}`)).toEqual(['monitor:3']);
+  });
+
+  // An id the results never contained is a model mistake; hiding every card
+  // over it would be worse than over-showing.
+  it('falls back to every card when nothing matches', () => {
+    expect(filterDisplayByShow(cards, { events: ['999'], monitors: [] })).toHaveLength(4);
+    expect(filterDisplayByShow(cards, { events: [], monitors: [] })).toHaveLength(4);
+  });
+
+  // An event id cannot select a monitor card of the same id.
+  it('never crosses kinds', () => {
+    const kept = filterDisplayByShow([event('3'), monitor('3')], { events: ['3'], monitors: [] });
+    expect(kept.map((c) => `${c.kind}:${c.id}`)).toEqual(['event:3']);
+  });
+});

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -57,6 +57,38 @@ describe('resolveWhen (English time windows)', () => {
     expect(when('yesterday')).toEqual({ startDateTime: '2026-07-15 00:00:00', endDateTime: '2026-07-16 00:00:00' });
   });
 
+  // The two phrasings live use rejected first (refs #262). NOW is Thursday
+  // 2026-07-16, so "2 days ago" is Tuesday the 14th and the most recent
+  // Sunday is the 12th.
+  it('resolves "N days ago" as that calendar day', () => {
+    expect(when('2 days ago')).toEqual({ startDateTime: '2026-07-14 00:00:00', endDateTime: '2026-07-15 00:00:00' });
+    expect(when('1 day ago')).toEqual({ startDateTime: '2026-07-15 00:00:00', endDateTime: '2026-07-16 00:00:00' });
+  });
+
+  it('resolves weekday names as the most recent such day', () => {
+    const sunday = { startDateTime: '2026-07-12 00:00:00', endDateTime: '2026-07-13 00:00:00' };
+    expect(when('sunday')).toEqual(sunday);
+    expect(when('on sunday')).toEqual(sunday);
+    expect(when('last sunday')).toEqual(sunday);
+  });
+
+  // A bare weekday that IS today means today; only "last" reaches back a week.
+  it('distinguishes "thursday" (today) from "last thursday" when asked on a Thursday', () => {
+    expect(when('thursday')).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 10:30:00' });
+    expect(when('last thursday')).toEqual({ startDateTime: '2026-07-09 00:00:00', endDateTime: '2026-07-10 00:00:00' });
+  });
+
+  it('composes a weekday with part-of-day narrowing', () => {
+    expect(when('sunday from 4pm to 10pm')).toEqual({
+      startDateTime: '2026-07-12 16:00:00',
+      endDateTime: '2026-07-12 22:00:00',
+    });
+    expect(when('2 days ago after 9am')).toEqual({
+      startDateTime: '2026-07-14 09:00:00',
+      endDateTime: '2026-07-15 00:00:00',
+    });
+  });
+
   it('resolves rolling windows', () => {
     expect(when('last hour')).toEqual({ startDateTime: '2026-07-16 09:30:00', endDateTime: '2026-07-16 10:30:00' });
     expect(when('last 24 hours')).toEqual({ startDateTime: '2026-07-15 10:30:00', endDateTime: '2026-07-16 10:30:00' });

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -1,134 +1,113 @@
+/**
+ * resolveWindow (refs #265): structured window fields in, exact ZM datetime
+ * strings out. The model interprets human time words into these fields; this
+ * module owns ONLY the arithmetic, so these tests fix the clock and the zone
+ * and assert exact wall-clock strings.
+ */
 import { describe, it, expect } from 'vitest';
-import { parseClockTime, resolveWhen } from '../event-range';
+import { resolveWindow } from '../event-range';
 
-// 2026-07-16T14:30:00Z is 2026-07-16 10:30:00 in America/New_York (EDT,
-// UTC-4) and 2026-07-16 23:30:00 in Asia/Tokyo (UTC+9): same UTC instant,
-// different local wall-clock hour, both still within 2026-07-16.
+// 2026-07-16T14:30:00Z is Thursday 2026-07-16 10:30:00 in America/New_York
+// (EDT, UTC-4) and 2026-07-16 23:30:00 in Asia/Tokyo (UTC+9).
 const NOW = new Date('2026-07-16T14:30:00Z');
+const at = (fields: Parameters<typeof resolveWindow>[0], timezone = 'America/New_York') =>
+  resolveWindow(fields, NOW, timezone);
 
-describe('resolveWhen timezone handling', () => {
-  it('resolves "today" using a different timezone\'s own wall-clock hour', () => {
-    const r = resolveWhen('today', NOW, 'Asia/Tokyo');
-    expect(r).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 23:30:00' });
+describe('rolling windows', () => {
+  it('resolves lastCount+lastUnit back from now', () => {
+    expect(at({ lastCount: 1, lastUnit: 'hour' })).toEqual({
+      startDateTime: '2026-07-16 09:30:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+    expect(at({ lastCount: 7, lastUnit: 'day' })).toEqual({
+      startDateTime: '2026-07-09 10:30:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+    expect(at({ lastCount: 1, lastUnit: 'week' })).toEqual({
+      startDateTime: '2026-07-09 10:30:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+    expect(at({ lastCount: 30, lastUnit: 'minute' })).toEqual({
+      startDateTime: '2026-07-16 10:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
   });
 
-  it('resolves "today" onto the correct calendar day even when zones disagree on the date', () => {
-    // 2026-07-16T23:30:00Z is 2026-07-16 19:30 in New York but already
-    // 2026-07-17 08:30 in Tokyo: the two zones must resolve different days.
-    const crossing = new Date('2026-07-16T23:30:00Z');
-    expect(resolveWhen('today', crossing, 'America/New_York')).toEqual({
-      startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 19:30:00',
-    });
-    expect(resolveWhen('today', crossing, 'Asia/Tokyo')).toEqual({
-      startDateTime: '2026-07-17 00:00:00', endDateTime: '2026-07-17 08:30:00',
-    });
+  it('rejects half a rolling window, a bad unit, and a bad count with corrective errors', () => {
+    expect(at({ lastCount: 7 })).toMatchObject({ error: expect.stringContaining('lastUnit') });
+    expect(at({ lastUnit: 'day' })).toMatchObject({ error: expect.stringContaining('lastCount') });
+    expect(at({ lastCount: 7, lastUnit: 'fortnight' })).toMatchObject({ error: expect.stringContaining('lastUnit must be one of') });
+    expect(at({ lastCount: -2, lastUnit: 'day' })).toMatchObject({ error: expect.stringContaining('positive') });
   });
 
-  // The keywords the retired `range` enum used, still understood in case a
-  // model repeats one from a persisted thread (see resolveWhen's LEGACY map).
-  it('still resolves the legacy enum keywords', () => {
-    expect(resolveWhen('last_24h', NOW, 'America/New_York')).toEqual({
-      startDateTime: '2026-07-15 10:30:00', endDateTime: '2026-07-16 10:30:00',
-    });
-    expect(resolveWhen('last_7d', NOW, 'America/New_York')).toEqual({
-      startDateTime: '2026-07-09 10:30:00', endDateTime: '2026-07-16 10:30:00',
+  it('rejects a rolling window combined with a day field or day narrowing', () => {
+    expect(at({ lastCount: 1, lastUnit: 'day', daysAgo: 1 })).toMatchObject({ error: expect.stringContaining('not both') });
+    expect(at({ lastCount: 1, lastUnit: 'day', fromTime: '16:00' })).toMatchObject({
+      error: expect.stringContaining('cannot combine'),
     });
   });
 });
 
-// NOW is 2026-07-16 10:30:00 in America/New_York, so "yesterday" is the 15th.
-describe('resolveWhen (English time windows)', () => {
-  const when = (phrase: string) => resolveWhen(phrase, NOW, 'America/New_York');
-
-  it('reads clock times the way people write them', () => {
-    expect(parseClockTime('4pm')).toBe(16 * 60);
-    expect(parseClockTime('4:30pm')).toBe(16 * 60 + 30);
-    expect(parseClockTime('16:00')).toBe(16 * 60);
-    expect(parseClockTime('noon')).toBe(12 * 60);
-    expect(parseClockTime('midnight')).toBe(0);
-    expect(parseClockTime('12am')).toBe(0);
-    expect(parseClockTime('12pm')).toBe(12 * 60);
-    expect(parseClockTime('half past four')).toBeUndefined();
-    expect(parseClockTime('25:00')).toBeUndefined();
+describe('single days', () => {
+  it('resolves daysAgo as calendar days: 0 ends now, 1 is midnight to midnight', () => {
+    expect(at({ daysAgo: 0 })).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 10:30:00' });
+    expect(at({ daysAgo: 1 })).toEqual({ startDateTime: '2026-07-15 00:00:00', endDateTime: '2026-07-16 00:00:00' });
+    expect(at({ daysAgo: 2 })).toEqual({ startDateTime: '2026-07-14 00:00:00', endDateTime: '2026-07-15 00:00:00' });
   });
 
-  it('resolves whole days', () => {
-    expect(when('today')).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 10:30:00' });
-    expect(when('yesterday')).toEqual({ startDateTime: '2026-07-15 00:00:00', endDateTime: '2026-07-16 00:00:00' });
+  it('resolves a weekday as the most recent such day, today included', () => {
+    // NOW is a Thursday.
+    expect(at({ weekday: 'sunday' })).toEqual({ startDateTime: '2026-07-12 00:00:00', endDateTime: '2026-07-13 00:00:00' });
+    expect(at({ weekday: 'thursday' })).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 10:30:00' });
   });
 
-  // The two phrasings live use rejected first (refs #262). NOW is Thursday
-  // 2026-07-16, so "2 days ago" is Tuesday the 14th and the most recent
-  // Sunday is the 12th.
-  it('resolves "N days ago" as that calendar day', () => {
-    expect(when('2 days ago')).toEqual({ startDateTime: '2026-07-14 00:00:00', endDateTime: '2026-07-15 00:00:00' });
-    expect(when('1 day ago')).toEqual({ startDateTime: '2026-07-15 00:00:00', endDateTime: '2026-07-16 00:00:00' });
+  it('resolves an explicit date', () => {
+    expect(at({ date: '2026-07-10' })).toEqual({ startDateTime: '2026-07-10 00:00:00', endDateTime: '2026-07-11 00:00:00' });
+    expect(at({ date: 'July 10' })).toMatchObject({ error: expect.stringContaining('YYYY-MM-DD') });
+    expect(at({ date: '2026-08-01' })).toMatchObject({ error: expect.stringContaining('future') });
   });
 
-  it('resolves weekday names as the most recent such day', () => {
-    const sunday = { startDateTime: '2026-07-12 00:00:00', endDateTime: '2026-07-13 00:00:00' };
-    expect(when('sunday')).toEqual(sunday);
-    expect(when('on sunday')).toEqual(sunday);
-    expect(when('last sunday')).toEqual(sunday);
-  });
-
-  // A bare weekday that IS today means today; only "last" reaches back a week.
-  it('distinguishes "thursday" (today) from "last thursday" when asked on a Thursday', () => {
-    expect(when('thursday')).toEqual({ startDateTime: '2026-07-16 00:00:00', endDateTime: '2026-07-16 10:30:00' });
-    expect(when('last thursday')).toEqual({ startDateTime: '2026-07-09 00:00:00', endDateTime: '2026-07-10 00:00:00' });
-  });
-
-  it('composes a weekday with part-of-day narrowing', () => {
-    expect(when('sunday from 4pm to 10pm')).toEqual({
-      startDateTime: '2026-07-12 16:00:00',
-      endDateTime: '2026-07-12 22:00:00',
-    });
-    expect(when('2 days ago after 9am')).toEqual({
-      startDateTime: '2026-07-14 09:00:00',
-      endDateTime: '2026-07-15 00:00:00',
-    });
-  });
-
-  it('resolves rolling windows', () => {
-    expect(when('last hour')).toEqual({ startDateTime: '2026-07-16 09:30:00', endDateTime: '2026-07-16 10:30:00' });
-    expect(when('last 24 hours')).toEqual({ startDateTime: '2026-07-15 10:30:00', endDateTime: '2026-07-16 10:30:00' });
-    expect(when('past 30 minutes')).toEqual({ startDateTime: '2026-07-16 10:00:00', endDateTime: '2026-07-16 10:30:00' });
-    expect(when('last 7 days')).toEqual({ startDateTime: '2026-07-09 10:30:00', endDateTime: '2026-07-16 10:30:00' });
-  });
-
-  // The case that started this: the model only has to echo the user's phrase.
-  it('resolves part of a named day', () => {
-    expect(when('yesterday from 4pm to 10pm')).toEqual({
-      startDateTime: '2026-07-15 16:00:00',
-      endDateTime: '2026-07-15 22:00:00',
-    });
-    expect(when('today between 9am and noon')).toEqual({
-      startDateTime: '2026-07-16 09:00:00',
-      endDateTime: '2026-07-16 12:00:00',
-    });
-    expect(when('yesterday 16:00 to 22:00')).toEqual({
-      startDateTime: '2026-07-15 16:00:00',
-      endDateTime: '2026-07-15 22:00:00',
-    });
-  });
-
-  it('resolves one-sided windows', () => {
-    expect(when('yesterday after 4pm')).toEqual({
-      startDateTime: '2026-07-15 16:00:00',
-      endDateTime: '2026-07-16 00:00:00',
-    });
-    expect(when('today before noon')).toEqual({
+  it('resolves the day in the profile timezone, not the runtime zone', () => {
+    // 2026-07-16T23:30:00Z is still the 16th in New York but the 17th in Tokyo.
+    const crossing = new Date('2026-07-16T23:30:00Z');
+    expect(resolveWindow({ daysAgo: 0 }, crossing, 'America/New_York')).toEqual({
       startDateTime: '2026-07-16 00:00:00',
-      endDateTime: '2026-07-16 12:00:00',
+      endDateTime: '2026-07-16 19:30:00',
+    });
+    expect(resolveWindow({ daysAgo: 0 }, crossing, 'Asia/Tokyo')).toEqual({
+      startDateTime: '2026-07-17 00:00:00',
+      endDateTime: '2026-07-17 08:30:00',
     });
   });
 
-  // Errors, not guesses: each names what could not be read so the model can
-  // correct rather than retry the same phrase.
-  it('reports what it could not read instead of guessing', () => {
-    expect(when('')).toMatchObject({ error: expect.stringContaining('empty') });
-    expect(when('sometime last spring')).toMatchObject({ error: expect.stringContaining('Could not read') });
-    expect(when('yesterday from 4pm to bananas')).toMatchObject({ error: expect.stringContaining('bananas') });
-    expect(when('yesterday from 10pm to 4pm')).toMatchObject({ error: expect.stringContaining('not after') });
+  it('rejects more than one day picker', () => {
+    expect(at({ daysAgo: 1, weekday: 'sunday' })).toMatchObject({ error: expect.stringContaining('only one') });
+  });
+});
+
+describe('day narrowing', () => {
+  it('narrows a single day with fromTime/toTime', () => {
+    expect(at({ daysAgo: 1, fromTime: '16:00', toTime: '22:00' })).toEqual({
+      startDateTime: '2026-07-15 16:00:00',
+      endDateTime: '2026-07-15 22:00:00',
+    });
+    expect(at({ weekday: 'sunday', fromTime: '09:00' })).toEqual({
+      startDateTime: '2026-07-12 09:00:00',
+      endDateTime: '2026-07-13 00:00:00',
+    });
+  });
+
+  it('rejects narrowing without a day, bad clock shapes, and inverted windows', () => {
+    expect(at({ fromTime: '16:00' })).toMatchObject({ error: expect.stringContaining('need a day') });
+    expect(at({ daysAgo: 1, fromTime: '4pm' })).toMatchObject({ error: expect.stringContaining('HH:MM') });
+    expect(at({ daysAgo: 1, fromTime: '22:00', toTime: '16:00' })).toMatchObject({
+      error: expect.stringContaining('after'),
+    });
+  });
+});
+
+describe('no window', () => {
+  it('returns undefined when no field is set, so the caller reports an unfiltered query', () => {
+    expect(at({})).toBeUndefined();
   });
 });

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -41,7 +41,7 @@ describe('rolling windows', () => {
   });
 
   it('rejects a rolling window combined with a day field or day narrowing', () => {
-    expect(at({ lastCount: 1, lastUnit: 'day', daysAgo: 1 })).toMatchObject({ error: expect.stringContaining('not both') });
+    expect(at({ lastCount: 1, lastUnit: 'day', daysAgo: 1 })).toMatchObject({ error: expect.stringContaining('ONE window shape') });
     expect(at({ lastCount: 1, lastUnit: 'day', fromTime: '16:00' })).toMatchObject({
       error: expect.stringContaining('cannot combine'),
     });
@@ -82,6 +82,48 @@ describe('single days', () => {
 
   it('rejects more than one day picker', () => {
     expect(at({ daysAgo: 1, weekday: 'sunday' })).toMatchObject({ error: expect.stringContaining('only one') });
+  });
+});
+
+describe('calendar spans (fromDate/toDate)', () => {
+  // The case that forced the primitive: "summarize april" was squeezed into
+  // {date:"2026-04-01"} and queried one day of a 30-day month (refs #265).
+  it('resolves an inclusive month span', () => {
+    expect(at({ fromDate: '2026-04-01', toDate: '2026-04-30' })).toEqual({
+      startDateTime: '2026-04-01 00:00:00',
+      endDateTime: '2026-05-01 00:00:00',
+    });
+  });
+
+  it('caps a span ending today (or later) at now', () => {
+    expect(at({ fromDate: '2026-07-01', toDate: '2026-07-16' })).toEqual({
+      startDateTime: '2026-07-01 00:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+    expect(at({ fromDate: '2026-07-01', toDate: '2026-07-31' })).toEqual({
+      startDateTime: '2026-07-01 00:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+  });
+
+  it('allows one-sided spans', () => {
+    expect(at({ fromDate: '2026-07-01' })).toEqual({ startDateTime: '2026-07-01 00:00:00' });
+    expect(at({ toDate: '2026-06-30' })).toEqual({ endDateTime: '2026-07-01 00:00:00' });
+  });
+
+  it('rejects bad shapes, inverted spans, future starts, and mixed window shapes', () => {
+    expect(at({ fromDate: 'april' })).toMatchObject({ error: expect.stringContaining('YYYY-MM-DD') });
+    // llama produced "february" as 2026-02-29 (leap confusion): shape-valid,
+    // calendar-impossible, must be a corrective error not a NaN throw.
+    expect(at({ fromDate: '2026-02-01', toDate: '2026-02-29' })).toMatchObject({
+      error: expect.stringContaining('not a real calendar date'),
+    });
+    expect(at({ fromDate: '2026-05-10', toDate: '2026-05-01' })).toMatchObject({ error: expect.stringContaining('on or after') });
+    expect(at({ fromDate: '2026-08-01' })).toMatchObject({ error: expect.stringContaining('future') });
+    expect(at({ fromDate: '2026-04-01', daysAgo: 1 })).toMatchObject({ error: expect.stringContaining('ONE window shape') });
+    expect(at({ fromDate: '2026-04-01', toDate: '2026-04-30', fromTime: '16:00' })).toMatchObject({
+      error: expect.stringContaining('single day'),
+    });
   });
 });
 

--- a/app/src/lib/assistant/__tests__/result-summary.test.ts
+++ b/app/src/lib/assistant/__tests__/result-summary.test.ts
@@ -56,6 +56,24 @@ describe('buildResultSummary', () => {
       partial: true,
     });
     expect(summary).toContain('partial result');
+    expect(summary).toContain('By monitor (listed rows)');
+  });
+
+  it('leads with the true total when rows were capped, so comparisons quote real counts', () => {
+    // Observed live: two capped results both said 25 and the model compared
+    // the page caps as totals.
+    const summary = buildResultSummary({
+      window: WINDOW,
+      matchCount: 25,
+      countsByMonitor: { A: 25 },
+      objectCounts: { person: 25 },
+      partial: true,
+      totalMatches: 142,
+    });
+    expect(summary).toContain('142 events');
+    expect(summary).toContain('The 25 most recent are listed.');
+    expect(summary).toContain('By monitor (listed rows)');
+    expect(summary).not.toContain('partial result');
   });
 
   it('reports an empty result without inventing a period', () => {

--- a/app/src/lib/assistant/__tests__/system-prompt.test.ts
+++ b/app/src/lib/assistant/__tests__/system-prompt.test.ts
@@ -50,18 +50,18 @@ describe('buildSystemPrompt', () => {
     expect(p).toContain("Today's date is Thursday, 2026-07-16 in timezone America/New_York");
   });
 
-  it('instructs the model to call list_events with when/objectType for day- or object-type-specific questions', () => {
+  it('teaches phrase copying, with interpretation done by the app (refs #265)', () => {
     const p = buildSystemPrompt(base);
-    expect(p).toContain('call list_events with when and/or objectType');
+    expect(p).toContain("COPY the user's own time words");
+    expect(p).toContain('`when`');
     expect(p).toContain('Describe only rows the query returned');
   });
 
   // The model echoes the user's phrasing accurately and does date arithmetic
   // badly, so the prompt has to send it to `when` rather than to a timestamp.
-  it('forbids working out a date, pointing at the when parameter instead', () => {
+  it('forbids computing timestamps outright', () => {
     const p = buildSystemPrompt(base);
-    expect(p).toContain('Never work out a date or timestamp yourself');
-    expect(p).toContain('`when`');
+    expect(p).toContain('Never compute timestamps yourself');
   });
 
   it('instructs the model to answer directly and never paste image links/ids, since the app shows thumbnails', () => {
@@ -69,9 +69,9 @@ describe('buildSystemPrompt', () => {
     expect(p).toContain('Never show image links, URLs, or raw ids');
   });
 
-  it('redirects count_events to a rolling window only, not a calendar day', () => {
+  it('offers count_events for bare rolling totals', () => {
     const p = buildSystemPrompt(base);
-    expect(p).toContain('rolling summaries such as "last 24 hours"');
+    expect(p).toContain('count_events is cheaper');
   });
 
   it('never mentions a JSON tool-call contract or WebLLM-specific directives (model-agnostic prompt)', () => {

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -882,6 +882,26 @@ describe('list_events when resolution (refs #246)', () => {
     expect(getEvents).toHaveBeenCalledWith(expect.objectContaining({ startDateTime: '2026-07-15 00:00:00' }));
   });
 
+  // "Busiest hour" is timestamp arithmetic, so the tool computes the tally
+  // and hands the winner over as a finished clause (refs #264).
+  it('reports the busiest hour and per-hour counts from the shown rows', async () => {
+    vi.mocked(getEvents).mockResolvedValueOnce({
+      events: [
+        { Event: { Id: '1', MonitorId: '1', StartDateTime: '2026-07-15 08:10:00', Length: '30', Notes: 'detected:person' } },
+        { Event: { Id: '2', MonitorId: '1', StartDateTime: '2026-07-15 08:40:00', Length: '30', Notes: 'detected:person' } },
+        { Event: { Id: '3', MonitorId: '2', StartDateTime: '2026-07-15 11:20:00', Length: '30', Notes: 'detected:car' } },
+      ],
+      pagination: { page: 1, pageCount: 1, current: 1, count: 3, prevPage: false, nextPage: false, limit: 25, totalCount: 3 },
+    } as never);
+
+    const tool = getToolByName('list_events')!;
+    const r = await tool.execute({ when: 'yesterday' }, { ...ctx(), timezone: 'America/New_York' });
+
+    const parsed = JSON.parse(r.output);
+    expect(parsed.summary).toContain('Busiest hour: 2026-07-15 08:00:00 (2 events).');
+    expect(parsed.countsByHour).toEqual({ '2026-07-15 08:00:00': 2, '2026-07-15 11:00:00': 1 });
+  });
+
   // The model reported ten rows as "8 Front Yard, 2 Garage Outdoor" when the
   // real split was four and six. It should be reading a tally, not counting.
   it('supplies the per-monitor tally so the model never counts rows', async () => {

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -853,6 +853,35 @@ describe('list_events when resolution (refs #246)', () => {
     );
   });
 
+  // The model echoes whatever time format the rows carry, so rendering rows
+  // and window through the profile's own format makes answers match the rest
+  // of the app (rule 21, refs #262). No format in the context leaves ZM's raw
+  // timestamps untouched (covered by every other test in this file).
+  it('renders row and window times in the profile date/time format when given one', async () => {
+    vi.mocked(getEvents).mockResolvedValueOnce({
+      events: [
+        { Event: { Id: '1', MonitorId: '1', StartDateTime: '2026-07-15 16:05:00', Length: '30', Notes: 'detected:person' } },
+      ],
+      pagination: { page: 1, pageCount: 1, current: 1, count: 1, prevPage: false, nextPage: false, limit: 25, totalCount: 1 },
+    } as never);
+
+    const tool = getToolByName('list_events')!;
+    const r = await tool.execute(
+      { when: 'yesterday' },
+      {
+        ...ctx(),
+        timezone: 'America/New_York',
+        dateTimeFormat: { dateFormat: 'MMM d, yyyy', timeFormat: '12h', customDateFormat: '', customTimeFormat: '' },
+      },
+    );
+
+    const parsed = JSON.parse(r.output);
+    expect(parsed.events[0].start).toBe('Jul 15, 2026, 4:05:00 PM');
+    expect(parsed.window.from).toBe('Jul 15, 2026, 12:00:00 AM');
+    // The QUERY still uses raw ZM timestamps; only the presentation formats.
+    expect(getEvents).toHaveBeenCalledWith(expect.objectContaining({ startDateTime: '2026-07-15 00:00:00' }));
+  });
+
   // The model reported ten rows as "8 Front Yard, 2 Garage Outdoor" when the
   // real split was four and six. It should be reading a tally, not counting.
   it('supplies the per-monitor tally so the model never counts rows', async () => {

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -882,32 +882,10 @@ describe('list_events when resolution (refs #246)', () => {
     expect(getEvents).toHaveBeenCalledWith(expect.objectContaining({ startDateTime: '2026-07-15 00:00:00' }));
   });
 
-  // A busiest-hour answer is about ONE hour; cards for the whole day under it
-  // read as a contradiction. The model still receives every row (refs #264).
-  it('narrows result cards to the busiest hour when that is what was asked', async () => {
-    vi.mocked(getEvents).mockResolvedValueOnce({
-      events: [
-        { Event: { Id: '1', MonitorId: '1', StartDateTime: '2026-07-15 08:10:00', Length: '30', Notes: 'detected:person' } },
-        { Event: { Id: '2', MonitorId: '1', StartDateTime: '2026-07-15 08:40:00', Length: '30', Notes: 'detected:person' } },
-        { Event: { Id: '3', MonitorId: '2', StartDateTime: '2026-07-15 11:20:00', Length: '30', Notes: 'detected:car' } },
-      ],
-      pagination: { page: 1, pageCount: 1, current: 1, count: 3, prevPage: false, nextPage: false, limit: 25, totalCount: 3 },
-    } as never);
-
-    const tool = getToolByName('list_events')!;
-    const r = await tool.execute(
-      { when: 'yesterday' },
-      { ...ctx(), timezone: 'America/New_York', question: 'what was my busiest hour yesterday' },
-    );
-
-    // Model output keeps all three rows; cards narrow to the 08:00 hour's two.
-    expect(JSON.parse(r.output).events).toHaveLength(3);
-    expect(r.display).toHaveLength(2);
-    expect(r.display?.map((d) => d.id)).toEqual(['1', '2']);
-  });
-
   // "Busiest hour" is timestamp arithmetic, so the tool computes the tally
-  // and hands the winner over as a finished clause (refs #264).
+  // and hands the winner over as data. It rides OUTSIDE the summary so a
+  // summarize answer quoting the summary never contains an hour label, which
+  // would falsely narrow the result cards (refs #264).
   it('reports the busiest hour and per-hour counts from the shown rows', async () => {
     vi.mocked(getEvents).mockResolvedValueOnce({
       events: [
@@ -922,7 +900,8 @@ describe('list_events when resolution (refs #246)', () => {
     const r = await tool.execute({ when: 'yesterday' }, { ...ctx(), timezone: 'America/New_York' });
 
     const parsed = JSON.parse(r.output);
-    expect(parsed.summary).toContain('Busiest hour: 2026-07-15 08:00:00 (2 events).');
+    expect(parsed.summary).not.toContain('Busiest hour');
+    expect(parsed.busiestHour).toEqual({ label: '2026-07-15 08:00:00', count: 2 });
     expect(parsed.countsByHour).toEqual({ '2026-07-15 08:00:00': 2, '2026-07-15 11:00:00': 1 });
   });
 

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -1146,6 +1146,10 @@ describe('list_events when resolution (refs #246)', () => {
     expect(parsed.moreMatchesExist).toBe(true);
     expect(parsed.shownEvents).toBe(1);
     expect(parsed.events).toHaveLength(1);
+    // matchCount is the server's TRUE total, not the page (refs #246):
+    // comparisons must quote real counts, never the cap.
+    expect(parsed.matchCount).toBe(2);
+    expect(parsed.summary).toContain('2 events');
   });
 
   it('leaves the more-matches flag unset when every match fits on the page', async () => {

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getToolByName, isWithheldToolName, readOnlyTools, WITHHELD_TOOL_NAMES, TOOLS } from '../tools';
-import { safeExecute, validateToolInput, objectTypePattern, coerceLabelList, isOmittedArg, stripOmittedArgs, objectQuestionMismatch, ungroundedWhenWords, toolCallSignature } from '../tool-helpers';
+import { safeExecute, validateToolInput, objectTypePattern, coerceLabelList, isOmittedArg, stripOmittedArgs, objectQuestionMismatch, toolCallSignature } from '../tool-helpers';
 import type { ToolContext } from '../types';
 import { asProfileId } from '../../../api/types';
 import { ASSISTANT } from '../../zmninja-ng-constants';
@@ -101,11 +101,24 @@ vi.mock('../../../api/tags', async () => {
   };
 });
 
+/** Test-local interpreter stub (refs #265): in production interpretWhen is a
+ *  model call; here a fixed phrase->fields map keeps executors deterministic. */
+const INTERPRETED: Record<string, Record<string, unknown>> = {
+  today: { daysAgo: 0 },
+  yesterday: { daysAgo: 1 },
+  'last hour': { lastCount: 1, lastUnit: 'hour' },
+  'yesterday from 4pm to 10pm': { daysAgo: 1, fromTime: '16:00', toTime: '22:00' },
+  gestern: { daysAgo: 1 },
+};
+
 function ctx(): ToolContext {
   return {
     profileId: asProfileId('p1'),
     queryClient: { fetchQuery: (o: { queryFn: () => unknown }) => o.queryFn() } as never,
     host: { navigate: vi.fn(), onActivity: vi.fn() },
+    interpretWhen: vi.fn(async (phrase: string) =>
+      INTERPRETED[phrase.toLowerCase()] ?? { error: `Could not interpret "${phrase}" as a time window.` },
+    ),
   };
 }
 
@@ -406,7 +419,7 @@ describe('read-only tools', () => {
 
   it('count_events maps monitor ids to names', async () => {
     const tool = getToolByName('count_events')!;
-    const r = await tool.execute({ interval: '1 hour' }, ctx());
+    const r = await tool.execute({ lastCount: 1, lastUnit: 'hour' }, ctx());
     expect(r.isError).toBeFalsy();
     expect(r.output).toContain('Front Door');
     expect(r.output).toContain('3');
@@ -414,7 +427,7 @@ describe('read-only tools', () => {
 
   it('count_events reports the summed total across monitors', async () => {
     const tool = getToolByName('count_events')!;
-    const r = await tool.execute({ interval: '1 hour' }, ctx());
+    const r = await tool.execute({ lastCount: 1, lastUnit: 'hour' }, ctx());
     expect(r.isError).toBeFalsy();
     const result = JSON.parse(r.output as string);
     expect(result).toMatchObject({
@@ -556,55 +569,33 @@ describe('read-only tools', () => {
   });
 });
 
-describe('ungroundedWhenWords', () => {
-  // The model sent when "yesterday from 4pm to 10pm" for a question that said
-  // only "yesterday": the example phrase from the prompt, not the user's words.
-  it('names the words the user never wrote', () => {
-    expect(ungroundedWhenWords('yesterday from 4pm to 10pm', 'how many vehicles came yesterday')).toEqual([
-      '4pm',
-      '10pm',
-    ]);
-  });
-
-  it('passes a phrase the user actually used', () => {
-    expect(ungroundedWhenWords('yesterday', 'how many vehicles came yesterday')).toEqual([]);
-    expect(
-      ungroundedWhenWords('yesterday from 4pm to 10pm', 'how many people came yesterday from 4pm to 10pm'),
-    ).toEqual([]);
-  });
-
-  it('ignores connective filler the user would not repeat', () => {
-    expect(ungroundedWhenWords('last 24 hours', 'what happened in the last 24 hours')).toEqual([]);
-  });
-});
-
 describe('toolCallSignature', () => {
   // Ollama sent {"monitorId":"","when":"yesterday","objectType":""} and then
   // {"when":"yesterday"}: the same query, two different strings, so the repeat
   // guard did not fire and the identical query ran again.
   it('treats omitted-argument spellings as the same call', () => {
-    const a = toolCallSignature('list_events', { monitorId: '', when: 'yesterday', objectType: '' });
-    const b = toolCallSignature('list_events', { when: 'yesterday' });
-    const c = toolCallSignature('list_events', { when: 'yesterday', objectType: null });
+    const a = toolCallSignature('list_events', { monitorId: '', daysAgo: 1, objectType: '' });
+    const b = toolCallSignature('list_events', { daysAgo: 1 });
+    const c = toolCallSignature('list_events', { daysAgo: 1, objectType: null });
     expect(a).toBe(b);
     expect(b).toBe(c);
   });
 
   it('ignores key order', () => {
-    expect(toolCallSignature('list_events', { when: 'today', limit: 5 })).toBe(
-      toolCallSignature('list_events', { limit: 5, when: 'today' }),
+    expect(toolCallSignature('list_events', { daysAgo: 0, limit: 5 })).toBe(
+      toolCallSignature('list_events', { limit: 5, daysAgo: 0 }),
     );
   });
 
   it('still separates genuinely different calls', () => {
-    expect(toolCallSignature('list_events', { when: 'today' })).not.toBe(
-      toolCallSignature('list_events', { when: 'yesterday' }),
+    expect(toolCallSignature('list_events', { daysAgo: 0 })).not.toBe(
+      toolCallSignature('list_events', { daysAgo: 1 }),
     );
-    expect(toolCallSignature('list_events', { when: 'today' })).not.toBe(
-      toolCallSignature('count_events', { when: 'today' }),
+    expect(toolCallSignature('list_events', { daysAgo: 0 })).not.toBe(
+      toolCallSignature('count_events', { daysAgo: 0 }),
     );
-    expect(toolCallSignature('list_events', { when: 'today', objectType: 'car' })).not.toBe(
-      toolCallSignature('list_events', { when: 'today' }),
+    expect(toolCallSignature('list_events', { daysAgo: 0, objectType: 'car' })).not.toBe(
+      toolCallSignature('list_events', { daysAgo: 0 }),
     );
   });
 });
@@ -652,17 +643,17 @@ describe('stripOmittedArgs', () => {
   // became the next crash.
   it('drops the null-filled arguments a model sends for "unused"', () => {
     expect(
-      stripOmittedArgs({ eventIds: null, limit: 25, when: 'today', monitorId: null, objectType: null, tag: null }),
-    ).toEqual({ limit: 25, when: 'today' });
+      stripOmittedArgs({ eventIds: null, limit: 25, daysAgo: 0, monitorId: null, objectType: null, tag: null }),
+    ).toEqual({ limit: 25, daysAgo: 0 });
   });
 
   it('drops placeholder strings and empty arrays too', () => {
-    expect(stripOmittedArgs({ when: 'today', objectType: '{}', tag: '', eventIds: [] })).toEqual({ when: 'today' });
+    expect(stripOmittedArgs({ daysAgo: 0, objectType: '{}', tag: '', eventIds: [] })).toEqual({ daysAgo: 0 });
   });
 
   it('keeps every real value, including falsy ones that mean something', () => {
-    expect(stripOmittedArgs({ when: 'today', objectType: ['car'], limit: 0 })).toEqual({
-      when: 'today',
+    expect(stripOmittedArgs({ daysAgo: 0, objectType: ['car'], limit: 0 })).toEqual({
+      daysAgo: 0,
       objectType: ['car'],
       limit: 0,
     });
@@ -745,11 +736,9 @@ describe('validateToolInput (the refine step, refs #246)', () => {
     expect(error).toContain('mode must be one of: fast, slow');
   });
 
-  // The failure this replaced: the model put the user's phrase in `range`,
-  // which was an enum. With `when` the only time field, the phrase has one
-  // place to go, and a stale `range` is now reported as an unknown argument
-  // that names `when` as a valid one.
-  it('steers a stale range argument to the field that replaced it', () => {
+  // A stale argument from an older contract (`range`, `when`) is reported as
+  // unknown, with the structured window fields named as the valid ones.
+  it('steers a stale time argument to the fields that replaced it', () => {
     const tool = getToolByName('list_events')!;
     const error = validateToolInput(tool.schema, { range: 'yesterday from 16:00 to 22:00' });
     expect(error).toContain('range is not an argument of this tool');
@@ -927,33 +916,6 @@ describe('list_events when resolution (refs #246)', () => {
     expect(parsed.countsByMonitor).toEqual({ 'Front Door': 2, '2': 1 });
   });
 
-  it('refuses a when phrase carrying words the user never wrote', async () => {
-    const tool = getToolByName('list_events')!;
-    const r = await tool.execute(
-      { when: 'yesterday from 4pm to 10pm', objectType: 'car' },
-      { ...ctx(), timezone: 'America/New_York', question: 'how many vehicles came yesterday' },
-    );
-
-    expect(r.isError).toBe(true);
-    expect(r.output).toContain('words the user did not write');
-    expect(r.output).toContain('4pm');
-    expect(getEvents).not.toHaveBeenCalled();
-  });
-
-  // WHEN_FILLER is an English word list; against another locale it flags
-  // legitimate connectives as invented and burns a correction round on a
-  // correct call, so the check is gated to English locales (refs #259).
-  it('skips the invented-words check for a non-English locale', async () => {
-    const tool = getToolByName('list_events')!;
-    const r = await tool.execute(
-      { when: 'yesterday' },
-      { ...ctx(), timezone: 'America/New_York', question: 'was geschah gestern', locale: 'de' },
-    );
-
-    expect(r.isError).toBeFalsy();
-    expect(getEvents).toHaveBeenCalled();
-  });
-
   // The whole point of giving the model the vocabulary: a label the detector
   // never writes cannot answer anything, and a zero-row "none" for it is
   // wrong when the real label was sitting right there.
@@ -1003,11 +965,11 @@ describe('list_events when resolution (refs #246)', () => {
     expect(getEvents).toHaveBeenCalledWith(expect.objectContaining({ notesRegexp: 'detected:.*(car|truck)' }));
   });
 
-  it('hands back an unreadable `when` phrase instead of querying a guessed window', async () => {
+  it('hands back an uninterpretable when phrase instead of querying a guessed window', async () => {
     const tool = getToolByName('list_events')!;
     const r = await tool.execute({ when: 'sometime last spring' }, { ...ctx(), timezone: 'America/New_York' });
     expect(r.isError).toBe(true);
-    expect(r.output).toContain('Could not read');
+    expect(r.output).toContain('Could not interpret');
     expect(getEvents).not.toHaveBeenCalled();
   });
 

--- a/app/src/lib/assistant/__tests__/tools.test.ts
+++ b/app/src/lib/assistant/__tests__/tools.test.ts
@@ -882,6 +882,30 @@ describe('list_events when resolution (refs #246)', () => {
     expect(getEvents).toHaveBeenCalledWith(expect.objectContaining({ startDateTime: '2026-07-15 00:00:00' }));
   });
 
+  // A busiest-hour answer is about ONE hour; cards for the whole day under it
+  // read as a contradiction. The model still receives every row (refs #264).
+  it('narrows result cards to the busiest hour when that is what was asked', async () => {
+    vi.mocked(getEvents).mockResolvedValueOnce({
+      events: [
+        { Event: { Id: '1', MonitorId: '1', StartDateTime: '2026-07-15 08:10:00', Length: '30', Notes: 'detected:person' } },
+        { Event: { Id: '2', MonitorId: '1', StartDateTime: '2026-07-15 08:40:00', Length: '30', Notes: 'detected:person' } },
+        { Event: { Id: '3', MonitorId: '2', StartDateTime: '2026-07-15 11:20:00', Length: '30', Notes: 'detected:car' } },
+      ],
+      pagination: { page: 1, pageCount: 1, current: 1, count: 3, prevPage: false, nextPage: false, limit: 25, totalCount: 3 },
+    } as never);
+
+    const tool = getToolByName('list_events')!;
+    const r = await tool.execute(
+      { when: 'yesterday' },
+      { ...ctx(), timezone: 'America/New_York', question: 'what was my busiest hour yesterday' },
+    );
+
+    // Model output keeps all three rows; cards narrow to the 08:00 hour's two.
+    expect(JSON.parse(r.output).events).toHaveLength(3);
+    expect(r.display).toHaveLength(2);
+    expect(r.display?.map((d) => d.id)).toEqual(['1', '2']);
+  });
+
   // "Busiest hour" is timestamp arithmetic, so the tool computes the tally
   // and hands the winner over as a finished clause (refs #264).
   it('reports the busiest hour and per-hour counts from the shown rows', async () => {

--- a/app/src/lib/assistant/__tests__/webllm.test.ts
+++ b/app/src/lib/assistant/__tests__/webllm.test.ts
@@ -345,6 +345,20 @@ describe('parseWebLlmTurn', () => {
     expect(turn.toolCalls[0].input).toEqual({});
   });
 
+  // Qwen's own tool-call template, observed arriving as CONTENT through
+  // Ollama when the server-side template failed to parse it into native
+  // tool_calls; printed as an answer it showed the user raw XML (refs #264).
+  it('recovers a Hermes-style <tool_call>{"name","arguments"}</tool_call> as the call it names', () => {
+    const turn = parseWebLlmTurn('<tool_call>\n{"name": "count_events", "arguments": {"interval":"1 hour"}}\n</tool_call>');
+    expect(turn.toolCalls).toHaveLength(1);
+    expect(turn.toolCalls[0].name).toBe('count_events');
+    expect(turn.toolCalls[0].input).toEqual({ interval: '1 hour' });
+  });
+
+  it('recovers a bare {"name","arguments"} object, with missing arguments as empty input', () => {
+    expect(parseWebLlmTurn('{"name":"list_monitors"}').toolCalls[0]).toMatchObject({ name: 'list_monitors', input: {} });
+  });
+
   it('falls back gracefully when even the embedded-object recovery finds no valid JSON', () => {
     const turn = parseWebLlmTurn('Sure, here you go: { this is not valid json');
     expect(turn).toEqual({

--- a/app/src/lib/assistant/__tests__/webllm.test.ts
+++ b/app/src/lib/assistant/__tests__/webllm.test.ts
@@ -502,6 +502,20 @@ describe('WebLlmProvider.chat', () => {
     // json_object mode is requested with no schema, so json_object must never
     // be sent bare.
     expect(call.response_format).toEqual({ type: 'json_object', schema: expect.stringContaining('"tool"') });
+    // Llama is not a thinking model; the Qwen3-only switch must stay off it.
+    expect(call.extra_body).toBeUndefined();
+  });
+
+  it('disables thinking via extra_body for a Qwen3 model', async () => {
+    const create = vi.fn().mockResolvedValue({ choices: [{ message: { content: '{"answer": "ok"}' } }] });
+    vi.mocked(getLoadedEngine).mockResolvedValue({ chat: { completions: { create } } } as never);
+
+    const provider = new WebLlmProvider('Qwen3-4B-q4f16_1-MLC');
+    await provider.chat([{ role: 'user', text: 'hi' }], [], 'sys', new AbortController().signal);
+
+    // The hard switch: web-llm pre-closes an empty think block, so the model
+    // cannot reason. The /no_think text directive alone is soft (measured).
+    expect(create.mock.calls[0][0].extra_body).toEqual({ enable_thinking: false });
   });
 
   // The XGrammar compiler has crashed before (see the module header), so the

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -34,6 +34,14 @@ describe('interpretWhen', () => {
     expect(fields).toEqual({ lastCount: 2, lastUnit: 'week' });
   });
 
+  it('parses a calendar span', async () => {
+    const p = providerSaying('{"fromDate": "2026-04-01", "toDate": "2026-04-30"}');
+    expect(await interpretWhen('april', p, NOW, 'UTC', new AbortController().signal)).toEqual({
+      fromDate: '2026-04-01',
+      toDate: '2026-04-30',
+    });
+  });
+
   it('maps none:true to an empty window', async () => {
     const p = providerSaying('{"none": true}');
     expect(await interpretWhen('all time', p, NOW, 'UTC', new AbortController().signal)).toEqual({});

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -1,0 +1,65 @@
+/**
+ * interpretWhen (refs #265): a single-purpose model call maps a human time
+ * phrase to WindowFields under a constrained schema. These tests cover the
+ * plumbing (schema handed to the provider, defensive parsing, caching, error
+ * paths); the interpretation quality itself is measured by the live eval
+ * (scripts/prompt-eval.mts interpret stage), not unit tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { interpretWhen, resetWindowInterpreterCacheForTests, WINDOW_SCHEMA } from '../window-interpreter';
+import type { AssistantProvider } from '../types';
+
+const NOW = new Date('2026-07-16T14:30:00Z');
+
+function providerSaying(text: string): AssistantProvider {
+  return { complete: vi.fn().mockResolvedValue({ text }) } as unknown as AssistantProvider;
+}
+
+describe('interpretWhen', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('passes the schema and the phrase to the provider and parses the fields', async () => {
+    const p = providerSaying('{"daysAgo": 1}');
+    const fields = await interpretWhen('yesterday', p, NOW, 'America/New_York', new AbortController().signal);
+    expect(fields).toEqual({ daysAgo: 1 });
+    const [system, phrase, , schema] = vi.mocked(p.complete).mock.calls[0];
+    expect(system).toContain('Today is Thursday, 2026-07-16');
+    expect(phrase).toBe('yesterday');
+    expect(schema).toBe(WINDOW_SCHEMA);
+  });
+
+  it('recovers fields wrapped in prose from an unconstrained backend', async () => {
+    const p = providerSaying('Sure: {"lastCount": 2, "lastUnit": "week"} there you go');
+    const fields = await interpretWhen('past 2 weeks', p, NOW, 'UTC', new AbortController().signal);
+    expect(fields).toEqual({ lastCount: 2, lastUnit: 'week' });
+  });
+
+  it('maps none:true to an empty window', async () => {
+    const p = providerSaying('{"none": true}');
+    expect(await interpretWhen('all time', p, NOW, 'UTC', new AbortController().signal)).toEqual({});
+  });
+
+  it('returns a corrective error for an unparseable reply', async () => {
+    const p = providerSaying('no json here');
+    const result = await interpretWhen('whenever', p, NOW, 'UTC', new AbortController().signal);
+    expect(result).toMatchObject({ error: expect.stringContaining('Could not interpret') });
+  });
+
+  it('returns a corrective error, not a throw, when the provider fails', async () => {
+    const p = { complete: vi.fn().mockRejectedValue(new Error('offline')) } as unknown as AssistantProvider;
+    const result = await interpretWhen('yesterday', p, NOW, 'UTC', new AbortController().signal);
+    expect(result).toMatchObject({ error: expect.stringContaining('right now') });
+  });
+
+  it('caches per phrase and calendar day, so repeats cost nothing', async () => {
+    const p = providerSaying('{"daysAgo": 0}');
+    await interpretWhen('today', p, NOW, 'UTC', new AbortController().signal);
+    await interpretWhen('  TODAY ', p, NOW, 'UTC', new AbortController().signal);
+    expect(p.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates an abort instead of caching it as an error', async () => {
+    const p = { complete: vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError')) } as unknown as AssistantProvider;
+    await expect(interpretWhen('today', p, NOW, 'UTC', new AbortController().signal)).rejects.toThrow('Aborted');
+  });
+});

--- a/app/src/lib/assistant/agent.ts
+++ b/app/src/lib/assistant/agent.ts
@@ -12,6 +12,7 @@ import type { AssistantMessage, AssistantProvider, AssistantHost, DisplayEntity,
 import { getToolByName, isWithheldToolName, TOOLS } from './tools';
 import { validateToolInput, objectQuestionMismatch, toolCallSignature, stripOmittedArgs } from './tool-helpers';
 import { captureApiCalls } from './api-capture';
+import { extractShowDirective, filterDisplayByShow } from './display';
 import { buildGroundingCorrection, fallbackAnswerFromData, retryIsUnusable } from './grounding';
 import { sanitizeModelText } from './sanitize';
 import { ASSISTANT } from '../zmninja-ng-constants';
@@ -347,6 +348,11 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
     if (turn.reasoning) {
       host.onActivity({ kind: 'model', detail: turn.reasoning, toolName: turn.toolCalls[0]?.name ?? '', status: 'running', input: {} });
     }
+    // The SHOW directive rides on the END of the answer text and must come
+    // off before anything reads it: the user never sees the line, and the
+    // grounding checks judge the prose, not the machine trailer (refs #264).
+    const { text: answerText, show } = turn.text ? extractShowDirective(turn.text) : { text: turn.text };
+    turn.text = answerText;
     const assistantMsg: AssistantMessage = { role: 'assistant', text: turn.text, toolCalls: turn.toolCalls, raw: turn.raw };
 
     if (turn.toolCalls.length === 0) {
@@ -419,7 +425,11 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
         });
         continue;
       }
-      assistantMsg.display = dedupeDisplay(turnDisplay);
+      // De-duped, then narrowed to the cards the model's SHOW directive
+      // selected (refs #264): the ids can only match cards this turn's tools
+      // produced, and no directive (or one matching nothing) shows everything.
+      const deduped = dedupeDisplay(turnDisplay);
+      assistantMsg.display = deduped && show ? filterDisplayByShow(deduped, show) : deduped;
       assistantMsg.trace = turnTrace.length > 0 ? [...turnTrace] : undefined;
       // The last iteration's usage, not the first: each tool round-trip
       // re-sends the history plus the new tool results, so the final call has

--- a/app/src/lib/assistant/agent.ts
+++ b/app/src/lib/assistant/agent.ts
@@ -21,7 +21,6 @@ import { log, LogLevel } from '../logger';
 /** Localized by the panel at render (Task 8): agent.ts never renders user-facing
  *  text itself, it only ever emits this key behind the `__i18n:` sentinel. */
 const ITERATION_CAP_KEY = 'assistant.iteration_cap_reached';
-const LIVE_DATA_REQUIRED_KEY = 'assistant.live_data_required';
 
 /** Returned to the model when it calls one of the actions the assistant no
  *  longer implements (see `WITHHELD_TOOL_NAMES` in tools.ts). Model-facing, so
@@ -35,63 +34,6 @@ const WITHHELD_TOOL_REFUSAL =
   'and say where: monitors and arming on the Monitors screen, run state on the Server screen, event ' +
   'deletion and archiving on that event. Do not retry any tool for this request.';
 
-interface ReadToolRequirement {
-  names: readonly string[];
-  reminder: string;
-}
-
-/**
- * Matches English only, deliberately.
- *
- * The obvious "fix" is keyword lists per language, and it is worse than
- * nothing: the terms are guesses at how someone phrases a question rather than
- * translated UI strings, no word list ever covers a language (a German user
- * can ask about events without using any noun on the list), and the collisions
- * are silent (French "hier" = yesterday, German "hier" = here, so a German
- * greeting would trip an events guard).
- *
- * The on-device model is an English-first 2B reasoning distill emitting a
- * strict JSON contract, so English is the path we actually support. The app
- * tells the user that outright when it is running on-device in another
- * language (see AskPanel's language notice) rather than implying, through a
- * half-working guard, that every language is equally supported.
- */
-function requiredReadTool(history: AssistantMessage[]): ReadToolRequirement | undefined {
-  const request = [...history].reverse().find((message) => message.role === 'user')?.text ?? '';
-  return readToolRequirementFor(request);
-}
-
-/** Whether this app's own heuristic says a question cannot be answered without
- *  fetching live data.
- *
- *  Exported so the caller can overrule a triage misclassification with it.
- *  Triage called "summarize yesterday" CHAT, the turn therefore ran with no
- *  tools, and this requirement then demanded a tool call that could not be
- *  made: the model called `list_events`, was told no tools were available,
- *  answered, was told to call a tool, and went round until the iteration cap.
- *  Two guards disagreeing is a deadlock, so they are made to agree. */
-export function requiresLiveData(question: string): boolean {
-  return readToolRequirementFor(question) !== undefined;
-}
-
-function readToolRequirementFor(request: string): ReadToolRequirement | undefined {
-  if (/\b(?:summar(?:y|i[sz]e)|recap|overview)\b.{0,80}\b(?:day|today|events?|activity)\b|\b(?:day|today)\b.{0,80}\b(?:summar(?:y|i[sz]e)|recap|overview)\b/i.test(request)) {
-    return {
-      names: ['list_events'],
-      reminder: 'Daily-summary requirement: call list_events with {"when":"today"} now. Do not answer until its result is available.',
-    };
-  }
-  if (/\b(?:server|health)\b/i.test(request)) {
-    return { names: ['get_server_health'], reminder: 'Live-data requirement: call get_server_health now. Do not answer until its result is available.' };
-  }
-  if (/\b(?:event|events?|detection|detections?|activity|activities|today|yesterday)\b/i.test(request)) {
-    return { names: ['list_events', 'count_events'], reminder: 'Live-data requirement: call list_events or count_events now. Do not answer until its result is available.' };
-  }
-  if (/\b(?:camera|cameras|monitor|monitors?|status|armed|disarmed|fps)\b/i.test(request)) {
-    return { names: ['list_monitors', 'get_monitor'], reminder: 'Live-data requirement: call list_monitors or get_monitor now. Do not answer until its result is available.' };
-  }
-  return undefined;
-}
 
 /** De-dupes by `kind`+`id` (the same event/monitor can surface from more than
  *  one tool call in a turn, e.g. list_events then get_event on one of its
@@ -288,19 +230,17 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
    *  iteration-cap message below can still tell AskPanel how full the window
    *  got: a turn that burns every iteration is exactly the kind that fills it. */
   let lastUsage: TokenUsage | undefined;
-  // Skipped entirely for a turn with no tools: demanding a tool call that
-  // cannot be made is the deadlock above. Belt and braces alongside the
-  // caller's own check, so no future routing decision can recreate it.
-  const readToolRequirement = tools.length > 0 ? requiredReadTool(history) : undefined;
-  let requiredReadToolComplete = false;
-  let requiredReadToolReminderSent = false;
-  /** Language-neutral net under the English-only requirement above (refs
-   *  #259): a turn that was routed here WITH tools (triage said this is a
-   *  ZoneMinder question) and answers without ever running one gets a single
-   *  generic reminder in any language. Unlike the specific requirement it
-   *  never hard-fails: without the regex match there is no certainty data was
-   *  required, so the second tool-less answer is accepted rather than
-   *  replaced. */
+  /** The tools THIS turn may execute. Starts as the caller's routing decision
+   *  and fails OPEN (refs #265): when a tool-less (triage chat/action) turn
+   *  produces a call for a real registry read tool, the model's own attempt
+   *  is better routing evidence than any classifier, so the turn flips to the
+   *  full registry and the call runs instead of being refused. Everything in
+   *  the registry is read-only, so opening up is always safe. */
+  let activeTools = tools;
+  /** Language-neutral live-data net (refs #259, #265: this replaced English
+   *  keyword regexes entirely): a turn routed here WITH tools that answers
+   *  without ever attempting one gets a single generic reminder, in any
+   *  language. It never hard-fails; the second tool-less answer is accepted. */
   let genericToolReminderSent = false;
   /** `name:JSON(input)` for every tool call attempted this turn, so an
    *  identical repeat can be refused rather than re-run (see the loop below). */
@@ -330,7 +270,7 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
     const bounded = truncateHistory(history, ASSISTANT.maxHistoryMessages, ASSISTANT.maxHistoryCharacters);
     if (bounded.length !== history.length) history.splice(0, history.length, ...bounded);
 
-    const rawTurn = await provider.chat(history, tools, system, signal);
+    const rawTurn = await provider.chat(history, activeTools, system, signal);
     // Repaired here, once, for every backend: this is the single point all
     // providers pass through, and it is upstream of both the history the model
     // is replayed and the answer the user reads. `exchange` keeps the raw text
@@ -387,30 +327,10 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
         }
       }
 
-      if (readToolRequirement && !requiredReadToolComplete) {
-        lastUsage = turn.usage ?? lastUsage;
-        if (!requiredReadToolReminderSent) {
-          requiredReadToolReminderSent = true;
-          history.push({ role: 'user', text: readToolRequirement.reminder });
-          continue;
-        }
-        push({
-          role: 'assistant',
-          text: `__i18n:${LIVE_DATA_REQUIRED_KEY}`,
-          trace: turnTrace.length > 0 ? [...turnTrace] : undefined,
-          usage: lastUsage,
-        });
-        return produced;
-      }
-
-      // The language-neutral net (see genericToolReminderSent above). Only
-      // when the SPECIFIC requirement never matched: for a non-English
-      // question the regexes cannot see, this is the only nudge toward live
-      // data the turn gets.
+      // The language-neutral net (see genericToolReminderSent above).
       if (
-        !readToolRequirement &&
         !genericToolReminderSent &&
-        tools.length > 0 &&
+        activeTools.length > 0 &&
         !anyToolCallAttempted &&
         turn.text &&
         !turn.text.startsWith('__i18n:')
@@ -445,12 +365,21 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
     const results: ToolResult[] = [];
     for (const call of turn.toolCalls) {
       if (signal.aborted) return produced;
-      // THIS turn's tool list is the execution authority, not the registry:
-      // a turn given no tools (triage classified it as chat or an unsupported
-      // action) must treat an invented call as unavailable, and a caller that
+      // THIS turn's tool list is the execution authority: a caller that
       // passes its own definitions (tests, fixtures) must have exactly those
-      // run. The registry is consulted only to phrase the refusal (refs #259).
-      const def = tools.find((t) => t.name === call.name);
+      // run. One exception fails OPEN (refs #265): a turn that was routed
+      // here with NO tools (triage said chat/action) but whose model calls a
+      // real registry read tool has just out-voted the classifier: "summarize
+      // last week" was triaged CHAT, the model called list_events anyway, and
+      // refusing it turned a correct instinct into an apology. The registry
+      // is read-only, so honoring the call is always safe.
+      if (activeTools.length === 0 && tools.length === 0 && getToolByName(call.name)) {
+        log.assistant('Tool-less turn called a real read tool; enabling the registry (triage overruled)', LogLevel.INFO, {
+          toolName: call.name,
+        });
+        activeTools = TOOLS;
+      }
+      const def = activeTools.find((t) => t.name === call.name);
       if (!def) {
         // A withheld action is not the same as a typo: told "unknown tool", a
         // model retries variations of the name. Told why, it explains to the
@@ -536,7 +465,6 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
         results.push({ callId: call.id, output: r.output, isError: r.isError, display: r.display, apiCalls });
         trace({ kind: 'tool', name: call.name, input: call.input, output: r.output, isError: r.isError, apiCalls });
         if (!r.isError) toolOutputs.push(r.output);
-        if (readToolRequirement?.names.includes(call.name) && !r.isError) requiredReadToolComplete = true;
         host.onActivity({ toolName: call.name, status: r.isError ? 'error' : 'done', input: call.input });
       } catch (e) {
         const message = e instanceof Error ? e.message : 'Tool failed';
@@ -554,7 +482,7 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
 
   push({
     role: 'assistant',
-    text: `__i18n:${readToolRequirement && !requiredReadToolComplete ? LIVE_DATA_REQUIRED_KEY : ITERATION_CAP_KEY}`,
+    text: `__i18n:${ITERATION_CAP_KEY}`,
     display: dedupeDisplay(turnDisplay),
     trace: turnTrace.length > 0 ? [...turnTrace] : undefined,
     usage: lastUsage,

--- a/app/src/lib/assistant/display.ts
+++ b/app/src/lib/assistant/display.ts
@@ -70,3 +70,51 @@ export function buildMonitorDisplayEntity(m: MonitorData): DisplayEntity {
     navigatePath: `/monitors/${m.Monitor.Id}`,
   };
 }
+
+/**
+ * The SHOW directive: how the model says which cards its answer is about
+ * (refs #264).
+ *
+ * The model may end its answer with one final line
+ * `SHOW: events=<id,id> monitors=<id,id>`. The line is stripped before the
+ * text renders (so the no-raw-ids rule for answer TEXT stands) and the ids
+ * select among the cards this turn's tools actually produced; an id the
+ * results never contained selects nothing, so the model cannot conjure a
+ * card. No directive, or a directive matching nothing, shows every card,
+ * which is also what every model produced before the directive existed.
+ */
+export interface ShowDirective {
+  events: string[];
+  monitors: string[];
+}
+
+/** Splits a SHOW directive off the end of an answer. Only a FINAL line is
+ *  honored: a mid-text mention is prose about the mechanism, not a directive. */
+export function extractShowDirective(text: string): { text: string; show?: ShowDirective } {
+  const lines = text.trimEnd().split('\n');
+  const last = lines[lines.length - 1]?.trim() ?? '';
+  const match = /^SHOW:\s*(.*)$/i.exec(last);
+  if (!match) return { text };
+  const ids = (name: string): string[] => {
+    // No whitespace tolerated around '=': a lax match swallowed the NEXT
+    // list's name as this list's value on "events= monitors=".
+    const part = new RegExp(`\\b${name}=([^\\s]*)`, 'i').exec(match[1]);
+    return (part?.[1] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+  };
+  return {
+    text: lines.slice(0, -1).join('\n').trimEnd(),
+    show: { events: ids('events'), monitors: ids('monitors') },
+  };
+}
+
+/** The cards a SHOW directive selects, or every card when it selects none:
+ *  a directive full of ids the results never contained is a model mistake,
+ *  and hiding all evidence over it would be worse than over-showing. */
+export function filterDisplayByShow(entities: DisplayEntity[], show: ShowDirective): DisplayEntity[] {
+  const wanted = new Set([...show.events.map((id) => `event:${id}`), ...show.monitors.map((id) => `monitor:${id}`)]);
+  const selected = entities.filter((e) => wanted.has(`${e.kind}:${e.id}`));
+  return selected.length > 0 ? selected : entities;
+}

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -64,10 +64,35 @@ export function parseClockTime(text: string): number | undefined {
   return hour * 60 + minute;
 }
 
-/** How many days back a day-word refers to, or undefined if it is not one. */
-function dayWordOffset(word: string): number | undefined {
-  if (/^to-?day$/.test(word)) return 0;
-  if (/^yester-?day$/.test(word)) return 1;
+const WEEKDAYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+/**
+ * How many calendar days back a leading day phrase refers to, or undefined if
+ * the text does not start with one. Returns the rest of the phrase too, so
+ * part-of-day narrowing composes with every form ("sunday after 4pm").
+ *
+ * Understood: "today", "yesterday", "N days ago", and weekday names with an
+ * optional "on"/"last"/"this". A bare or "on"/"this" weekday is the most
+ * recent such day, today included ("on thursday" asked on a Thursday is
+ * today); "last" always reaches into the past week ("last thursday" asked on
+ * a Thursday is seven days ago). These were the two most common phrasings in
+ * live use that the resolver rejected (refs #262).
+ */
+function parseLeadingDay(text: string, now: Date, timezone: string): { daysAgo: number; rest?: string } | undefined {
+  const dayWord = /^(to-?day|yester-?day)(?: (.*))?$/.exec(text);
+  if (dayWord) return { daysAgo: /^to/.test(dayWord[1]) ? 0 : 1, rest: dayWord[2] };
+
+  const daysAgo = /^(\d+) days? ago(?: (.*))?$/.exec(text);
+  if (daysAgo) return { daysAgo: Number(daysAgo[1]), rest: daysAgo[2] };
+
+  const weekday = /^(?:(on|last|this) )?(sunday|monday|tuesday|wednesday|thursday|friday|saturday)(?: (.*))?$/.exec(text);
+  if (weekday) {
+    const todayDow = toZonedTime(now, timezone).getDay();
+    const targetDow = WEEKDAYS.indexOf(weekday[2]);
+    const back = (todayDow - targetDow + 7) % 7;
+    return { daysAgo: weekday[1] === 'last' && back === 0 ? 7 : back, rest: weekday[3] };
+  }
+
   return undefined;
 }
 
@@ -122,12 +147,13 @@ export function resolveWhen(
     return { startDateTime: formatForZm(subHours(now, hours), timezone), endDateTime: formatForZm(now, timezone) };
   }
 
-  // A day word, optionally narrowed to part of that day.
-  const dayMatch = /^(to-?day|yester-?day)(?: (.*))?$/.exec(text);
+  // A day phrase (today, yesterday, "2 days ago", a weekday), optionally
+  // narrowed to part of that day.
+  const dayMatch = parseLeadingDay(text, now, timezone);
   if (dayMatch) {
-    const daysAgo = dayWordOffset(dayMatch[1])!;
+    const { daysAgo } = dayMatch;
     const dayStart = localMidnight(now, timezone, daysAgo);
-    const rest = dayMatch[2]?.trim();
+    const rest = dayMatch.rest?.trim();
 
     // The whole day. "today" ends now rather than at a midnight that has not
     // happened yet.
@@ -172,7 +198,7 @@ export function resolveWhen(
 
   return {
     error:
-      `Could not read "${phrase}" as a time window. Use a phrase like "today", "yesterday", ` +
-      '"last 24 hours", "last 7 days", "yesterday from 4pm to 10pm", or "today before noon".',
+      `Could not read "${phrase}" as a time window. Use a phrase like "today", "yesterday", "sunday", ` +
+      '"2 days ago", "last 24 hours", "last 7 days", "yesterday from 4pm to 10pm", or "today before noon".',
   };
 }

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -41,13 +41,21 @@ export interface WindowFields {
   daysAgo?: number;
   weekday?: string;
   date?: string;
+  /** Calendar span, inclusive on both ends: "april" is fromDate 2026-04-01 +
+   *  toDate 2026-04-30. Either side may stand alone ("since july 1"). The
+   *  general primitive for every calendar-aligned window (a named month,
+   *  "this month", an explicit range, a year), so no month/quarter/year
+   *  field list ever needs enumerating (refs #265). */
+  fromDate?: string;
+  toDate?: string;
   fromTime?: string;
   toTime?: string;
 }
 
 export interface ResolvedEventRange {
-  startDateTime: string;
-  endDateTime: string;
+  /** Either side may be absent for a one-sided window ("since july 1"). */
+  startDateTime?: string;
+  endDateTime?: string;
 }
 
 /** Formats a real instant as the ZM API's local-timezone datetime string.
@@ -80,20 +88,64 @@ function clockMinutes(value: string): number | undefined {
  * for the model to correct from, or `undefined` when no window field was
  * given at all (an unfiltered query, which the caller reports as such).
  */
+const DATE_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Local midnight at the start of `date` (YYYY-MM-DD) in `timezone`, plus
+ *  `dayOffset` days, as a real instant. */
+function dateMidnight(date: string, timezone: string, dayOffset: number): Date | undefined {
+  const parsed = new Date(`${date}T12:00:00`);
+  // An impossible calendar date must become a corrective error upstream:
+  // V8 turns a 13th month into Invalid Date but ROLLS 2026-02-29 over to
+  // March 1, so a round-trip compare is needed, not just a NaN check.
+  if (Number.isNaN(parsed.getTime()) || format(parsed, 'yyyy-MM-dd') !== date) return undefined;
+  const zoned = startOfDay(toZonedTime(fromZonedTime(parsed, timezone), timezone));
+  return fromZonedTime(dayOffset === 0 ? zoned : subDays(zoned, -dayOffset), timezone);
+}
+
 export function resolveWindow(
   fields: WindowFields,
   now: Date,
   timezone: string,
 ): ResolvedEventRange | { error: string } | undefined {
-  const { lastCount, lastUnit, daysAgo, weekday, date, fromTime, toTime } = fields;
+  const { lastCount, lastUnit, daysAgo, weekday, date, fromDate, toDate, fromTime, toTime } = fields;
   const dayPickers = [daysAgo !== undefined, weekday !== undefined, date !== undefined].filter(Boolean).length;
   const rolling = lastCount !== undefined || lastUnit !== undefined;
+  const ranged = fromDate !== undefined || toDate !== undefined;
 
-  if (rolling && dayPickers > 0) {
-    return { error: 'Send either a rolling window (lastCount+lastUnit) or a day (daysAgo, weekday, or date), not both.' };
+  if ([rolling, dayPickers > 0, ranged].filter(Boolean).length > 1) {
+    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, or date), or a span (fromDate/toDate).' };
   }
   if (dayPickers > 1) {
     return { error: 'Send only one of daysAgo, weekday, or date.' };
+  }
+
+  if (ranged) {
+    if (fromTime !== undefined || toTime !== undefined) {
+      return { error: 'fromTime/toTime narrow a single day; use daysAgo, weekday, or date alongside them.' };
+    }
+    for (const [name, value] of [['fromDate', fromDate], ['toDate', toDate]] as const) {
+      if (value !== undefined && !DATE_SHAPE.test(String(value).trim())) {
+        return { error: `${name} must be "YYYY-MM-DD". Received "${String(value)}".` };
+      }
+    }
+    const start = fromDate === undefined ? undefined : dateMidnight(String(fromDate).trim(), timezone, 0);
+    // toDate is INCLUSIVE: the window closes at the midnight after it,
+    // capped at now so "this month" never claims the future.
+    const endRaw = toDate === undefined ? undefined : dateMidnight(String(toDate).trim(), timezone, 1);
+    if ((fromDate !== undefined && start === undefined) || (toDate !== undefined && endRaw === undefined)) {
+      return { error: `"${String(start === undefined ? fromDate : toDate)}" is not a real calendar date.` };
+    }
+    const end = endRaw === undefined ? undefined : endRaw.getTime() > now.getTime() ? now : endRaw;
+    if (start && start.getTime() > now.getTime()) {
+      return { error: `fromDate "${String(fromDate)}" is in the future.` };
+    }
+    if (start && end && end.getTime() <= start.getTime()) {
+      return { error: 'toDate must be on or after fromDate.' };
+    }
+    return {
+      ...(start ? { startDateTime: formatForZm(start, timezone) } : {}),
+      ...(end ? { endDateTime: formatForZm(end, timezone) } : {}),
+    };
   }
 
   if (rolling) {

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -1,19 +1,49 @@
 /**
- * Resolves the assistant's relative event-date filters ("today", "yesterday",
- * rolling windows) into concrete ZM API datetime strings (refs #246).
+ * Converts the assistant's STRUCTURED time-window fields into concrete ZM API
+ * datetime strings (refs #265).
  *
- * Small/local models (Gemma, Qwen, etc. run through Ollama or on-device) are
- * unreliable at computing an ISO timestamp for "today" or "yesterday"
- * themselves: this is why `list_events`' `when` input exists at all (see
- * `tools-readonly.ts`). Resolving it here, in app code, means the model only
- * ever has to repeat the user's phrase, never compute a date. `now` and
- * `timezone` are both explicit parameters, never read from a store, so this
- * stays pure and unit-testable with a fixed clock and a fixed zone regardless
- * of the CI runner's own system timezone.
+ * The model interprets the user's time words, in any phrasing and language,
+ * into flat fields (`lastCount`+`lastUnit`, `daysAgo`, `weekday`, `date`,
+ * `fromTime`/`toTime`); this module only does arithmetic on them. This
+ * replaced an English phrase grammar (`resolveWhen`) that understood exactly
+ * the phrasings someone had written regexes for and silently failed on every
+ * other human variant. Interpretation is what a language model is good at;
+ * date arithmetic is what code is good at; each now does its own job.
+ *
+ * `now` and `timezone` are explicit parameters, never read from a store, so
+ * this stays pure and unit-testable with a fixed clock and a fixed zone
+ * regardless of the CI runner's own system timezone.
  */
-import { subHours, subDays, startOfDay, addMinutes, format } from 'date-fns';
+import { subHours, startOfDay, subDays, addMinutes, format } from 'date-fns';
 import { toZonedTime, fromZonedTime } from 'date-fns-tz';
 import { ZM_API_DATETIME_FORMAT } from '../zm/zm-constants';
+
+/** Closed, universal sets: the tool CONTRACT, not a vocabulary. The model
+ *  maps whatever the user said onto these; no word list exists app-side. */
+export const WINDOW_UNITS = ['minute', 'hour', 'day', 'week', 'month'] as const;
+export const WEEKDAYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'] as const;
+
+const UNIT_HOURS: Record<(typeof WINDOW_UNITS)[number], number> = {
+  minute: 1 / 60,
+  hour: 1,
+  day: 24,
+  // ponytail: rolling approximations; calendar-aligned weeks/months are a
+  // `calendarAgo` field away if anyone asks for "last calendar month".
+  week: 24 * 7,
+  month: 24 * 30,
+};
+
+/** The window fields the event tools accept. All optional; validation of
+ *  combinations happens in `resolveWindow` with corrective errors. */
+export interface WindowFields {
+  lastCount?: number;
+  lastUnit?: string;
+  daysAgo?: number;
+  weekday?: string;
+  date?: string;
+  fromTime?: string;
+  toTime?: string;
+}
 
 export interface ResolvedEventRange {
   startDateTime: string;
@@ -21,184 +51,119 @@ export interface ResolvedEventRange {
 }
 
 /** Formats a real instant as the ZM API's local-timezone datetime string.
- *  `toZonedTime` + `format` is date-fns-tz's own documented recipe for this:
- *  `toZonedTime` shifts `instant` so that plain `Date` getters (which
- *  `date-fns`'s `format` reads) return `timezone`'s wall-clock values
- *  regardless of the runtime's own system timezone. */
+ *  `toZonedTime` + `format` is date-fns-tz's own documented recipe for this. */
 function formatForZm(instant: Date, timezone: string): string {
   return format(toZonedTime(instant, timezone), ZM_API_DATETIME_FORMAT);
 }
 
 /** Local midnight, `daysAgo` calendar days before `now`'s day in `timezone`,
- *  returned as a real UTC instant. `fromZonedTime` is the reverse of
- *  `toZonedTime`: it reads `zonedMidnight`'s plain `Date` getters as
- *  `timezone`'s wall clock and converts that back to the actual instant. */
+ *  returned as a real UTC instant. */
 function localMidnight(now: Date, timezone: string, daysAgo: number): Date {
   const zonedToday = startOfDay(toZonedTime(now, timezone));
   const zonedMidnight = daysAgo > 0 ? subDays(zonedToday, daysAgo) : zonedToday;
   return fromZonedTime(zonedMidnight, timezone);
 }
 
-/** One clock time expressed the way people write it, as minutes past
- *  midnight: "4pm", "4:30pm", "16:00", "noon", "midnight". Undefined if the
- *  text is not a time at all. */
-export function parseClockTime(text: string): number | undefined {
-  const value = text.trim().toLowerCase().replace(/\./g, '');
-  if (value === 'noon' || value === 'midday') return 12 * 60;
-  if (value === 'midnight') return 0;
-
-  const match = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$/.exec(value);
+/** Strict `HH:MM` (24h) as minutes past midnight, or undefined. The model is
+ *  asked for exactly this shape; anything else is refused, not guessed at. */
+function clockMinutes(value: string): number | undefined {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
   if (!match) return undefined;
-  const [, rawHour, rawMinute, meridiem] = match;
-  let hour = Number(rawHour);
-  const minute = Number(rawMinute ?? '0');
-  if (minute > 59) return undefined;
-
-  if (meridiem) {
-    if (hour < 1 || hour > 12) return undefined;
-    if (meridiem === 'am') hour = hour === 12 ? 0 : hour;
-    else hour = hour === 12 ? 12 : hour + 12;
-  } else if (hour > 23) {
-    return undefined;
-  }
-  return hour * 60 + minute;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return undefined;
+  return hours * 60 + minutes;
 }
 
-const WEEKDAYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
-
 /**
- * How many calendar days back a leading day phrase refers to, or undefined if
- * the text does not start with one. Returns the rest of the phrase too, so
- * part-of-day narrowing composes with every form ("sunday after 4pm").
- *
- * Understood: "today", "yesterday", "N days ago", and weekday names with an
- * optional "on"/"last"/"this". A bare or "on"/"this" weekday is the most
- * recent such day, today included ("on thursday" asked on a Thursday is
- * today); "last" always reaches into the past week ("last thursday" asked on
- * a Thursday is seven days ago). These were the two most common phrasings in
- * live use that the resolver rejected (refs #262).
+ * The exact start/stop pair the window fields describe, an `{error}` written
+ * for the model to correct from, or `undefined` when no window field was
+ * given at all (an unfiltered query, which the caller reports as such).
  */
-function parseLeadingDay(text: string, now: Date, timezone: string): { daysAgo: number; rest?: string } | undefined {
-  const dayWord = /^(to-?day|yester-?day)(?: (.*))?$/.exec(text);
-  if (dayWord) return { daysAgo: /^to/.test(dayWord[1]) ? 0 : 1, rest: dayWord[2] };
-
-  const daysAgo = /^(\d+) days? ago(?: (.*))?$/.exec(text);
-  if (daysAgo) return { daysAgo: Number(daysAgo[1]), rest: daysAgo[2] };
-
-  const weekday = /^(?:(on|last|this) )?(sunday|monday|tuesday|wednesday|thursday|friday|saturday)(?: (.*))?$/.exec(text);
-  if (weekday) {
-    const todayDow = toZonedTime(now, timezone).getDay();
-    const targetDow = WEEKDAYS.indexOf(weekday[2]);
-    const back = (todayDow - targetDow + 7) % 7;
-    return { daysAgo: weekday[1] === 'last' && back === 0 ? 7 : back, rest: weekday[3] };
-  }
-
-  return undefined;
-}
-
-const ROLLING_UNIT_HOURS: Record<string, number> = {
-  minute: 1 / 60, minutes: 1 / 60,
-  hour: 1, hours: 1,
-  day: 24, days: 24,
-  week: 24 * 7, weeks: 24 * 7,
-  month: 24 * 30, months: 24 * 30,
-};
-
-/**
- * Resolves a time window written the way a person says it.
- *
- * This exists because asking the model for a date is the one thing it
- * reliably gets wrong. Measured on llama3.2, "how many people came yesterday
- * from 4pm to 10pm" produced `range: "yesterday from 16:00 to 22:00"` (prose
- * in an enum field), and full ISO pairs ending on the 19th and the 20th when
- * yesterday was the 18th. The model is good at repeating the phrase the user
- * typed and bad at arithmetic on it, so the tool now takes the phrase and does
- * the arithmetic here, where a fixed clock and a fixed zone make it testable.
- *
- * Understood:
- *   "today", "yesterday"
- *   "last hour", "last 24 hours", "past 30 minutes", "last 7 days"
- *   "yesterday from 4pm to 10pm", "today between 9am and noon"
- *   "yesterday after 4pm", "today before noon"
- *
- * Returns an error message (not a throw) naming what was not understood, so
- * the caller can hand it back to the model as a correction.
- */
-export function resolveWhen(
-  phrase: string,
+export function resolveWindow(
+  fields: WindowFields,
   now: Date,
   timezone: string,
-): ResolvedEventRange | { error: string } {
-  // The enum keywords this parameter replaced, in case a model repeats one
-  // from an older conversation or a persisted thread.
-  const LEGACY = new Map([
-    ['last_hour', 'last hour'], ['last_24h', 'last 24 hours'],
-    ['last_7d', 'last 7 days'], ['last_30d', 'last 30 days'],
-  ]);
-  const raw = phrase.trim().toLowerCase().replace(/\s+/g, ' ');
-  const text = LEGACY.get(raw) ?? raw;
-  if (!text) return { error: 'when was empty.' };
+): ResolvedEventRange | { error: string } | undefined {
+  const { lastCount, lastUnit, daysAgo, weekday, date, fromTime, toTime } = fields;
+  const dayPickers = [daysAgo !== undefined, weekday !== undefined, date !== undefined].filter(Boolean).length;
+  const rolling = lastCount !== undefined || lastUnit !== undefined;
 
-  // "last 7 days" / "past 30 minutes" / "last hour"
-  const rolling = /^(?:in the )?(?:last|past|previous) (\d+ )?(minute|minutes|hour|hours|day|days|week|weeks|month|months)$/.exec(text);
-  if (rolling) {
-    const count = Number(rolling[1] ?? '1');
-    const hours = ROLLING_UNIT_HOURS[rolling[2]] * count;
-    return { startDateTime: formatForZm(subHours(now, hours), timezone), endDateTime: formatForZm(now, timezone) };
+  if (rolling && dayPickers > 0) {
+    return { error: 'Send either a rolling window (lastCount+lastUnit) or a day (daysAgo, weekday, or date), not both.' };
+  }
+  if (dayPickers > 1) {
+    return { error: 'Send only one of daysAgo, weekday, or date.' };
   }
 
-  // A day phrase (today, yesterday, "2 days ago", a weekday), optionally
-  // narrowed to part of that day.
-  const dayMatch = parseLeadingDay(text, now, timezone);
-  if (dayMatch) {
-    const { daysAgo } = dayMatch;
-    const dayStart = localMidnight(now, timezone, daysAgo);
-    const rest = dayMatch.rest?.trim();
-
-    // The whole day. "today" ends now rather than at a midnight that has not
-    // happened yet.
-    if (!rest) {
-      return {
-        startDateTime: formatForZm(dayStart, timezone),
-        endDateTime: formatForZm(daysAgo === 0 ? now : localMidnight(now, timezone, daysAgo - 1), timezone),
-      };
+  if (rolling) {
+    if (lastCount === undefined || lastUnit === undefined) {
+      return { error: 'A rolling window needs both lastCount and lastUnit.' };
     }
-
-    const window =
-      /^(?:from |between )?(.+?) (?:to|and|until|till|-) (.+)$/.exec(rest) ??
-      /^(after|since|before|until) (.+)$/.exec(rest);
-    if (!window) return { error: `Could not read "${rest}" as a time of day.` };
-
-    const isBound = /^(after|since|before|until)$/.test(window[1]);
-    const startText = isBound ? undefined : window[1];
-    const endText = isBound ? undefined : window[2];
-    const boundMinutes = isBound ? parseClockTime(window[2]) : undefined;
-
-    if (isBound) {
-      if (boundMinutes === undefined) return { error: `Could not read "${window[2]}" as a time of day.` };
-      const at = addMinutes(dayStart, boundMinutes);
-      const dayEnd = daysAgo === 0 ? now : localMidnight(now, timezone, daysAgo - 1);
-      return /^(after|since)$/.test(window[1])
-        ? { startDateTime: formatForZm(at, timezone), endDateTime: formatForZm(dayEnd, timezone) }
-        : { startDateTime: formatForZm(dayStart, timezone), endDateTime: formatForZm(at, timezone) };
+    const count = Number(lastCount);
+    if (!Number.isFinite(count) || count <= 0) {
+      return { error: `lastCount must be a positive number. Received "${String(lastCount)}".` };
     }
-
-    const startMinutes = parseClockTime(startText!);
-    const endMinutes = parseClockTime(endText!);
-    if (startMinutes === undefined) return { error: `Could not read "${startText}" as a time of day.` };
-    if (endMinutes === undefined) return { error: `Could not read "${endText}" as a time of day.` };
-    if (endMinutes <= startMinutes) {
-      return { error: `"${endText}" is not after "${startText}"; a window cannot end before it starts.` };
+    const unit = String(lastUnit).toLowerCase() as (typeof WINDOW_UNITS)[number];
+    if (!WINDOW_UNITS.includes(unit)) {
+      return { error: `lastUnit must be one of: ${WINDOW_UNITS.join(', ')}. Received "${String(lastUnit)}".` };
+    }
+    if (fromTime !== undefined || toTime !== undefined) {
+      return { error: 'fromTime/toTime narrow a single day; they cannot combine with a rolling window.' };
     }
     return {
-      startDateTime: formatForZm(addMinutes(dayStart, startMinutes), timezone),
-      endDateTime: formatForZm(addMinutes(dayStart, endMinutes), timezone),
+      startDateTime: formatForZm(subHours(now, UNIT_HOURS[unit] * count), timezone),
+      endDateTime: formatForZm(now, timezone),
     };
   }
 
+  let back: number | undefined;
+  if (daysAgo !== undefined) {
+    const n = Number(daysAgo);
+    if (!Number.isFinite(n) || n < 0) return { error: `daysAgo must be 0 or more. Received "${String(daysAgo)}".` };
+    back = Math.floor(n);
+  } else if (weekday !== undefined) {
+    const target = WEEKDAYS.indexOf(String(weekday).toLowerCase() as (typeof WEEKDAYS)[number]);
+    if (target === -1) return { error: `weekday must be one of: ${WEEKDAYS.join(', ')}. Received "${String(weekday)}".` };
+    // Most recent such day, today included: the model interprets "last
+    // sunday" vs "sunday" itself and can send daysAgo when it means a
+    // different week.
+    back = (toZonedTime(now, timezone).getDay() - target + 7) % 7;
+  } else if (date !== undefined) {
+    const text = String(date).trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+      return { error: `date must be "YYYY-MM-DD". Received "${String(date)}".` };
+    }
+    const zonedToday = startOfDay(toZonedTime(now, timezone));
+    const zonedTarget = startOfDay(toZonedTime(fromZonedTime(new Date(`${text}T12:00:00`), timezone), timezone));
+    back = Math.round((zonedToday.getTime() - zonedTarget.getTime()) / 86_400_000);
+    if (back < 0) return { error: `date "${text}" is in the future.` };
+  }
+
+  if (back === undefined) {
+    if (fromTime !== undefined || toTime !== undefined) {
+      return { error: 'fromTime/toTime need a day: send daysAgo, weekday, or date alongside them.' };
+    }
+    return undefined;
+  }
+
+  const dayStart = localMidnight(now, timezone, back);
+  const dayEnd = back === 0 ? now : localMidnight(now, timezone, back - 1);
+
+  const fromMinutes = fromTime === undefined ? undefined : clockMinutes(String(fromTime));
+  const toMinutes = toTime === undefined ? undefined : clockMinutes(String(toTime));
+  if (fromTime !== undefined && fromMinutes === undefined) {
+    return { error: `fromTime must be 24h "HH:MM". Received "${String(fromTime)}".` };
+  }
+  if (toTime !== undefined && toMinutes === undefined) {
+    return { error: `toTime must be 24h "HH:MM". Received "${String(toTime)}".` };
+  }
+  if (fromMinutes !== undefined && toMinutes !== undefined && toMinutes <= fromMinutes) {
+    return { error: 'toTime must be after fromTime.' };
+  }
+
   return {
-    error:
-      `Could not read "${phrase}" as a time window. Use a phrase like "today", "yesterday", "sunday", ` +
-      '"2 days ago", "last 24 hours", "last 7 days", "yesterday from 4pm to 10pm", or "today before noon".',
+    startDateTime: formatForZm(fromMinutes === undefined ? dayStart : addMinutes(dayStart, fromMinutes), timezone),
+    endDateTime: formatForZm(toMinutes === undefined ? dayEnd : addMinutes(dayStart, toMinutes), timezone),
   };
 }

--- a/app/src/lib/assistant/object-labels.ts
+++ b/app/src/lib/assistant/object-labels.ts
@@ -77,6 +77,11 @@ export function buildObjectLabelLine(labels: string[]): string {
     `Detected object labels seen recently on this installation: ${labels.join(', ')}. ` +
     'When the user names a category ("vehicles", "animals", "people"), pass EVERY label above that belongs ' +
     'to it as objectType, for example objectType ["car","truck"] for vehicles. Pass labels exactly as ' +
-    'written above, never the user\'s word for them. Other labels may exist that are not in this list.'
+    'written above, never the user\'s word for them. Other labels may exist that are not in this list. ' +
+    // The scoping sentence lives HERE, at the attractor: with the vocabulary
+    // alone in view, "summarize april" grew objectType with every known
+    // label, deterministically, silently excluding no-detection events.
+    'This list is ONLY for questions that name such a thing; a summary, recap, or comparison names none, ' +
+    'so it takes no objectType, ever.'
   );
 }

--- a/app/src/lib/assistant/providers/__tests__/openai.test.ts
+++ b/app/src/lib/assistant/providers/__tests__/openai.test.ts
@@ -142,6 +142,21 @@ describe('parseOpenAiTurn', () => {
     expect(turn).toEqual({ text: '__i18n:assistant.parse_error', toolCalls: [] });
   });
 
+  // Observed live on qwen3:8b: the server-side template failed to map the
+  // model's Hermes-style call onto native tool_calls, the XML arrived as
+  // content, and the lenient prose fallback printed it into the chat
+  // (refs #264).
+  it('parses a Hermes tool_call arriving as content into the call it names', () => {
+    const turn = parseOpenAiTurn({ content: '<tool_call>\n{"name": "count_events", "arguments": {"interval":"1 hour"}}\n</tool_call>' });
+    expect(turn.toolCalls[0]).toMatchObject({ name: 'count_events', input: { interval: '1 hour' } });
+  });
+
+  it('fails unparseable tool_call content instead of printing it as the answer', () => {
+    const turn = parseOpenAiTurn({ content: '<tool_call>{ not json at all' });
+    expect(turn.text).toBe('__i18n:assistant.parse_error');
+    expect(turn.raw).toContain('<tool_call>');
+  });
+
   // Measured against qwen3:30b-a3b through Ollama: a reasoning model that
   // spends the whole token budget thinking returns its chain of thought in a
   // separate `reasoning` field and leaves `content` empty. Rendered as-is that

--- a/app/src/lib/assistant/providers/__tests__/openai.test.ts
+++ b/app/src/lib/assistant/providers/__tests__/openai.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildOpenAiMessages, toOpenAiTools, parseOpenAiTurn, OpenAiProvider, listOpenAiModels, probeToolSupport, toolSupportFromError, suggestOllamaBaseUrl, resetNativeToolServersForTests, resetContextWindowsForTests } from '../openai';
+import { buildOpenAiMessages, toOpenAiTools, parseOpenAiTurn, OpenAiProvider, listOpenAiModels, probeToolSupport, toolSupportFromError, suggestOllamaBaseUrl, resetNativeToolServersForTests, resetContextWindowsForTests, warmOllamaModel, resetWarmedModelsForTests } from '../openai';
 import type { AssistantMessage, ToolDefinition } from '../../types';
 import { ASSISTANT } from '../../../zmninja-ng-constants';
 
@@ -552,6 +552,51 @@ describe('context window discovery', () => {
 
     expect(p.contextWindow).toBeUndefined();
     expect(httpGetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('warmOllamaModel', () => {
+  beforeEach(() => {
+    httpPostMock.mockReset();
+    httpGetMock.mockReset();
+    resetWarmedModelsForTests();
+    resetContextWindowsForTests();
+    resetNativeToolServersForTests();
+  });
+
+  it('loads the model via the native generate endpoint and confirms the server', async () => {
+    httpPostMock.mockResolvedValue({ data: { done: true } });
+    httpGetMock.mockResolvedValue({ data: { models: [{ model: 'qwen3:8b', context_length: 40960 }] } });
+
+    const warmed = await warmOllamaModel({ baseUrl: 'http://zm:11434/v1', model: 'qwen3:8b' });
+    expect(warmed).toBe(true);
+    expect(httpPostMock.mock.calls[0][0]).toBe('http://zm:11434/api/generate');
+    expect(httpPostMock.mock.calls[0][1]).toEqual({ model: 'qwen3:8b' });
+
+    // The whole point: the FIRST chat after a warmup already runs confirmed,
+    // with reasoning disabled and the context window known.
+    httpPostMock.mockResolvedValue({ data: { choices: [{ message: { content: 'hi' } }] } });
+    const p = new OpenAiProvider({ baseUrl: 'http://zm:11434/v1', model: 'qwen3:8b' });
+    expect(p.contextWindow).toBe(40960);
+    await p.chat([{ role: 'user', text: 'hello' }], [], 'sys', new AbortController().signal);
+    expect(httpPostMock.mock.calls.at(-1)?.[1]).toMatchObject({ reasoning_effort: ASSISTANT.ollamaReasoningEffort });
+  });
+
+  it('issues one warmup per server and model for the session', async () => {
+    httpPostMock.mockResolvedValue({ data: { done: true } });
+    httpGetMock.mockResolvedValue({ data: { models: [] } });
+    await warmOllamaModel({ baseUrl: 'http://zm:11434/v1', model: 'qwen3:8b' });
+    await expect(warmOllamaModel({ baseUrl: 'http://zm:11434/v1', model: 'qwen3:8b' })).resolves.toBe(false);
+    expect(httpPostMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws, and lets a later open retry after a failure', async () => {
+    httpPostMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(warmOllamaModel({ baseUrl: 'http://down:11434/v1', model: 'qwen3:8b' })).resolves.toBe(false);
+
+    httpPostMock.mockResolvedValue({ data: { done: true } });
+    httpGetMock.mockResolvedValue({ data: { models: [] } });
+    await expect(warmOllamaModel({ baseUrl: 'http://down:11434/v1', model: 'qwen3:8b' })).resolves.toBe(true);
   });
 });
 

--- a/app/src/lib/assistant/providers/openai.ts
+++ b/app/src/lib/assistant/providers/openai.ts
@@ -281,6 +281,11 @@ export function parseOpenAiTurn(message: OpenAiResponseMessage | undefined): Ass
   if (content.trim() === '') return { text: PARSE_ERROR_TEXT, toolCalls: [] };
   const portableTurn = parseWebLlmTurn(content);
   if (portableTurn.text !== PARSE_ERROR_TEXT) return portableTurn;
+  // Content that still carries a tool-call wrapper after the parser gave up
+  // is a malformed call, not prose: returning it as the answer printed raw
+  // <tool_call> XML into the chat (refs #264). Fail it so the self-repair
+  // retry runs instead.
+  if (/<tool_call>/i.test(content)) return { text: PARSE_ERROR_TEXT, toolCalls: [], raw: content };
   return { text: content, toolCalls: [] };
 }
 

--- a/app/src/lib/assistant/providers/openai.ts
+++ b/app/src/lib/assistant/providers/openai.ts
@@ -85,6 +85,65 @@ interface OllamaPsResponse {
   models?: Array<{ name?: string; model?: string; context_length?: number }>;
 }
 
+/** `baseUrl::model` pairs a warmup has already been issued for this session,
+ *  so reopening the panel does not re-post a load. A FAILED warmup is removed
+ *  again: the server may simply have been down at that moment, and the next
+ *  panel open should retry rather than remember the outage all session. */
+const WARMED_MODELS = new Set<string>();
+
+/** Test-only. */
+export function resetWarmedModelsForTests(): void {
+  WARMED_MODELS.clear();
+}
+
+/**
+ * Loads `model` into the Ollama server's memory before the first question
+ * (refs #261). An empty `/api/generate` body is Ollama's documented
+ * load-only call: it resolves once the model is resident and generates
+ * nothing. This is also the earliest possible Ollama confirmation, so the
+ * FIRST chat of the session already runs with `reasoning_effort` applied and
+ * a known context window; without it, both waited for the first completed
+ * call, which is how a first question came to cost ~36s (cold load plus one
+ * full thinking chain) while every later one took ~2s.
+ *
+ * Resolves `true` when the model is loaded, `false` when the warmup was
+ * already issued or failed. Never throws: a warmup must not break the panel,
+ * and a real turn surfaces real failures with better messages.
+ */
+export async function warmOllamaModel(config: OpenAiProviderConfig): Promise<boolean> {
+  const key = `${config.baseUrl}::${config.model}`;
+  if (WARMED_MODELS.has(key)) return false;
+  WARMED_MODELS.add(key);
+  const root = config.baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
+  try {
+    await httpPost(
+      `${root}/api/generate`,
+      { model: config.model },
+      { headers, timeoutMs: ASSISTANT.modelProbeTimeoutMs, intent: 'Assistant Ollama model warmup' },
+    );
+    OLLAMA_SERVERS.add(config.baseUrl);
+    // The window while we are here, same data refreshContextWindow reads
+    // after a turn; the model is certainly loaded now.
+    const ps = await httpGet<OllamaPsResponse>(`${root}/api/ps`, {
+      timeoutMs: ASSISTANT.testConnectionTimeoutMs,
+      intent: 'Assistant Ollama context window',
+    });
+    const entry = ps?.data?.models?.find((m) => m.model === config.model || m.name === config.model);
+    if (entry?.context_length) CONTEXT_WINDOWS.set(key, entry.context_length);
+    log.assistant('Ollama model warmed', LogLevel.INFO, { model: config.model, contextWindow: entry?.context_length });
+    return true;
+  } catch (error) {
+    WARMED_MODELS.delete(key);
+    log.assistant('Ollama model warmup failed; the first question will load it instead', LogLevel.WARN, {
+      model: config.model,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
 export interface OpenAiProviderConfig {
   /** e.g. `http://localhost:11434/v1` (no trailing `/chat/completions`). */
   baseUrl: string;

--- a/app/src/lib/assistant/providers/webllm.ts
+++ b/app/src/lib/assistant/providers/webllm.ts
@@ -438,6 +438,15 @@ function toTurn(parsed: unknown): AssistantTurn | undefined {
     if (nested?.toolCalls.length) return nested;
     return { text: obj.answer, toolCalls: [] };
   }
+  // Qwen's own tool-call template: `{"name": ..., "arguments": {...}}`,
+  // usually wrapped in <tool_call> tags. Observed live through Ollama when
+  // the server-side template failed to parse it into native tool_calls: the
+  // shape then arrived as CONTENT, and printing it as an answer showed the
+  // user raw XML (refs #264). It names a call as unambiguously as the
+  // contract shape does, so honor it.
+  if (typeof obj.name === 'string' && (obj.arguments === undefined || (obj.arguments !== null && typeof obj.arguments === 'object'))) {
+    return { toolCalls: [{ id: crypto.randomUUID(), name: obj.name, input: (obj.arguments ?? {}) as Record<string, unknown> }] };
+  }
   return undefined;
 }
 

--- a/app/src/lib/assistant/providers/webllm.ts
+++ b/app/src/lib/assistant/providers/webllm.ts
@@ -552,6 +552,12 @@ export class WebLlmProvider implements AssistantProvider {
     temperature: number,
     schema?: string,
   ) {
+    // The REAL Qwen3 no-think switch: web-llm pre-closes an empty <think/>
+    // block in the reply, so the model cannot reason at all. The /no_think
+    // directive in the system message (buildWebLlmMessages) is only the soft
+    // form; measured on Ollama it hides the tag without skipping the
+    // reasoning. Ignored by non-Qwen3 models.
+    const extraBody = isQwen3Model(this.modelId) ? { extra_body: { enable_thinking: false } } : {};
     if (schema && grammarUsable) {
       try {
         return await engine.chat.completions.create({
@@ -559,6 +565,7 @@ export class WebLlmProvider implements AssistantProvider {
           max_tokens: ASSISTANT.maxTokens,
           temperature,
           response_format: { type: 'json_object', schema },
+          ...extraBody,
         });
       } catch (error) {
         grammarUsable = false;
@@ -568,7 +575,7 @@ export class WebLlmProvider implements AssistantProvider {
         });
       }
     }
-    return engine.chat.completions.create({ messages, max_tokens: ASSISTANT.maxTokens, temperature });
+    return engine.chat.completions.create({ messages, max_tokens: ASSISTANT.maxTokens, temperature, ...extraBody });
   }
 
   /** Runs `work` with the abort signal wired to `engine.interruptGenerate()`.

--- a/app/src/lib/assistant/result-summary.ts
+++ b/app/src/lib/assistant/result-summary.ts
@@ -64,13 +64,8 @@ export function buildResultSummary(params: {
   countsByMonitor: Record<string, number>;
   objectCounts: Record<string, number>;
   partial: boolean;
-  /** The hour with the most SHOWN rows, when the caller computed one:
-   *  "busiest hour" is arithmetic over timestamps, which is exactly the kind
-   *  of derivation the model gets wrong, so it is supplied as a finished
-   *  clause instead (refs #264). */
-  busiestHour?: { label: string; count: number };
 }): string {
-  const { window, matchCount, countsByMonitor, objectCounts, partial, busiestHour } = params;
+  const { window, matchCount, countsByMonitor, objectCounts, partial } = params;
 
   // A string window means no time filter was applied. Saying so is the point:
   // told only a count, the model named a period it had never queried.
@@ -90,10 +85,6 @@ export function buildResultSummary(params: {
 
   const byObject = describeCounts(objectCounts);
   if (byObject) parts.push(`Detected: ${byObject}.`);
-
-  if (busiestHour) {
-    parts.push(`Busiest hour: ${busiestHour.label} (${busiestHour.count} ${busiestHour.count === 1 ? 'event' : 'events'}).`);
-  }
 
   if (partial) {
     parts.push('This is a partial result: more events matched than are listed here.');

--- a/app/src/lib/assistant/result-summary.ts
+++ b/app/src/lib/assistant/result-summary.ts
@@ -56,7 +56,10 @@ export type ResultWindow = { from?: string | null; to?: string | null } | string
  * The finished sentence, for the model to quote rather than reconstruct.
  *
  * `partial` marks a result whose rows were capped, so the model says so instead
- * of presenting a truncated list as the whole picture.
+ * of presenting a truncated list as the whole picture. `totalMatches` is the
+ * server's true match total when it exceeds the rows shown: without it, a
+ * comparison of two capped results read both page caps as "similar totals"
+ * (observed live: two windows both reported 25, real totals unknown).
  */
 export function buildResultSummary(params: {
   window: ResultWindow;
@@ -64,8 +67,9 @@ export function buildResultSummary(params: {
   countsByMonitor: Record<string, number>;
   objectCounts: Record<string, number>;
   partial: boolean;
+  totalMatches?: number;
 }): string {
-  const { window, matchCount, countsByMonitor, objectCounts, partial } = params;
+  const { window, matchCount, countsByMonitor, objectCounts, partial, totalMatches } = params;
 
   // A string window means no time filter was applied. Saying so is the point:
   // told only a count, the model named a period it had never queried.
@@ -78,15 +82,23 @@ export function buildResultSummary(params: {
 
   if (matchCount === 0) return `No events${range}.`;
 
-  const parts: string[] = [`${matchCount} ${matchCount === 1 ? 'event' : 'events'}${range}.`];
+  // Lead with the true total when it is known and larger than the page, so an
+  // answer that quotes this sentence quotes the real count, not the cap.
+  const knownTotal = totalMatches !== undefined && totalMatches > matchCount;
+  const lead = knownTotal ? totalMatches : matchCount;
+  const parts: string[] = [`${lead} ${lead === 1 ? 'event' : 'events'}${range}.`];
+  if (knownTotal) parts.push(`The ${matchCount} most recent are listed.`);
 
+  // The tallies cover the listed rows only; say so whenever rows were capped,
+  // so the model cannot present a page tally as the window's.
+  const scope = knownTotal || partial ? ' (listed rows)' : '';
   const byMonitor = describeCounts(countsByMonitor);
-  if (byMonitor) parts.push(`By monitor: ${byMonitor}.`);
+  if (byMonitor) parts.push(`By monitor${scope}: ${byMonitor}.`);
 
   const byObject = describeCounts(objectCounts);
-  if (byObject) parts.push(`Detected: ${byObject}.`);
+  if (byObject) parts.push(`Detected${scope}: ${byObject}.`);
 
-  if (partial) {
+  if (partial && !knownTotal) {
     parts.push('This is a partial result: more events matched than are listed here.');
   }
 

--- a/app/src/lib/assistant/result-summary.ts
+++ b/app/src/lib/assistant/result-summary.ts
@@ -64,8 +64,13 @@ export function buildResultSummary(params: {
   countsByMonitor: Record<string, number>;
   objectCounts: Record<string, number>;
   partial: boolean;
+  /** The hour with the most SHOWN rows, when the caller computed one:
+   *  "busiest hour" is arithmetic over timestamps, which is exactly the kind
+   *  of derivation the model gets wrong, so it is supplied as a finished
+   *  clause instead (refs #264). */
+  busiestHour?: { label: string; count: number };
 }): string {
-  const { window, matchCount, countsByMonitor, objectCounts, partial } = params;
+  const { window, matchCount, countsByMonitor, objectCounts, partial, busiestHour } = params;
 
   // A string window means no time filter was applied. Saying so is the point:
   // told only a count, the model named a period it had never queried.
@@ -85,6 +90,10 @@ export function buildResultSummary(params: {
 
   const byObject = describeCounts(objectCounts);
   if (byObject) parts.push(`Detected: ${byObject}.`);
+
+  if (busiestHour) {
+    parts.push(`Busiest hour: ${busiestHour.label} (${busiestHour.count} ${busiestHour.count === 1 ? 'event' : 'events'}).`);
+  }
 
   if (partial) {
     parts.push('This is a partial result: more events matched than are listed here.');

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -40,17 +40,15 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     'You can only read data and navigate. For any request to change something (arming or disarming, run state, monitor function, alarms, deleting or archiving), say plainly you cannot do it, because an assistant can misread a request and some actions cannot be undone, and point to where in the app: monitors and arming on the Monitors screen, run state on the Server screen, deletion and archiving on the event itself.',
     'Answer camera, monitor, event, detection, server, health, status, count, and current-state questions from a read tool called this turn.',
     'Use list_monitors to resolve a monitor name. Never ask the user for an id. Event tools search every monitor when monitorId is omitted.',
-    // The model echoes phrasing accurately and does date arithmetic badly, so
-    // the tool takes the phrase. Concrete example values were removed after
-    // the model copied them verbatim into queries: examples that look like
-    // values get used as values.
-    'Never work out a date or timestamp yourself. COPY the user\'s own time words into list_events\' `when`, exactly as they wrote them and nothing more: if they say "yesterday", send "yesterday".',
-    'For calendar days or detected objects, call list_events with when and/or objectType.',
+    // The model COPIES the phrase; a dedicated interpreter call maps it to
+    // structured fields and code does the arithmetic (refs #265). Measured:
+    // both reference models copy phrases perfectly and fill a time DSL badly.
+    'Never compute timestamps yourself. COPY the user\'s own time words into list_events\' `when`, verbatim and in their language ("yesterday", "last week", "letzte Woche"); the app interprets the phrase. Never add time words the user did not say.',
     // The summary rule must FORBID the filter, not merely omit it: asked to
     // "summarize today" the model added objectType "people" by analogy with
     // nearby object examples, hiding everything else that happened.
-    'For a daily summary, or any "what happened"/"summarize" question that names no specific object, call list_events with {"when":"today"} and NO objectType.',
-    'For rolling summaries such as "last 24 hours" or "most active", call count_events with the matching interval.',
+    'For a summary or any "what happened" question that names no specific object, call list_events with the asked-about window and NO objectType.',
+    'For bare "how many events in the last N hours/days" totals, count_events is cheaper than list_events.',
     // count_events measures ONE rolling window, so it cannot rank hours;
     // asked for a busiest hour it reported "the last hour" (refs #264). The
     // list_events result carries an app-computed busiest-hour clause.

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -51,6 +51,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     // nearby object examples, hiding everything else that happened.
     'For a daily summary, or any "what happened"/"summarize" question that names no specific object, call list_events with {"when":"today"} and NO objectType.',
     'For rolling summaries such as "last 24 hours" or "most active", call count_events with the matching interval.',
+    // count_events measures ONE rolling window, so it cannot rank hours;
+    // asked for a busiest hour it reported "the last hour" (refs #264). The
+    // list_events result carries an app-computed busiest-hour clause.
+    'For "busiest hour" or "most active hour" questions, call list_events with the day asked about: its summary names the busiest hour outright.',
     // count_events reports per-monitor counts and nothing about what was
     // detected; asked "how many vehicles came today" the model called it
     // anyway and reported all events as vehicles. The loop enforces this too

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -54,7 +54,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     // count_events measures ONE rolling window, so it cannot rank hours;
     // asked for a busiest hour it reported "the last hour" (refs #264). The
     // list_events result carries an app-computed busiest-hour clause.
-    'For "busiest hour" or "most active hour" questions, call list_events with the day asked about: its summary names the busiest hour outright.',
+    'For "busiest hour" or "most active hour" questions, call list_events with the day asked about: the result\'s busiestHour field is the answer, quote its label and count exactly, and end with a SHOW line listing the ids of that hour\'s events (see the SHOW rule below).',
     // count_events reports per-monitor counts and nothing about what was
     // detected; asked "how many vehicles came today" the model called it
     // anyway and reported all events as vehicles. The loop enforces this too
@@ -74,8 +74,13 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     // makes the answer reading, not arithmetic. The field-naming sentence is
     // the measured fix for reading matchCount (events) when asked about
     // objects (prompt-eval's `fields` variant, refs #259).
-    'A result\'s summary line is the counts already written out: START your answer with it, using its numbers and wording exactly, then add detail from the rows. matchCount and countsByMonitor ARE the counts; quote them and never tally rows yourself.',
+    'A result\'s summary line is the counts already written out: make it your first sentence, using its numbers and wording exactly, then add detail from the rows. matchCount and countsByMonitor ARE the counts; quote them and never tally rows yourself.',
     'matchCount is how many EVENTS matched. objectCounts is how many of each thing was detected. For "how many people/cars" questions, read objectCounts, not matchCount.',
-    'Be direct. Never show image links, URLs, or raw ids. Offer a next step only when helpful. Ask a question only when tools cannot resolve ambiguity.',
+    'Be direct. Never show image links, URLs, or raw ids in the answer text. Offer a next step only when helpful. Ask a question only when tools cannot resolve ambiguity.',
+    // The one machine-readable line in an otherwise prose answer. The app
+    // strips it before display and uses it to pick which result cards render,
+    // so an answer about one hour is not buried under the whole day's
+    // thumbnails (refs #264). Ids that no tool result carried select nothing.
+    'Always write your full prose answer first; a SHOW line never replaces it. Then, when the answer is about specific rows rather than every row (one hour of a day, one monitor, particular events), add one last line "SHOW: events=<ids> monitors=<ids>" with the ids of exactly those rows. The app removes that line and uses it to pick which result cards appear. Only an answer that covers every returned row equally gets no SHOW line.',
   ].join('\n');
 }

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -46,8 +46,12 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     'Never compute timestamps yourself. COPY the user\'s own time words into list_events\' `when`, verbatim and in their language ("yesterday", "last week", "letzte Woche"); the app interprets the phrase. Never add time words the user did not say.',
     // The summary rule must FORBID the filter, not merely omit it: asked to
     // "summarize today" the model added objectType "people" by analogy with
-    // nearby object examples, hiding everything else that happened.
+    // nearby object examples, hiding everything else that happened. Merging
+    // the comparison rule INTO this sentence broke it (measured: "summarize
+    // april" regressed to creeping the vocabulary), so comparisons get their
+    // own line.
     'For a summary or any "what happened" question that names no specific object, call list_events with the asked-about window and NO objectType.',
+    '"compare <A> to <B>" means two such summaries, one list_events call per period with `when` as the only argument: "compare may to june" is exactly {"when":"may"} then {"when":"june"}. objectType in a comparison is WRONG: it hides every event without a detection.',
     'For bare "how many events in the last N hours/days" totals, count_events is cheaper than list_events.',
     // count_events measures ONE rolling window, so it cannot rank hours;
     // asked for a busiest hour it reported "the last hour" (refs #264). The
@@ -73,6 +77,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     // the measured fix for reading matchCount (events) when asked about
     // objects (prompt-eval's `fields` variant, refs #259).
     'A result\'s summary line is the counts already written out: make it your first sentence, using its numbers and wording exactly, then add detail from the rows. matchCount and countsByMonitor ARE the counts; quote them and never tally rows yourself.',
+    // Unchanged when matchCount became the true total (refs #246): every
+    // longer variant naming "listed rows" or comparisons cost llama3.2 its
+    // per-monitor quoting (measured); the summary sentence already leads with
+    // the true total, and answers quote the summary.
     'matchCount is how many EVENTS matched. objectCounts is how many of each thing was detected. For "how many people/cars" questions, read objectCounts, not matchCount.',
     'Be direct. Never show image links, URLs, or raw ids in the answer text. Offer a next step only when helpful. Ask a question only when tools cannot resolve ambiguity.',
     // The one machine-readable line in an otherwise prose answer. The app

--- a/app/src/lib/assistant/tool-helpers.ts
+++ b/app/src/lib/assistant/tool-helpers.ts
@@ -193,34 +193,6 @@ export function objectQuestionMismatch(
 }
 
 /**
- * Whether a model-supplied time phrase actually came from the user, or was
- * lifted from an example in the prompt.
- *
- * Asked "how many vehicles came yesterday", the model sent
- * `when: "yesterday from 4pm to 10pm"`, the exact example phrase written in
- * the tool description and the system prompt. The query then covered six hours
- * of the day instead of all of it, silently, and the answer was confidently
- * wrong. The tool's own contract is "put the user's own words in `when`", so
- * that contract is checkable: every significant word of the phrase should
- * appear in the question.
- *
- * Only flags words the user never wrote. Filler and connective words are
- * ignored, so "yesterday" against "how many vehicles came yesterday" passes
- * while "4pm" does not.
- */
-const WHEN_FILLER = new Set(['from', 'to', 'and', 'the', 'at', 'in', 'on', 'between', 'until', 'till', 'of', 'a']);
-
-export function ungroundedWhenWords(phrase: string, question: string): string[] {
-  const asked = question.toLowerCase();
-  return phrase
-    .toLowerCase()
-    .split(/[\s,]+/)
-    .map((word) => word.trim())
-    .filter((word) => word.length > 0 && !WHEN_FILLER.has(word))
-    .filter((word) => !asked.includes(word));
-}
-
-/**
  * Drops every argument the model meant to leave out, before the tool sees it.
  *
  * Each tool used to do this itself, one argument at a time, and each one that

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -178,6 +178,24 @@ function formatTimestamp(value: string | undefined | null, ctx: ToolContext): st
   return formatAppDateTime(parsed, ctx.dateTimeFormat);
 }
 
+/** Raw ZM wall-clock starts tallied into absolute-hour buckets
+ *  (`YYYY-MM-DD HH:00:00` keys). Shared by the summary's busiest-hour clause
+ *  and the card-narrowing below it (refs #264). */
+function hourBuckets(rawStarts: readonly string[]): Record<string, number> {
+  return rawStarts.reduce<Record<string, number>>((acc, raw) => {
+    const key = `${raw.slice(0, 13)}:00:00`;
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+/** Whether the question asks for a busiest/peak hour. English heuristic with
+ *  the same standing as objectQuestionMismatch: it narrows presentation only,
+ *  and a miss just shows every card. */
+function asksBusiestHour(question: string | undefined): boolean {
+  return /\b(?:busiest|peak|most active)\b[^.?!]*\bhour\b/i.test(question ?? '');
+}
+
 /** Clamps a model-supplied limit into [1, ASSISTANT.maxListEventsLimit].
  *  Non-numeric or negative input (NaN, -5, "banana") falls back to the max
  *  instead of producing a NaN/negative EventFilters.limit. */
@@ -455,12 +473,9 @@ const listEventsTool: ToolDefinition = {
         // badly, so the tally is computed here and the winning hour handed
         // over as a finished clause (refs #264). Buckets are absolute hours
         // (date + hour) in ZM wall clock, labelled in the profile's format.
-        const hourCounts = rawStarts.slice(0, rowsToShow.length).reduce<Record<string, number>>((acc, raw) => {
-          const key = `${raw.slice(0, 13)}:00:00`;
-          acc[key] = (acc[key] ?? 0) + 1;
-          return acc;
-        }, {});
-        const hourEntries = Object.entries(hourCounts).sort((a, b) => b[1] - a[1]);
+        const hourEntries = Object.entries(hourBuckets(rawStarts.slice(0, rowsToShow.length))).sort(
+          (a, b) => b[1] - a[1],
+        );
         const busiestHour =
           rowsToShow.length > 1 && hourEntries.length > 0
             ? { label: String(formatTimestamp(hourEntries[0][0], ctx)), count: hourEntries[0][1] }
@@ -505,9 +520,20 @@ const listEventsTool: ToolDefinition = {
         output = buildOutput(shown);
       }
 
-      // Cards mirror EXACTLY the rows the model was given. Building them from
-      // the full set is what let the UI contradict the answer.
-      const display = res.events.slice(0, shown.length).map(({ Event: e }) =>
+      // Cards mirror the rows the model was given, with one narrowing: a
+      // busiest-hour question is about ONE hour, and a full-day card wall
+      // under an answer naming nine events read as a contradiction
+      // (refs #264). The model still sees every row (it needs the whole day
+      // to rank hours); only the presentation narrows, and only when the
+      // question asked for a busiest hour and one exists.
+      const shownEvents = res.events.slice(0, shown.length);
+      let displayEvents = shownEvents;
+      if (asksBusiestHour(ctx.question) && shown.length > 1) {
+        const top = Object.entries(hourBuckets(rawStarts.slice(0, shown.length))).sort((a, b) => b[1] - a[1])[0]?.[0];
+        const inTopHour = shownEvents.filter(({ Event: e }) => `${e.StartDateTime.slice(0, 13)}:00:00` === top);
+        if (inTopHour.length > 0) displayEvents = inTopHour;
+      }
+      const display = displayEvents.map(({ Event: e }) =>
         buildEventDisplayEntity(e, nameById.get(e.MonitorId) ?? e.MonitorId, monitors, ctx),
       );
       return { output, display };

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -20,8 +20,9 @@ import { buildResultSummary, countObjects } from './result-summary';
 import { parseDetectedObjects } from '../event/event-detection';
 import { buildEventDisplayEntity, buildMonitorDisplayEntity } from './display';
 import { resolveWhen } from './event-range';
+import { formatAppDateTime } from '../format-date-time';
 import { resolveMonitorRef } from './monitor-ref';
-import type { ToolDefinition } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 import { safeExecute, isOmittedArg, objectTypePattern, coerceLabelList, ungroundedWhenWords, NAVIGATE_ALLOWLIST } from './tool-helpers';
 
 /** Maps a raw MonitorData into the clean, model-friendly shape shared by
@@ -161,6 +162,22 @@ const countEventsTool: ToolDefinition = {
     }),
 };
 
+/** A ZM timestamp re-rendered in the profile's own date/time format, so the
+ *  model quotes times the way the user reads them everywhere else in the app
+ *  (rule 21, refs #262). The model reliably echoes whatever format the rows
+ *  carry, so formatting the data IS formatting the answer. Raw when the
+ *  context carries no format (tests, older callers) or the value does not
+ *  parse; query filters never pass through here.
+ *  ponytail: parses the ZM wall-clock string in the runtime's own zone, same
+ *  as the result cards do; a profile-timezone-aware parse needs date-fns-tz
+ *  plumbing everywhere cards already accept this. */
+function formatTimestamp(value: string | undefined | null, ctx: ToolContext): string | undefined | null {
+  if (!value || !ctx.dateTimeFormat) return value;
+  const parsed = new Date(value.replace(' ', 'T'));
+  if (Number.isNaN(parsed.getTime())) return value;
+  return formatAppDateTime(parsed, ctx.dateTimeFormat);
+}
+
 /** Clamps a model-supplied limit into [1, ASSISTANT.maxListEventsLimit].
  *  Non-numeric or negative input (NaN, -5, "banana") falls back to the max
  *  instead of producing a NaN/negative EventFilters.limit. */
@@ -198,8 +215,9 @@ const listEventsTool: ToolDefinition = {
         type: 'string',
         description:
           'PREFERRED for any time window. COPY the user\'s own time words, exactly as they wrote them and ' +
-          'nothing more. Whole days, rolling windows ("last N hours/days") and parts of a day (from X to Y, ' +
-          'before X, after X) are all understood. The app converts the phrase to exact timestamps in the ' +
+          'nothing more. Whole days ("today", "yesterday", a weekday name, "N days ago"), rolling windows ' +
+          '("last N hours/days") and parts of a day (from X to Y, before X, after X) are all understood. ' +
+          'The app converts the phrase to exact timestamps in the ' +
           'profile\'s timezone, so never work out a date yourself and never pass a date here. Do not send a ' +
           'time of day the user did not mention.',
       },
@@ -325,8 +343,8 @@ const listEventsTool: ToolDefinition = {
        *  ever recorded. A function because the zero-match branch needs it
        *  before the rows exist. */
       const windowOf = () => {
-        const from = resolvedWhen?.startDateTime;
-        const to = resolvedWhen?.endDateTime;
+        const from = formatTimestamp(resolvedWhen?.startDateTime, ctx);
+        const to = formatTimestamp(resolvedWhen?.endDateTime, ctx);
         return from || to ? { from: from ?? null, to: to ?? null } : 'all recorded events, no time filter applied';
       };
 
@@ -397,7 +415,7 @@ const listEventsTool: ToolDefinition = {
       const rows = res.events.map(({ Event: e }) => ({
         id: e.Id,
         monitor: nameById.get(e.MonitorId) ?? e.MonitorId,
-        start: e.StartDateTime,
+        start: formatTimestamp(e.StartDateTime, ctx),
         durationSec: Number(e.Length),
         objects: parseDetectedObjects(e.Notes),
       }));
@@ -497,8 +515,8 @@ const getEventTool: ToolDefinition = {
         monitor: monitorName,
         monitorId: e.MonitorId,
         cause: e.Cause,
-        start: e.StartDateTime,
-        end: e.EndDateTime,
+        start: formatTimestamp(e.StartDateTime, ctx),
+        end: formatTimestamp(e.EndDateTime, ctx),
         durationSec: Number(e.Length),
         frames: Number(e.Frames),
         alarmFrames: Number(e.AlarmFrames),

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -19,11 +19,11 @@ import { ASSISTANT } from '../zmninja-ng-constants';
 import { buildResultSummary, countObjects } from './result-summary';
 import { parseDetectedObjects } from '../event/event-detection';
 import { buildEventDisplayEntity, buildMonitorDisplayEntity } from './display';
-import { resolveWhen } from './event-range';
+import { resolveWindow, type WindowFields } from './event-range';
 import { formatAppDateTime } from '../format-date-time';
 import { resolveMonitorRef } from './monitor-ref';
 import type { ToolContext, ToolDefinition } from './types';
-import { safeExecute, isOmittedArg, objectTypePattern, coerceLabelList, ungroundedWhenWords, NAVIGATE_ALLOWLIST } from './tool-helpers';
+import { safeExecute, isOmittedArg, objectTypePattern, coerceLabelList, NAVIGATE_ALLOWLIST } from './tool-helpers';
 
 /** Maps a raw MonitorData into the clean, model-friendly shape shared by
  *  list_monitors and get_monitor (refs #246): '0'/'1' strings become
@@ -134,24 +134,36 @@ const getMonitorTool: ToolDefinition = {
 const countEventsTool: ToolDefinition = {
   name: 'count_events',
   description:
-    'Count events per monitor over a ROLLING interval ending now, such as "1 hour" or "1 day" (that means ' +
-    'the last 24 hours, NOT since local midnight), covering ALL monitors in one call (no monitorId needed) ' +
-    'and reporting the combined total. Use this for "how many events in the last N hours/days" or ' +
-    '"summarize recent events" questions instead of list_events, which returns individual rows. ' +
+    'Count events per monitor over a ROLLING window ending now (lastCount + lastUnit; {"lastCount":1,' +
+    '"lastUnit":"day"} means the last 24 hours, NOT since local midnight), covering ALL monitors in one ' +
+    'call (no monitorId needed) and reporting the combined total. Use this for "how many events in the ' +
+    'last N hours/days" questions instead of list_events, which returns individual rows. ' +
     'It has TWO hard limits. It CANNOT express a calendar day: for "today" (since local midnight) or ' +
-    '"yesterday", call list_events with when instead. It CANNOT filter or report detected object types: ' +
+    '"yesterday", call list_events instead. It CANNOT filter or report detected object types: ' +
     'it returns event COUNTS ONLY and says nothing about what was detected, so for "how many ' +
     'people/cars/animals" questions call list_events with objectType instead. Calling this tool for an ' +
     'object-type question returns numbers that cannot answer it.',
   schema: {
     type: 'object',
-    properties: { interval: { type: 'string', description: 'A rolling window ending now, e.g. "1 hour", "1 day".' } },
-    required: ['interval'],
+    properties: {
+      lastCount: { type: 'number', description: 'How many lastUnits back the window reaches, e.g. 24 with "hour".' },
+      lastUnit: {
+        type: 'string',
+        enum: ['minute', 'hour', 'day', 'week', 'month'],
+        description: 'The unit of the rolling window.',
+      },
+    },
+    required: ['lastCount', 'lastUnit'],
+    additionalProperties: false,
   },
   execute: (input, _ctx) =>
     safeExecute('count_events', async () => {
-      const interval = String(input.interval ?? '');
-      if (!interval) throw new Error('interval is required');
+      const count = Number(input.lastCount);
+      const unit = String(input.lastUnit ?? '');
+      if (!Number.isFinite(count) || count <= 0 || !unit) throw new Error('lastCount and lastUnit are required.');
+      // ZoneMinder's consoleEvents endpoint takes a MySQL INTERVAL phrase; the
+      // singular unit is valid for any count ("2 week").
+      const interval = `${Math.floor(count)} ${unit}`;
       const [counts, { monitors }] = await Promise.all([getConsoleEvents(interval), getMonitors()]);
       const nameById = new Map(monitors.map((m) => [m.Monitor.Id, m.Monitor.Name]));
       const rows = counts
@@ -203,9 +215,8 @@ const listEventsTool: ToolDefinition = {
   description:
     'List individual events, newest first, optionally filtered by monitor, time window, detected object ' +
     'type, a single tag, or an explicit set of event ids. For ANY time window, COPY the user\'s own time ' +
-    'words into `when` and nothing more; the app converts the phrase against the profile\'s own timezone, ' +
-    'so never compute a date yourself. Whole days, rolling windows and parts of a day are all understood, ' +
-    'but send only what the user actually said. Combine when with objectType ' +
+    'words into `when`, verbatim and in their language; the app interprets the phrase and turns it into ' +
+    'exact timestamps in the profile\'s timezone. Combine when with objectType ' +
     'ONLY for questions that name an object, passing the labels this installation records (the system ' +
     'prompt lists them) and never the user\'s own word for them. Omit objectType for a summary. The ' +
     'rows this returns for a filter are exactly what ' +
@@ -225,12 +236,10 @@ const listEventsTool: ToolDefinition = {
       when: {
         type: 'string',
         description:
-          'PREFERRED for any time window. COPY the user\'s own time words, exactly as they wrote them and ' +
-          'nothing more. Whole days ("today", "yesterday", a weekday name, "N days ago"), rolling windows ' +
-          '("last N hours/days") and parts of a day (from X to Y, before X, after X) are all understood. ' +
-          'The app converts the phrase to exact timestamps in the ' +
-          'profile\'s timezone, so never work out a date yourself and never pass a date here. Do not send a ' +
-          'time of day the user did not mention.',
+          'The time window in the user\'s OWN words, copied verbatim, in whatever language they used ' +
+          '("yesterday", "last week", "letzte Woche", "2 days ago", "sunday from 4pm to 10pm"). The app ' +
+          'interprets the phrase and converts it to exact timestamps in the profile\'s timezone; never ' +
+          'compute a date yourself and never add time words the user did not say.',
       },
       objectType: {
         // Both shapes, declared honestly: the model is asked to send a list for
@@ -261,32 +270,21 @@ const listEventsTool: ToolDefinition = {
     return safeExecute('list_events', async () => {
       const timezone = ctx.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-      // `when` first: it is the argument the model is asked to fill, and it
-      // carries the user's own phrasing rather than arithmetic the model did.
-      // A phrase it cannot read is thrown back naming the unreadable part, so
-      // the model corrects instead of silently querying the wrong window.
+      // The phrase is the user's own words; a dedicated model call interprets
+      // it into structured fields (window-interpreter.ts) and resolveWindow
+      // does the arithmetic (refs #265). Any failure on the way becomes a
+      // corrective error the calling model retries from. Measured before
+      // splitting the jobs: both reference models copied phrases perfectly
+      // but filled the fields directly at 27/36 and 15/36.
       const whenPhrase = isOmittedArg(input.when) ? undefined : String(input.when);
       let resolvedWhen: { startDateTime: string; endDateTime: string } | undefined;
-      // English-locale only: WHEN_FILLER is an English word list, and against
-      // another language it flags legitimate connectives ("desde", "von") as
-      // invented, burning a correction round on a correct call (refs #259).
-      if (whenPhrase && ctx.question && (ctx.locale ?? 'en').toLowerCase().startsWith('en')) {
-        // The contract is "the user's own words". A phrase carrying words the
-        // user never wrote is the prompt's example leaking into the argument,
-        // and it narrows the window without anyone noticing.
-        const invented = ungroundedWhenWords(whenPhrase, ctx.question);
-        if (invented.length > 0) {
-          throw new Error(
-            `when "${whenPhrase}" contains words the user did not write (${invented.join(', ')}). ` +
-              'Copy the time period from the question itself, exactly as the user phrased it, and nothing more. ' +
-              'The examples in the tool description are formats, not values to send.',
-          );
-        }
-      }
       if (whenPhrase) {
-        const parsed = resolveWhen(whenPhrase, new Date(), timezone);
-        if ('error' in parsed) throw new Error(parsed.error);
-        resolvedWhen = parsed;
+        if (!ctx.interpretWhen) throw new Error('Time phrases are unavailable right now; retry without `when`.');
+        const fields = await ctx.interpretWhen(whenPhrase);
+        if ('error' in fields && fields.error) throw new Error(String(fields.error));
+        const window = resolveWindow(fields as WindowFields, new Date(), timezone);
+        if (window && 'error' in window) throw new Error(window.error);
+        resolvedWhen = window;
       }
 
       // Monitors first, and awaited rather than raced with getEvents: the
@@ -362,7 +360,7 @@ const listEventsTool: ToolDefinition = {
       const filters: EventFilters = {
         monitorId,
         // `when` is the only time argument this tool takes: the resolved
-        // phrase, or no window at all (see event-range.ts's resolveWhen).
+        // fields, or no window at all (see event-range.ts's resolveWindow).
         startDateTime: resolvedWhen?.startDateTime,
         endDateTime: resolvedWhen?.endDateTime,
         // Expanded through the category map, so "vehicles" matches the car and

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -189,13 +189,6 @@ function hourBuckets(rawStarts: readonly string[]): Record<string, number> {
   }, {});
 }
 
-/** Whether the question asks for a busiest/peak hour. English heuristic with
- *  the same standing as objectQuestionMismatch: it narrows presentation only,
- *  and a miss just shows every card. */
-function asksBusiestHour(question: string | undefined): boolean {
-  return /\b(?:busiest|peak|most active)\b[^.?!]*\bhour\b/i.test(question ?? '');
-}
-
 /** Clamps a model-supplied limit into [1, ASSISTANT.maxListEventsLimit].
  *  Non-numeric or negative input (NaN, -5, "banana") falls back to the max
  *  instead of producing a NaN/negative EventFilters.limit. */
@@ -494,14 +487,18 @@ const listEventsTool: ToolDefinition = {
           countsByMonitor,
           objectCounts,
           partial: Boolean(truncated),
-          busiestHour,
         });
+        // busiestHour rides OUTSIDE the summary on purpose: answers quote the
+        // summary verbatim, and an hour label inside it would make the
+        // answer-narrowing in agent.ts (refs #264) shrink the cards for every
+        // summarize question, not just busiest-hour ones.
         const base = {
           summary,
           window,
           matchCount: rowsToShow.length,
           countsByMonitor,
           objectCounts,
+          ...(busiestHour ? { busiestHour } : {}),
           ...(countsByHour ? { countsByHour } : {}),
           events: rowsToShow,
         };
@@ -520,20 +517,11 @@ const listEventsTool: ToolDefinition = {
         output = buildOutput(shown);
       }
 
-      // Cards mirror the rows the model was given, with one narrowing: a
-      // busiest-hour question is about ONE hour, and a full-day card wall
-      // under an answer naming nine events read as a contradiction
-      // (refs #264). The model still sees every row (it needs the whole day
-      // to rank hours); only the presentation narrows, and only when the
-      // question asked for a busiest hour and one exists.
-      const shownEvents = res.events.slice(0, shown.length);
-      let displayEvents = shownEvents;
-      if (asksBusiestHour(ctx.question) && shown.length > 1) {
-        const top = Object.entries(hourBuckets(rawStarts.slice(0, shown.length))).sort((a, b) => b[1] - a[1])[0]?.[0];
-        const inTopHour = shownEvents.filter(({ Event: e }) => `${e.StartDateTime.slice(0, 13)}:00:00` === top);
-        if (inTopHour.length > 0) displayEvents = inTopHour;
-      }
-      const display = displayEvents.map(({ Event: e }) =>
+      // Cards mirror EXACTLY the rows the model was given; whether they all
+      // RENDER is decided later, against the answer text (agent.ts's
+      // narrowDisplayToAnswer, refs #264), because only the finished answer
+      // says which rows it is about.
+      const display = res.events.slice(0, shown.length).map(({ Event: e }) =>
         buildEventDisplayEntity(e, nameById.get(e.MonitorId) ?? e.MonitorId, monitors, ctx),
       );
       return { output, display };

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -448,6 +448,9 @@ const listEventsTool: ToolDefinition = {
        *  allowance is a guess. */
       const buildOutput = (rowsToShow: typeof rows) => {
         const truncated = rowsToShow.length < rows.length || res.pagination.nextPage;
+        // The server's true match total. Two capped results both said
+        // "matchCount":25 and the model compared the page caps as totals.
+        const totalMatches = Math.max(res.pagination.totalCount ?? 0, rows.length);
         // Counted here, not left to the model. Asked "how many vehicles came
         // yesterday" against ten rows (four Front Yard, six Garage Outdoor), it
         // answered "8 on the Front Yard and 2 on the Garage Outdoor": the total
@@ -485,6 +488,7 @@ const listEventsTool: ToolDefinition = {
           countsByMonitor,
           objectCounts,
           partial: Boolean(truncated),
+          totalMatches,
         });
         // busiestHour rides OUTSIDE the summary on purpose: answers quote the
         // summary verbatim, and an hour label inside it would make the
@@ -493,7 +497,8 @@ const listEventsTool: ToolDefinition = {
         const base = {
           summary,
           window,
-          matchCount: rowsToShow.length,
+          // The TOTAL that matched, not the page: quoted directly in answers.
+          matchCount: totalMatches,
           countsByMonitor,
           objectCounts,
           ...(busiestHour ? { busiestHour } : {}),

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -277,7 +277,7 @@ const listEventsTool: ToolDefinition = {
       // splitting the jobs: both reference models copied phrases perfectly
       // but filled the fields directly at 27/36 and 15/36.
       const whenPhrase = isOmittedArg(input.when) ? undefined : String(input.when);
-      let resolvedWhen: { startDateTime: string; endDateTime: string } | undefined;
+      let resolvedWhen: { startDateTime?: string; endDateTime?: string } | undefined;
       if (whenPhrase) {
         if (!ctx.interpretWhen) throw new Error('Time phrases are unavailable right now; retry without `when`.');
         const fields = await ctx.interpretWhen(whenPhrase);

--- a/app/src/lib/assistant/tools-readonly.ts
+++ b/app/src/lib/assistant/tools-readonly.ts
@@ -419,6 +419,10 @@ const listEventsTool: ToolDefinition = {
         durationSec: Number(e.Length),
         objects: parseDetectedObjects(e.Notes),
       }));
+      // Raw wall-clock starts aligned with `rows`, for the per-hour tally
+      // below: `rows.start` is already re-rendered in the profile's display
+      // format, which no longer slices into hour buckets.
+      const rawStarts = res.events.map(({ Event: e }) => e.StartDateTime);
 
       // State the window that was actually queried. Asked "how many people came
       // to my house", the model queried no time range at all and then answered
@@ -447,6 +451,24 @@ const listEventsTool: ToolDefinition = {
           return acc;
         }, {});
         const objectCounts = countObjects(rowsToShow as { monitor?: unknown; objects?: unknown }[]);
+        // "Busiest hour" is arithmetic over timestamps, which the model does
+        // badly, so the tally is computed here and the winning hour handed
+        // over as a finished clause (refs #264). Buckets are absolute hours
+        // (date + hour) in ZM wall clock, labelled in the profile's format.
+        const hourCounts = rawStarts.slice(0, rowsToShow.length).reduce<Record<string, number>>((acc, raw) => {
+          const key = `${raw.slice(0, 13)}:00:00`;
+          acc[key] = (acc[key] ?? 0) + 1;
+          return acc;
+        }, {});
+        const hourEntries = Object.entries(hourCounts).sort((a, b) => b[1] - a[1]);
+        const busiestHour =
+          rowsToShow.length > 1 && hourEntries.length > 0
+            ? { label: String(formatTimestamp(hourEntries[0][0], ctx)), count: hourEntries[0][1] }
+            : undefined;
+        const countsByHour =
+          hourEntries.length > 1
+            ? Object.fromEntries(hourEntries.map(([key, count]) => [String(formatTimestamp(key, ctx)), count]))
+            : undefined;
         // The counts, already written out. Supplying the numbers was not enough:
         // asked to summarize, the model enumerated all five rows and quoted
         // neither matchCount nor countsByMonitor. `summary` leads the object so
@@ -457,8 +479,17 @@ const listEventsTool: ToolDefinition = {
           countsByMonitor,
           objectCounts,
           partial: Boolean(truncated),
+          busiestHour,
         });
-        const base = { summary, window, matchCount: rowsToShow.length, countsByMonitor, objectCounts, events: rowsToShow };
+        const base = {
+          summary,
+          window,
+          matchCount: rowsToShow.length,
+          countsByMonitor,
+          objectCounts,
+          ...(countsByHour ? { countsByHour } : {}),
+          events: rowsToShow,
+        };
         return JSON.stringify(
           truncated ? { ...base, shownEvents: rowsToShow.length, moreMatchesExist: true } : base,
         );

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -21,27 +21,35 @@ import { sanitizeModelText } from './sanitize';
 
 export type RequestKind = 'zoneminder' | 'chat' | 'action';
 
-/** Model-facing (rule 5 exempt): never rendered, only matched below. */
+/** Model-facing (rule 5 exempt): never rendered, only matched below.
+ *
+ *  Written as a RULE over two orthogonal dimensions (what is wanted done,
+ *  and what it concerns), not as example instances (refs #265). The old
+ *  instance list ("how many people came by today") taught the classifier a
+ *  handful of verb-times-time combinations, and every combination outside it
+ *  misclassified: "summarize yesterday", "summarize last week", and
+ *  "summarize this month" all went to CHAT, one after another, because no
+ *  example looked like an imperative or mentioned a week. The time span is
+ *  the interpreter's job and never decides the category, and the prompt now
+ *  says exactly that; the template examples ("summarize <any period>") show
+ *  the shape of the rule rather than enumerate its instances. */
 const TRIAGE_PROMPT = [
-  'You are a classifier for a ZoneMinder security-camera app. Read the user message and reply with EXACTLY',
-  'one word, nothing else:',
+  'You classify one user message for a ZoneMinder security-camera app. Reply with EXACTLY one word.',
   '',
-  'ZONEMINDER - they are asking about cameras, monitors, events, detections, recordings, server health,',
-  '  or want to be taken to a screen in the app.',
-  'ACTION - they are asking to CHANGE something: arm or disarm a monitor, enable or disable a camera,',
+  'Decide by WHAT THE USER WANTS DONE and WHAT IT CONCERNS, whatever language the message is in:',
+  'classify its meaning, not its words. Asking what happened at their place or home means this',
+  'camera system. A time span in the message (today, last week, this month, an hour, any custom',
+  'range) NEVER changes the category.',
+  '',
+  'ZONEMINDER - any request to summarize, recap, count, list, look up, check, or view THIS system\'s',
+  '  cameras, monitors, events, detections, recordings, activity, or server health, or to be taken to a',
+  '  screen in the app. Questions and commands alike, in any language: "summarize <any period>",',
+  '  "what happened <any period>", "how many <thing> <any period>", "is the server ok",',
+  '  "show me <camera>".',
+  'ACTION - a request to CHANGE something here: arm or disarm a monitor, enable or disable a camera,',
   '  trigger or cancel an alarm, change the run state or a monitor function, delete or archive an event.',
-  'CHAT - anything else: greetings, thanks, small talk, questions about you, or any topic unrelated to',
-  '  this app.',
-  '',
-  'Examples:',
-  '"how many people came by today" -> ZONEMINDER',
-  '"is the server ok" -> ZONEMINDER',
-  '"show me the front camera" -> ZONEMINDER',
-  '"arm the backyard camera" -> ACTION',
-  '"delete that event" -> ACTION',
-  '"hello" -> CHAT',
-  '"thanks!" -> CHAT',
-  '"what is the capital of France" -> CHAT',
+  'CHAT - anything NOT about this system: greetings, thanks, small talk, questions about you, general',
+  '  knowledge, or summarizing something that is not this system\'s activity.',
   '',
   'Reply with one word: ZONEMINDER, ACTION, or CHAT.',
 ].join('\n');
@@ -63,6 +71,11 @@ export const TRIAGE_SCHEMA = {
  *  appears, not whether the reply is clean. ZONEMINDER wins ties: routing a
  *  real question to the chat path would answer it with no data at all, which
  *  is the worse failure. */
+/** The triage prompt, exported for the eval harness (scripts/prompt-eval.mts
+ *  triage stage) so the classifier is scored on exactly what production
+ *  sends. Not used elsewhere. */
+export const TRIAGE_PROMPT_FOR_EVAL = TRIAGE_PROMPT;
+
 export function parseRequestKind(reply: string): RequestKind {
   try {
     const kind = (JSON.parse(reply) as { kind?: unknown }).kind;

--- a/app/src/lib/assistant/types.ts
+++ b/app/src/lib/assistant/types.ts
@@ -170,10 +170,13 @@ export interface ToolContext {
    *  model-supplied phrase came from the user rather than from an example in
    *  the prompt (see `list_events`' `when`). */
   question?: string;
-  /** The active UI locale (BCP 47, e.g. `de` or `en-US`). English-only text
-   *  heuristics (ungroundedWhenWords) are gated on it so they never
-   *  false-positive on another language's connectives (refs #259). */
+  /** The active UI locale (BCP 47, e.g. `de` or `en-US`). */
   locale?: string;
+  /** Interprets a human time phrase into structured window fields using the
+   *  session's model under a constrained schema (window-interpreter.ts,
+   *  refs #265). Injected by AskPanel so the tool layer stays provider-free;
+   *  a context without it cannot resolve `when` phrases and says so. */
+  interpretWhen?: (phrase: string) => Promise<import('./event-range').WindowFields | { error: string }>;
   /** Detected-object labels this install writes (object-labels.ts). A tool
    *  rejects an objectType outside this list rather than querying a label the
    *  detector never emits. */

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -32,6 +32,8 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
     daysAgo: { type: 'number' },
     weekday: { type: 'string', enum: [...WEEKDAYS] },
     date: { type: 'string' },
+    fromDate: { type: 'string' },
+    toDate: { type: 'string' },
     fromTime: { type: 'string' },
     toTime: { type: 'string' },
     none: { type: 'boolean' },
@@ -41,8 +43,10 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
 
 /** Model-facing (rule 5 exempt). The few-shot lines teach the mapping the
  *  schema cannot express; they are examples for a model, not a grammar the
- *  app executes. */
-function buildInterpreterPrompt(now: Date, timezone: string): string {
+ *  app executes. Exported so the eval harness scores EXACTLY what production
+ *  sends: a hand-copied prompt in the harness drifted the moment this one
+ *  changed, and measured a bug the app did not have. */
+export function buildInterpreterPrompt(now: Date, timezone: string): string {
   const today = format(toZonedTime(now, timezone), 'EEEE, yyyy-MM-dd');
   return [
     'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
@@ -51,7 +55,8 @@ function buildInterpreterPrompt(now: Date, timezone: string): string {
     '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}.',
     '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}.',
     '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}.',
-    '- date: an explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
+    '- date: one explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
+    '- fromDate + toDate: a calendar span, both inclusive. "april" -> {"fromDate":"2026-04-01","toDate":"2026-04-30"}. "this month" -> the 1st of the current month through today. "june 1 to june 15" -> both dates. Either side may stand alone: "since july 1" -> {"fromDate":"2026-07-01"}.',
     '- fromTime/toTime: 24h "HH:MM", narrowing a single day. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
     '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
     'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}.',
@@ -111,6 +116,8 @@ function parseFields(text: string): WindowFields | undefined {
     if (raw.daysAgo !== undefined) fields.daysAgo = Number(raw.daysAgo);
     if (raw.weekday !== undefined) fields.weekday = String(raw.weekday);
     if (raw.date !== undefined) fields.date = String(raw.date);
+    if (raw.fromDate !== undefined) fields.fromDate = String(raw.fromDate);
+    if (raw.toDate !== undefined) fields.toDate = String(raw.toDate);
     if (raw.fromTime !== undefined) fields.fromTime = String(raw.fromTime);
     if (raw.toTime !== undefined) fields.toTime = String(raw.toTime);
     return fields;

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -1,0 +1,120 @@
+/**
+ * Interprets a human time phrase into structured window fields, using a MODEL
+ * under a constrained schema (refs #265).
+ *
+ * Division of labor, each part doing what it measurably does best:
+ * - The assistant model COPIES the user's time words into `when` verbatim
+ *   (measured perfect on both reference models; the same models filled a
+ *   structured time DSL directly at 27/36 and 15/36 after two prompt
+ *   iterations, reading "today" as a rolling day and "last week" as 7 weeks).
+ * - THIS single-purpose call interprets the phrase into `WindowFields`, in
+ *   any language, constrained to the schema where the backend supports it.
+ * - `resolveWindow` (event-range.ts) does the arithmetic in code.
+ *
+ * No app-side phrase grammar exists anywhere in this path: the examples in
+ * the interpreter prompt teach the mapping, they are not a parser.
+ */
+import type { AssistantProvider } from './types';
+import { WINDOW_UNITS, WEEKDAYS, type WindowFields } from './event-range';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+import { log, LogLevel } from '../logger';
+
+/** The interpreter's output contract, enforced via constrained generation on
+ *  backends that support it (Ollama json_schema, WebLLM XGrammar) and parsed
+ *  defensively everywhere. `none: true` means the phrase names no time window
+ *  at all ("everything you have"). */
+export const WINDOW_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    lastCount: { type: 'number' },
+    lastUnit: { type: 'string', enum: [...WINDOW_UNITS] },
+    daysAgo: { type: 'number' },
+    weekday: { type: 'string', enum: [...WEEKDAYS] },
+    date: { type: 'string' },
+    fromTime: { type: 'string' },
+    toTime: { type: 'string' },
+    none: { type: 'boolean' },
+  },
+  additionalProperties: false,
+};
+
+/** Model-facing (rule 5 exempt). The few-shot lines teach the mapping the
+ *  schema cannot express; they are examples for a model, not a grammar the
+ *  app executes. */
+function buildInterpreterPrompt(now: Date, timezone: string): string {
+  const today = format(toZonedTime(now, timezone), 'EEEE, yyyy-MM-dd');
+  return [
+    'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
+    `Today is ${today} (timezone ${timezone}).`,
+    'Fields (use the fewest that express the phrase):',
+    '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}.',
+    '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}.',
+    '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}.',
+    '- date: an explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
+    '- fromTime/toTime: 24h "HH:MM", narrowing a single day. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
+    '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
+    'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}.',
+    'A calendar day word is never a rolling span: "today" is daysAgo 0, NOT lastCount 1 day.',
+  ].join('\n');
+}
+
+/** Session cache: the same phrase on the same calendar day means the same
+ *  window, and "yesterday"/"today" repeat constantly. */
+const CACHE = new Map<string, WindowFields | { error: string }>();
+
+/** Test-only. */
+export function resetWindowInterpreterCacheForTests(): void {
+  CACHE.clear();
+}
+
+/** The parsed fields for `phrase`, or `{error}` written for the model that
+ *  sent the phrase. Never throws. */
+export async function interpretWhen(
+  phrase: string,
+  provider: AssistantProvider,
+  now: Date,
+  timezone: string,
+  signal: AbortSignal,
+): Promise<WindowFields | { error: string }> {
+  const cacheKey = `${format(toZonedTime(now, timezone), 'yyyy-MM-dd')}::${timezone}::${phrase.trim().toLowerCase()}`;
+  const cached = CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  let result: WindowFields | { error: string };
+  try {
+    const reply = await provider.complete(buildInterpreterPrompt(now, timezone), phrase, signal, WINDOW_SCHEMA);
+    const parsed = parseFields(reply.text);
+    result = parsed ?? { error: `Could not interpret "${phrase}" as a time window. Rephrase the when argument.` };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') throw error;
+    log.assistant('Window interpretation failed', LogLevel.WARN, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    result = { error: `Could not interpret "${phrase}" as a time window right now. Retry, or rephrase the when argument.` };
+  }
+  CACHE.set(cacheKey, result);
+  return result;
+}
+
+/** The first JSON object in `text` as WindowFields, or undefined. Defensive:
+ *  an unconstrained backend may wrap the object in prose. */
+function parseFields(text: string): WindowFields | undefined {
+  const match = /\{[\s\S]*\}/.exec(text);
+  if (!match) return undefined;
+  try {
+    const raw = JSON.parse(match[0]) as Record<string, unknown>;
+    if (raw.none === true) return {};
+    const fields: WindowFields = {};
+    if (raw.lastCount !== undefined) fields.lastCount = Number(raw.lastCount);
+    if (raw.lastUnit !== undefined) fields.lastUnit = String(raw.lastUnit);
+    if (raw.daysAgo !== undefined) fields.daysAgo = Number(raw.daysAgo);
+    if (raw.weekday !== undefined) fields.weekday = String(raw.weekday);
+    if (raw.date !== undefined) fields.date = String(raw.date);
+    if (raw.fromTime !== undefined) fields.fromTime = String(raw.fromTime);
+    if (raw.toTime !== undefined) fields.toTime = String(raw.toTime);
+    return fields;
+  } catch {
+    return undefined;
+  }
+}

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -707,6 +707,11 @@ export const ASSISTANT = {
   // vocabulary (person, car, dog, truck, ...) without pasting a long tail of
   // rare labels into a context window this assistant is already tight on.
   objectLabelHintLimit: 12,
+  // Monitor result cards render a LIVE preview (refs #264), and each one is
+  // a real stream with real bandwidth and server cost. Above this many
+  // monitor cards in one answer, cards fall back to text: "show me the
+  // garage" wants a stream, "list my 12 cameras" wants a list.
+  maxLiveMonitorCards: 4,
   requestTimeoutMs: 120000,
   // A "Test connection" click only needs to know the server answers, not run a
   // full chat turn: `requestTimeoutMs` (120s) covers the WORST case (a slow

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -759,16 +759,22 @@ export const ASSISTANT = {
   // Its own 512-token window is the only untried mode and is far smaller than
   // this app's system prompt, so the model would never see the tool contract.
   // Do not re-add without checking a newer web-llm first.
-  // One model, not a menu. Llama 3.2 is what the assistant is tuned against on
-  // every backend (see `recommendedOllamaModel` for the measurements and
-  // and a picker of six was six
-  // prompt-compatibility surfaces to keep working rather than one.
+  // A short list, not a menu: a picker of six was six prompt-compatibility
+  // surfaces to keep working. Llama 3.2 is what the assistant is tuned
+  // against on every backend and stays the default (`defaultModelId`).
   //
-  // The 3B because this list only ever serves desktop and web: the assistant's
-  // on-device backend is not offered on phones or tablets at all, so there is
-  // no memory-tight device to size down for here.
+  // These sizes because this list only ever serves desktop and web: the
+  // assistant's on-device backend is not offered on phones or tablets at all,
+  // so there is no memory-tight device to size down for here.
   webllmModels: [
     { id: 'Llama-3.2-3B-Instruct-q4f16_1-MLC', label: 'Llama 3.2 3B', approxSizeMb: 2264, contextWindowSize: 16384 },
+    // Candidate upgrade (refs #246): qwen family led every server-side eval,
+    // and the 4B-class proxy (qwen3:4b-instruct, temp 0, 3 runs/case) scored
+    // tool 36/42, answer 12/12, interpret 48/51, triage 42/45 vs the llama3.2
+    // class's 30/42 tool. Thinking is disabled for real via WebLLM's
+    // enable_thinking:false (providers/webllm.ts). Not the default until a
+    // WebGPU device pass confirms the MLC build.
+    { id: 'Qwen3-4B-q4f16_1-MLC', label: 'Qwen3 4B', approxSizeMb: 3432, contextWindowSize: 16384 },
   ],
   /** Saved `assistantModelId` values no longer in `webllmModels`, mapped to
    *  their replacement. Consumed by migrateSettings (stores/settings.ts).

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1299,7 +1299,6 @@
       "used": "Verwendet: {{tools}}"
     },
     "iteration_cap_reached": "Nach zu vielen Schritten gestoppt. Bitte einfacher formulieren.",
-    "live_data_required": "Aktuelle ZoneMinder-Daten konnten nicht geladen werden. Deshalb kann ich keine verlässliche Antwort geben.",
     "context_cleared": "Dieses Gespräch hat den Kontext des Modells gefüllt, daher habe ich ein neues begonnen. Die Nachrichten oben bleiben für dich lesbar, ich sehe sie aber nicht mehr.",
     "parse_error": "Die Antwort konnte nicht verarbeitet werden. Bitte anders formulieren.",
     "show_raw_output": "Modellausgabe anzeigen",
@@ -1327,6 +1326,6 @@
     "context_cleared_manual": "Unterhaltung gelöscht. Das Modell auf dem Gerät wurde entladen, um Speicher freizugeben; es wird bei deiner nächsten Frage neu geladen.",
     "context_cleared_manual_remote": "Unterhaltung gelöscht.",
     "model_unavailable_native": "Dieses Modell läuft nicht auf deinem Gerät. Wähle in den Einstellungen ein Modell für das Gerät.",
-    "english_only_notice": "Bitte auf Englisch fragen. In anderen Sprachen funktioniert der Assistent nicht zuverlässig: Fragen können falsch verstanden oder ohne Prüfung der Kameras beantwortet werden."
+    "english_only_notice": "Der Assistent versteht auch andere Sprachen, funktioniert aber auf Englisch am besten: einige Antwortprüfungen laufen nur bei englischen Antworten."
   }
 }

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1291,6 +1291,7 @@
     "send": "Senden",
     "abort": "Stopp",
     "thinking": "Denkt nach...",
+    "loading_model": "Lade {{model}} auf dem Server...",
     "activity": {
       "running": "{{tool}} läuft...",
       "done": "{{tool}} fertig",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1299,7 +1299,6 @@
       "used": "Used {{tools}}"
     },
     "iteration_cap_reached": "Stopped after too many steps. Try a simpler request.",
-    "live_data_required": "I could not load current ZoneMinder data, so I can’t provide a reliable answer.",
     "context_cleared": "This conversation filled up the model's context, so I've started a fresh one. The messages above are still here for you to read, but I can't see them any more.",
     "parse_error": "Sorry, I had trouble putting together a response. Could you try rephrasing?",
     "show_raw_output": "Show model output",
@@ -1327,6 +1326,6 @@
     "context_cleared_manual": "Conversation cleared. The on-device model was unloaded to free memory; it will load again on your next question.",
     "context_cleared_manual_remote": "Conversation cleared.",
     "model_unavailable_native": "This model cannot run on your device. Choose an on-device model in Settings.",
-    "english_only_notice": "Ask in English. The assistant does not work reliably in other languages: questions may be misunderstood or answered without checking your cameras."
+    "english_only_notice": "The assistant understands other languages, but works best in English: some answer-accuracy checks only run on English replies."
   }
 }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1291,6 +1291,7 @@
     "send": "Send",
     "abort": "Stop",
     "thinking": "Thinking...",
+    "loading_model": "Loading {{model}} on the server...",
     "activity": {
       "running": "Running {{tool}}...",
       "done": "{{tool}} done",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1299,7 +1299,6 @@
       "used": "Se usó {{tools}}"
     },
     "iteration_cap_reached": "Detenido tras demasiados pasos. Prueba con una solicitud más simple.",
-    "live_data_required": "No pude cargar datos actuales de ZoneMinder, así que no puedo dar una respuesta fiable.",
     "context_cleared": "Esta conversación llenó el contexto del modelo, así que he empezado una nueva. Los mensajes de arriba siguen ahí para que los leas, pero yo ya no puedo verlos.",
     "parse_error": "No se pudo generar una respuesta. Prueba a reformular la pregunta.",
     "show_raw_output": "Ver salida del modelo",
@@ -1327,6 +1326,6 @@
     "context_cleared_manual": "Conversación borrada. El modelo del dispositivo se descargó para liberar memoria; se cargará de nuevo con tu próxima pregunta.",
     "context_cleared_manual_remote": "Conversación borrada.",
     "model_unavailable_native": "Este modelo no funciona en tu dispositivo. Elige un modelo del dispositivo en Ajustes.",
-    "english_only_notice": "Pregunta en inglés. El asistente no funciona de forma fiable en otros idiomas: las preguntas pueden malinterpretarse o responderse sin consultar tus cámaras."
+    "english_only_notice": "El asistente entiende otros idiomas, pero funciona mejor en inglés: algunas comprobaciones de respuestas solo se aplican en inglés."
   }
 }

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1291,6 +1291,7 @@
     "send": "Enviar",
     "abort": "Detener",
     "thinking": "Pensando...",
+    "loading_model": "Cargando {{model}} en el servidor...",
     "activity": {
       "running": "Ejecutando {{tool}}...",
       "done": "{{tool}} completado",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1299,7 +1299,6 @@
       "used": "A utilisé {{tools}}"
     },
     "iteration_cap_reached": "Arrêté après trop d'étapes. Essayez une demande plus simple.",
-    "live_data_required": "Je n’ai pas pu charger les données ZoneMinder actuelles, donc je ne peux pas fournir une réponse fiable.",
     "context_cleared": "Cette conversation a saturé le contexte du modèle, j'en ai donc démarré une nouvelle. Les messages ci-dessus restent lisibles pour vous, mais je ne les vois plus.",
     "parse_error": "Impossible de générer une réponse. Essayez de reformuler.",
     "show_raw_output": "Voir la sortie du modèle",
@@ -1327,6 +1326,6 @@
     "context_cleared_manual": "Conversation effacée. Le modèle sur l'appareil a été déchargé pour libérer de la mémoire ; il se rechargera à votre prochaine question.",
     "context_cleared_manual_remote": "Conversation effacée.",
     "model_unavailable_native": "Ce modèle ne fonctionne pas sur votre appareil. Choisissez un modèle sur l'appareil dans les Réglages.",
-    "english_only_notice": "Posez vos questions en anglais. L'assistant ne fonctionne pas de manière fiable dans d'autres langues : les questions peuvent être mal comprises ou traitées sans consulter vos caméras."
+    "english_only_notice": "L'assistant comprend d'autres langues, mais fonctionne mieux en anglais : certaines vérifications de réponses ne s'appliquent qu'en anglais."
   }
 }

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1291,6 +1291,7 @@
     "send": "Envoyer",
     "abort": "Arrêter",
     "thinking": "Réflexion...",
+    "loading_model": "Chargement de {{model}} sur le serveur...",
     "activity": {
       "running": "Exécution de {{tool}}...",
       "done": "{{tool}} terminé",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1299,7 +1299,6 @@
       "used": "已使用 {{tools}}"
     },
     "iteration_cap_reached": "步骤过多已停止，请尝试更简单的请求。",
-    "live_data_required": "无法加载当前 ZoneMinder 数据，因此无法提供可靠的回答。",
     "context_cleared": "本次对话已填满模型的上下文，因此我已开始新的对话。上面的消息你仍可查看，但我已看不到它们了。",
     "parse_error": "抱歉，无法生成回复，请换个说法再试。",
     "show_raw_output": "查看模型输出",
@@ -1327,6 +1326,6 @@
     "context_cleared_manual": "对话已清除。设备端模型已卸载以释放内存，下次提问时会重新加载。",
     "context_cleared_manual_remote": "对话已清除。",
     "model_unavailable_native": "此模型无法在你的设备上运行。请在设置中选择设备端模型。",
-    "english_only_notice": "请用英语提问。助手在其他语言下无法可靠工作：问题可能被误解，或在未查询摄像头的情况下作答。"
+    "english_only_notice": "助手可以理解其他语言，但英语效果最好：部分回答准确性检查仅适用于英语回复。"
   }
 }

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1291,6 +1291,7 @@
     "send": "发送",
     "abort": "停止",
     "thinking": "思考中...",
+    "loading_model": "正在服务器上加载 {{model}}...",
     "activity": {
       "running": "正在运行 {{tool}}...",
       "done": "{{tool}} 已完成",

--- a/app/tests/steps/assistant.steps.ts
+++ b/app/tests/steps/assistant.steps.ts
@@ -66,7 +66,7 @@ async function seedScript(page: import('@playwright/test').Page, script: Assista
 
 Given('the assistant will answer {string} after calling count_events', async ({ page }, answer: string) => {
   await seedScript(page, [
-    { toolCalls: [{ id: '1', name: 'count_events', input: { interval: '1 day' } }] },
+    { toolCalls: [{ id: '1', name: 'count_events', input: { lastCount: 1, lastUnit: 'day' } }] },
     { text: answer, toolCalls: [] },
   ]);
 });
@@ -99,7 +99,7 @@ Given(
   'the assistant will answer {string} using {string} prompt tokens',
   async ({ page }, answer: string, promptTokens: string) => {
     await seedScript(page, [
-      { toolCalls: [{ id: '1', name: 'count_events', input: { interval: '1 day' } }] },
+      { toolCalls: [{ id: '1', name: 'count_events', input: { lastCount: 1, lastUnit: 'day' } }] },
       {
         text: answer,
         toolCalls: [],

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2166,9 +2166,13 @@ property of the registry (``TOOLS`` holds no mutating tool and
 
 #. **The app, not the model, does the date arithmetic.** ``list_events`` takes
    ``when``: the user's own time words, copied verbatim ("yesterday from 4pm
-   to 10pm"), which ``resolveWhen`` (``event-range.ts``) resolves into
-   concrete ZM datetime strings against the profile timezone, because a small
-   model repeats a phrase accurately and computes a date badly.
+   to 10pm", "on sunday", "2 days ago"), which ``resolveWhen``
+   (``event-range.ts``) resolves into concrete ZM datetime strings against
+   the profile timezone, because a small model repeats a phrase accurately
+   and computes a date badly. Row and window timestamps in the OUTPUT are
+   re-rendered through the profile's date/time format
+   (``formatTimestamp``, ``tools-readonly.ts``): the model echoes whatever
+   format the rows carry, so formatting the data is formatting the answer.
    ``ungroundedWhenWords`` rejects a phrase containing words the user never
    wrote, since models lift example phrases from the prompt. The old ``range``
    enum and ``startTime``/``endTime`` inputs no longer exist and

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2032,11 +2032,8 @@ property of the registry (``TOOLS`` holds no mutating tool and
        participant ZM as ZoneMinder
 
        Key->>Panel: open(), widget renders AskPanel
-       Panel->>Panel: requiresLiveData(question)?
-       alt heuristic is silent
-           Panel->>Triage: provider.complete(TRIAGE_PROMPT, TRIAGE_SCHEMA)
-           Triage-->>Panel: zoneminder / chat / action
-       end
+       Panel->>Triage: provider.complete(TRIAGE_PROMPT, TRIAGE_SCHEMA)
+       Triage-->>Panel: zoneminder / chat / action (advisory)
        Panel->>Agent: runAssistantTurn(history, system, tools)
        Agent->>Prov: provider.chat (constrained JSON or native tools)
        Prov-->>Agent: AssistantTurn (toolCalls or text)
@@ -2081,18 +2078,16 @@ property of the registry (``TOOLS`` holds no mutating tool and
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/assistant/AskPanel.tsx#L349>`__
    · → :doc:`05-component-architecture`
 
-#. **Triage decides what kind of request this is before any tool is offered.**
-   The deterministic check runs first: ``requiresLiveData`` (``agent.ts``)
-   recognises known English data questions outright, and when it fires there
-   is no triage call at all, because triage has misclassified exactly those
-   questions before. Otherwise ``classifyRequest`` (``triage.ts``) runs
-   ``provider.complete`` with ``TRIAGE_SCHEMA``, a
-   ``{"kind": ZONEMINDER|ACTION|CHAT}`` JSON Schema a backend may enforce
-   through constrained generation, so the reply is exactly
-   ``{"kind":"CHAT"}`` where the server supports it and a loose one-word
-   match everywhere else. A chat or action verdict runs the turn with
-   ``tools: []`` and ``buildNoToolPrompt``: the way to stop a small model
-   reaching for a tool is to hand it none, not to ask it nicely.
+#. **Triage classifies the request, and its verdict is advisory.**
+   ``classifyRequest`` (``triage.ts``) runs ``provider.complete`` with
+   ``TRIAGE_SCHEMA``, a ``{"kind": ZONEMINDER|ACTION|CHAT}`` JSON Schema a
+   backend may enforce through constrained generation, so the reply is
+   exactly ``{"kind":"CHAT"}`` where the server supports it and a loose
+   one-word match everywhere else. A chat or action verdict runs the turn
+   with ``tools: []`` and ``buildNoToolPrompt``. A wrong verdict cannot
+   refuse a data question any more: the loop fails open (next steps), so the
+   old English keyword overrule (``requiresLiveData``) is deleted rather
+   than maintained as a vocabulary.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/triage.ts>`__
    · → :doc:`12-shared-services-and-components`
 
@@ -2164,22 +2159,25 @@ property of the registry (``TOOLS`` holds no mutating tool and
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/agent.ts#L430>`__
    · → :doc:`12-shared-services-and-components`
 
-#. **The app, not the model, does the date arithmetic.** ``list_events`` takes
-   ``when``: the user's own time words, copied verbatim ("yesterday from 4pm
-   to 10pm", "on sunday", "2 days ago"), which ``resolveWhen``
-   (``event-range.ts``) resolves into concrete ZM datetime strings against
-   the profile timezone, because a small model repeats a phrase accurately
-   and computes a date badly. Row and window timestamps in the OUTPUT are
-   re-rendered through the profile's date/time format
-   (``formatTimestamp``, ``tools-readonly.ts``): the model echoes whatever
-   format the rows carry, so formatting the data is formatting the answer.
-   ``ungroundedWhenWords`` rejects a phrase containing words the user never
-   wrote, since models lift example phrases from the prompt. The old ``range``
-   enum and ``startTime``/``endTime`` inputs no longer exist and
-   ``isEventRange``/``resolveEventRange`` are deleted; ``resolveWhen``'s
-   ``LEGACY`` map still accepts the old enum keywords in case a persisted
-   thread replays one.
-   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/event-range.ts#L102>`__
+#. **Three jobs, three owners: copy, interpret, compute.** The assistant
+   model COPIES the user's time words into ``list_events``' ``when``
+   verbatim, in whatever language (measured perfect on both reference
+   models). A dedicated interpreter call (``interpretWhen``,
+   ``window-interpreter.ts``) then maps the phrase onto structured fields
+   (``lastCount``+``lastUnit``, ``daysAgo``, ``weekday``, ``date``,
+   ``fromTime``/``toTime``) under a constrained schema, cached per phrase
+   and day; "letzte Woche" becomes ``lastCount: 1, lastUnit: "week"``.
+   Finally ``resolveWindow`` (``event-range.ts``) does the arithmetic into
+   concrete ZM datetime strings against the profile timezone. No app-side
+   phrase grammar exists anywhere on this path; the middle job was given its
+   own model call after measurement showed the assistant models copy phrases
+   perfectly but fill the fields directly at 27/36 and 15/36. Any failure
+   along the way returns a corrective error the calling model retries from.
+   Row and window timestamps in the OUTPUT are re-rendered through the
+   profile's date/time format (``formatTimestamp``, ``tools-readonly.ts``):
+   the model echoes whatever format the rows carry, so formatting the data
+   is formatting the answer.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/window-interpreter.ts>`__
    · → :doc:`12-shared-services-and-components`
 
 #. **Results feed back into history.** ``captureApiCalls`` wraps
@@ -2203,12 +2201,12 @@ property of the registry (``TOOLS`` holds no mutating tool and
    fails the same check, ``fallbackAnswerFromData`` answers with the tool's
    own code-built summary line. There is no second model call: the judge this
    file used to hold never caught a fabrication and rejected accurate answers.
-   Separately, the live-data requirement (``requiredReadTool``'s deliberately
-   English-only regexes in ``agent.ts``) sends one reminder and then
-   hard-fails to ``__i18n:assistant.live_data_required`` if the required read
-   tool never ran, and a language-neutral net gives a tool-less answer on a
-   tools-available turn one generic reminder, accepting the second answer
-   rather than replacing it.
+   Separately, two language-neutral nets replace the old English live-data
+   regexes (refs #265): a tool-less turn whose model calls a real registry
+   read tool fails OPEN (``activeTools`` flips to the registry and the call
+   runs, since the model's own attempt outranks the classifier), and a
+   tools-available turn answered without any tool attempt gets one generic
+   reminder, with the second answer accepted rather than replaced.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/grounding.ts>`__
    · → :doc:`12-shared-services-and-components`
 
@@ -2218,7 +2216,7 @@ property of the registry (``TOOLS`` holds no mutating tool and
    would be a different length than the panel's own. ``AskPanel`` appends
    them, attaches the accumulated activity steps to the final answer message,
    and renders assistant text as Markdown, except the ``__i18n:`` sentinels
-   (iteration cap, live-data requirement, context cleared), which
+   (iteration cap, context cleared), which
    ``renderAssistantText`` localizes with ``t()`` instead of treating as
    literal text.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/assistant/AskPanel.tsx#L180>`__

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -42,6 +42,8 @@ Examples of what you can ask:
 - "What was my busiest hour on Sunday?" (weekday names and "2 days ago" work too)
 - "Show me the most recent event on the front door camera" (Ninjii navigates you there)
 
+Answers come with cards underneath: event thumbnails you can tap to open the event, and monitor cards with a live preview when the answer is about a few specific cameras (a long list of monitors stays text, since every preview is a real stream). The cards are the rows the answer is about, not everything the lookup touched: ask for your busiest hour and you get that hour's events, not the whole day's.
+
 Ask it to change something, such as "arm the backyard camera" or "delete event 1234", and it will tell you it cannot and point you to the screen where you can. See below for why.
 
 Ninjii only knows what its tools can look up: your monitors, events, groups, tags, and server health. Ask it something unrelated to this ZoneMinder server and it answers as an ordinary assistant would, without pretending to have looked anything up.

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -64,9 +64,10 @@ On a desktop or in a browser, the model runs inside the app using your GPU (WebG
 
 | Model | Download | Notes |
 |---|---|---|
-| Llama 3.2 3B | ~2264 MB | The only on-device model on desktop. |
+| Llama 3.2 3B | ~2264 MB | The default. Fastest download, smallest memory footprint. |
+| Qwen3 4B | ~3432 MB | Answers camera questions more accurately in server-side testing. Needs about a gigabyte more GPU memory. |
 
-Earlier versions offered a choice of six models. Ninjii is tuned against Llama 3.2 on every backend, and the models it replaced varied widely in whether they would use a tool at all, so there is now one model per backend rather than a picker. If your settings still name a model that was removed, the app moves you to Llama 3.2 3B automatically.
+Earlier versions offered a choice of six models. The models that choice replaced varied widely in whether they would use a tool at all, so the list is now short and every entry on it is tested against the same question suite. If your settings still name a model that was removed, the app moves you to Llama 3.2 3B automatically.
 
 The download size is a floor, not the total: running a model needs additional memory on top of its weights, and how much depends on how long the conversation gets.
 
@@ -103,7 +104,7 @@ Two things to know about the qwen3 family:
 
 Some models cannot drive the assistant at all: gemma2 has no tool support and qwen2.5-coder never uses one, so with either the assistant can only guess. The **Test model** button catches both cases before you commit to a model.
 
-The on-device Llama 3.2 3B passed 21 of 24 lookup checks in an equivalent test. Its misses were answering from memory instead of looking things up, which the app detects and corrects by insisting on a lookup, at the cost of a slower reply. A server-backed qwen3:8b answers noticeably better and faster than on-device; on-device remains the choice when the conversation must not leave your machine.
+The on-device Llama 3.2 3B passed 21 of 24 lookup checks in an equivalent test. Its misses were answering from memory instead of looking things up, which the app detects and corrects by insisting on a lookup, at the cost of a slower reply. The on-device Qwen3 4B option scored between Llama 3.2 and the server-backed qwen3:8b in the same suite, at the cost of a larger download and more GPU memory. A server-backed qwen3:8b answers noticeably better and faster than either; on-device remains the choice when the conversation must not leave your machine.
 
 ## Long conversations
 

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -84,7 +84,7 @@ The model list fills in automatically from the server, and you can also type a m
 
 ## Performance and accuracy
 
-Which model you pick matters more than any other assistant setting. zmNinjaNg carries a test suite for exactly this: eleven camera-and-events questions ("summarize today", "how many people came today", "is the server ok", and so on), each asked three times against known data, scored on whether the model looked the right thing up with usable filters and whether its answer quoted the data correctly. Every claim below comes from that suite, measured in July 2026 against Ollama 0.32 on a GPU server. Your hardware changes the times, not the accuracy.
+Which model you pick matters more than any other assistant setting. zmNinjaNg carries a test suite for exactly this: fourteen camera-and-events questions ("summarize today", "how many people came today", "compare may to june", "is the server ok", and so on), each asked three times against known data, scored on whether the model looked the right thing up with usable filters and whether its answer quoted the data correctly. Every claim below comes from that suite, measured in July 2026 against Ollama 0.32 on a GPU server. Your hardware changes the times, not the accuracy.
 
 | Ollama model | Accuracy | Typical reply |
 |---|---|---|

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -39,6 +39,7 @@ Examples of what you can ask:
 - "Summarize today"
 - "How many events happened on the driveway camera in the last hour?"
 - "How many people came by yesterday?"
+- "What was my busiest hour on Sunday?" (weekday names and "2 days ago" work too)
 - "Show me the most recent event on the front door camera" (Ninjii navigates you there)
 
 Ask it to change something, such as "arm the backyard camera" or "delete event 1234", and it will tell you it cannot and point you to the screen where you can. See below for why.

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -125,7 +125,7 @@ While the model is loading, the chat says so instead of showing the usual "Think
 
 ## Language
 
-Ask the assistant in English. This is not only about the model's own ability: the rules that decide exactly which lookup a question needs, and the reading of time phrases like "yesterday from 4pm to 10pm", both understand English only. In another language the app can still nudge the model once to check your cameras before answering, but it cannot verify the details the way it does in English, so a question is more likely to be misunderstood. This holds on every backend, including a server-backed model through Ollama. The app's own screens stay translated as usual; a note appears above the conversation when the app language is not English.
+The assistant now understands questions in other languages: the model itself interprets your time words ("letzte Woche", "ayer por la tarde") into the exact window it looks up, and tool routing no longer depends on English keywords. English remains the best-tested path, and a few answer-accuracy safeguards (such as catching an answer that contradicts the data) only recognize English replies, so a note above the conversation says as much when the app language is not English. Replies come back in the app's language either way.
 
 ## Privacy
 


### PR DESCRIPTION
Refs #261, #262, #246.

Three fixes from live testing of the #260 work:

**Ollama warmup (#261).** The first question of a session cost ~36s (VRAM load plus one thinking chain, since reasoning is only disabled once the server is confirmed, which happened after the first call). Opening the panel now issues Ollama's load-only call (empty `/api/generate`), confirms the server and learns the context window immediately, and the chat shows "Loading <model> on the server..." while it runs. De-dupes per session, retries on a later open after failure, never throws, skipped in e2e mock mode. New i18n key in en/de/es/fr/zh.

**Human day phrases (#262).** "what was my busiest hour 2 days ago?" and "... on sunday?" were rejected by `resolveWhen`, not the model. It now resolves "N days ago" and weekday names (bare/"on"/"this" is the most recent such day, today included; "last" always reaches back a week), composable with part-of-day narrowing ("sunday from 4pm to 10pm").

**App-formatted times (#262).** list_events/get_event rows and the summary window are re-rendered through the profile's date/time format before the model sees them, so answer times match the rest of the app. Query filters keep raw ZM timestamps.

Prompt-eval after the changes: 33/33 native on both qwen3:8b (REASONING=none, 55s) and llama3.2 (19s) at temp 0.

Gates: `npm test` 2638 passed / 2 skipped, `npx tsc -b` clean, `npm run build` clean, `npm run test:e2e -- assistant.feature` 6/6.

---
This PR was prepared by Claude assisting @pliablepixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYupXUqt5boWVdss5fMsdc