### PR TITLE
feat(assistant): default on-device model is Qwen3 4B

### DIFF
--- a/app/src/components/settings/__tests__/AssistantSection-download.test.tsx
+++ b/app/src/components/settings/__tests__/AssistantSection-download.test.tsx
@@ -315,10 +315,12 @@ describe('AssistantSection download/delete', () => {
       />
     );
 
-    // The retired id resolves to the one supported model rather than leaving
-    // the picker blank or the status unknown (AssistantSection.tsx:82).
+    // The retired id resolves to its retiredModelIds target (still Llama,
+    // independent of which model is the fresh-install default) rather than
+    // leaving the picker blank or the status unknown (AssistantSection.tsx:82).
+    const mapped = ASSISTANT.retiredModelIds[MODEL_B];
     await waitFor(() => expect(screen.getByTestId('assistant-model-downloaded-status')).toBeInTheDocument());
-    expect(isModelDownloadedMock).toHaveBeenCalledWith(MODEL_A);
-    expect(screen.getByTestId('assistant-model-select')).toHaveValue(MODEL_A);
+    expect(isModelDownloadedMock).toHaveBeenCalledWith(mapped);
+    expect(screen.getByTestId('assistant-model-select')).toHaveValue(mapped);
   });
 });

--- a/app/src/lib/assistant/__tests__/webllm.test.ts
+++ b/app/src/lib/assistant/__tests__/webllm.test.ts
@@ -486,11 +486,13 @@ describe('WebLlmProvider.chat', () => {
     const create = vi.fn().mockResolvedValue({ choices: [{ message: { content: '{"answer": "It is armed."}' } }] });
     vi.mocked(getLoadedEngine).mockResolvedValue({ chat: { completions: { create } } } as never);
 
-    const provider = new WebLlmProvider(ASSISTANT.defaultModelId);
+    // Explicitly the non-Qwen model, so the extra_body assertion below stays
+    // about model family, not about which model is the current default.
+    const provider = new WebLlmProvider('Llama-3.2-3B-Instruct-q4f16_1-MLC');
     const turn = await provider.chat([{ role: 'user', text: 'hi' }], [], 'sys', new AbortController().signal);
 
     expect(turn).toMatchObject({ text: 'It is armed.', toolCalls: [] });
-    expect(getLoadedEngine).toHaveBeenCalledWith(ASSISTANT.defaultModelId);
+    expect(getLoadedEngine).toHaveBeenCalledWith('Llama-3.2-3B-Instruct-q4f16_1-MLC');
     const call = create.mock.calls[0][0];
     expect(call).toEqual(
       expect.objectContaining({

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -733,9 +733,11 @@ export const ASSISTANT = {
   // to an activity step in AskPanel (rule 11: truncate long text).
   activityInputPreviewChars: 40,
   // On-device only runs on desktop (web/Electron); mobile is gated off for
-  // memory (see AssistantSection). So the default targets a desktop, where
-  // Gemma 2B loads comfortably.
-  defaultModelId: 'Llama-3.2-3B-Instruct-q4f16_1-MLC',
+  // memory (see AssistantSection). So the default targets a desktop. Qwen3 4B
+  // after a WebGPU device pass confirmed the MLC build with thinking off
+  // (refs #265); it beat the llama class across the eval suite (see
+  // webllmModels). Existing installs keep their saved model choice.
+  defaultModelId: 'Qwen3-4B-q4f16_1-MLC',
   // Ordered smallest first: the top of the picker is the safest thing to load
   // on a phone, and `approxSizeMb` is web-llm's own `vram_required_MB` for the
   // record (measured at ITS 4096 window, so the real figure at the

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -64,8 +64,8 @@ On a desktop or in a browser, the model runs inside the app using your GPU (WebG
 
 | Model | Download | Notes |
 |---|---|---|
-| Llama 3.2 3B | ~2264 MB | The default. Fastest download, smallest memory footprint. |
-| Qwen3 4B | ~3432 MB | Answers camera questions more accurately in server-side testing. Needs about a gigabyte more GPU memory. |
+| Llama 3.2 3B | ~2264 MB | Fastest download, smallest memory footprint. |
+| Qwen3 4B | ~3432 MB | The default. Answers camera questions more accurately in testing. Needs about a gigabyte more GPU memory. |
 
 Earlier versions offered a choice of six models. The models that choice replaced varied widely in whether they would use a tool at all, so the list is now short and every entry on it is tested against the same question suite. If your settings still name a model that was removed, the app moves you to Llama 3.2 3B automatically.
 


### PR DESCRIPTION
Flips the on-device default from Llama 3.2 3B to Qwen3 4B after the WebGPU device pass confirmed the MLC build with thinking disabled (`extra_body: enable_thinking:false`). Refs #265, refs #246.

- Fresh installs start on `Qwen3-4B-q4f16_1-MLC`; existing installs keep their saved choice.
- Retired ids still map to Llama 3.2 3B, which remains in the picker as the smaller option.
- User guide model table updated.

Measurement chain: proxy eval (qwen3:4b-instruct, temp 0, 3 runs/case) tool 36/42, answer 12/12, interpret 48/51, triage 42/45 vs llama class 30/42; device pass confirmed by @pliablepixels.

Gates: 2663 unit tests, tsc, build, lint:a11y, assistant.feature e2e 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYupXUqt5boWVdss5fMsdc