### PR TITLE
docs(assistant): developer guide catches up with the shipped pipeline

### DIFF
--- a/app/src/lib/assistant/providers/webllm.ts
+++ b/app/src/lib/assistant/providers/webllm.ts
@@ -17,11 +17,12 @@
  * engine rejects it at runtime the adapter falls back to prompt + parser for
  * the rest of the session (see `grammarUsable`) instead of failing turns.
  *
- * The default model, Qwen3-1.7B, is a reasoning model that emits a
- * `<think>...</think>` chain-of-thought block before its final answer;
- * `parseWebLlmTurn` strips that block before extracting JSON so the model's
- * scratch-work (which may itself contain brace-y text) is never mistaken for
- * the real reply.
+ * The default model, Qwen3 4B, is a reasoning model. `createCompletion`
+ * disables that for real via `extra_body: { enable_thinking: false }` (the
+ * engine pre-closes an empty think block), and `parseWebLlmTurn` still
+ * strips any `<think>...</think>` block before extracting JSON so model
+ * scratch-work (which may itself contain brace-y text) is never mistaken
+ * for the real reply.
  *
  * `buildWebLlmMessages` and `parseWebLlmTurn` are pure and exported so they
  * unit-test without WebGPU; only `WebLlmProvider.chat` touches the engine.

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -762,8 +762,8 @@ export const ASSISTANT = {
   // this app's system prompt, so the model would never see the tool contract.
   // Do not re-add without checking a newer web-llm first.
   // A short list, not a menu: a picker of six was six prompt-compatibility
-  // surfaces to keep working. Llama 3.2 is what the assistant is tuned
-  // against on every backend and stays the default (`defaultModelId`).
+  // surfaces to keep working. Qwen3 4B is the default (`defaultModelId`);
+  // Llama 3.2 3B stays as the smaller option and the retired-id target.
   //
   // These sizes because this list only ever serves desktop and web: the
   // assistant's on-device backend is not offered on phones or tablets at all,

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -1292,9 +1292,8 @@ for it.
 the per-profile thread in ``useAssistantStore``, builds a system prompt from
 the current profile's monitor list and ZM version (``buildSystemPrompt``),
 and calls ``runAssistantTurn`` with an ``AbortController`` it owns. That same
-controller's ``signal`` is what an abort or an unmount cancels, and unmounting
-also resolves any pending confirmation as declined so the agent loop never
-hangs waiting on a panel that is gone.
+controller's ``signal`` is what an abort or an unmount cancels, so the agent
+loop never keeps generating for a panel that is gone.
 
 **Rendering the model's answer.** ``agent.ts`` never renders user-facing text
 itself; the only text it emits outside a normal reply is the sentinel
@@ -1317,16 +1316,16 @@ no translation lookup for a normal reply, only for this one fixed sentinel
 (rule 5's "never hardcode user-facing strings" still holds, it just applies
 to the sentinel's key, not to arbitrary model output).
 
-**Confirming a destructive tool.** ``useAssistantHost``
+**The host has no confirm flow.** ``useAssistantHost``
 (``components/assistant/useAssistantHost.ts``) is the ``AssistantHost``
-implementation ``AskPanel`` hands to ``runAssistantTurn``: its ``confirm``
-parks the ``ConfirmRequest`` in local state and returns a Promise that only
-``resolveConfirm`` can settle. ``AskPanel`` renders ``AssistantConfirmCard``
-whenever that state is non-null, and wires its Accept/Cancel buttons straight
-to ``resolveConfirm(true)`` / ``resolveConfirm(false)``. ``navigate`` on the
-same host closes the palette (``setOpen(false)``) before routing, so a
-``navigate`` tool call collapses the panel as a side effect instead of
-leaving a chat window open behind the page it just navigated to.
+implementation ``AskPanel`` hands to ``runAssistantTurn``. The assistant is
+read-only: there are no destructive tools, so the confirmation flow an
+earlier revision carried (``confirm``/``resolveConfirm`` and a confirm card)
+no longer exists; a request to change something gets a plain refusal that
+points at the right screen instead. ``navigate`` on the host closes the
+palette (``setOpen(false)``) before routing, so a ``navigate`` tool call
+collapses the panel as a side effect instead of leaving a chat window open
+behind the page it just navigated to.
 
 **Used by:** ``CommandPalette.tsx`` (the only mount point). ``useAssistantStore``
 holds the per-profile conversation thread and is not persisted, closing the

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1175,8 +1175,7 @@ so Llama 3.2's native 128K would need gigabytes by itself. Each value is
 therefore ``min(the model's native window, ASSISTANT.contextWindowCap)``, which
 is why the Llama 3.2 3B entry sits at the cap rather than its native 128K. A
 model id absent from the list gets no override at all rather than a guessed
-window. The list holds one model now (see below), so the per-model shape is
-about the next entry rather than about choosing between current ones.
+window.
 
 ``chatOptsFor`` always sends ``sliding_window_size: -1`` alongside the window,
 and that pairing is load-bearing. web-llm throws
@@ -1198,13 +1197,19 @@ corrupted output (empty at 16384, token soup at 8192). Its native 512-token
 window is the only untried mode and is smaller than this app's system prompt, so
 the model would never see the tool contract.
 
-``webllmModels`` lists exactly one model. The picker used to offer six, and the
-six differed in the one behaviour that matters: whether the model calls a tool
-at all rather than answering from nothing. Llama 3.2 is what the assistant is
-tuned against on every backend, so the WebGPU path pins
-``Llama-3.2-3B-Instruct-q4f16_1-MLC``. This list only ever serves desktop and
-web: the on-device backend is not offered on phones or tablets at all. ``ASSISTANT.retiredModelIds`` maps every id the list
-used to carry onto that model, and ``SETTINGS_VERSION`` moves with it so the
+``webllmModels`` lists two models: ``Llama-3.2-3B-Instruct-q4f16_1-MLC`` and
+``Qwen3-4B-q4f16_1-MLC``, with Qwen3 4B as ``ASSISTANT.defaultModelId`` for
+fresh installs after it beat the llama class across the eval suite. The picker
+used to offer six, and the six differed in the one behaviour that matters:
+whether the model calls a tool at all rather than answering from nothing; the
+short list keeps every entry measured against the same question suite. Qwen3
+is a reasoning model, so ``WebLlmProvider`` sends web-llm's
+``extra_body: { enable_thinking: false }`` for Qwen3 model ids: the engine
+pre-closes an empty think block so the model cannot reason, unlike the
+``/no_think`` text directive, which only hides the tag. This list only ever
+serves desktop and web: the on-device backend is not offered on phones or
+tablets at all. ``ASSISTANT.retiredModelIds`` maps every id the list used to
+carry onto Llama 3.2 3B, and ``SETTINGS_VERSION`` moves with it so the
 rewrite reaches installs already persisted at the previous version.
 
 **Used by:** ``components/assistant/AskPanel.tsx`` (drives one turn per

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2165,8 +2165,12 @@ property of the registry (``TOOLS`` holds no mutating tool and
    models). A dedicated interpreter call (``interpretWhen``,
    ``window-interpreter.ts``) then maps the phrase onto structured fields
    (``lastCount``+``lastUnit``, ``daysAgo``, ``weekday``, ``date``,
-   ``fromTime``/``toTime``) under a constrained schema, cached per phrase
-   and day; "letzte Woche" becomes ``lastCount: 1, lastUnit: "week"``.
+   ``fromDate``/``toDate`` calendar spans, ``fromTime``/``toTime``) under a
+   constrained schema, cached per phrase and day; "letzte Woche" becomes
+   ``lastCount: 1, lastUnit: "week"``, and "april" becomes an inclusive
+   ``fromDate``/``toDate`` month span (either side may stand alone, the end
+   is capped at now, and an impossible date like a non-leap February 29 is
+   a corrective error, since V8 would otherwise roll it into March).
    Finally ``resolveWindow`` (``event-range.ts``) does the arithmetic into
    concrete ZM datetime strings against the profile timezone. No app-side
    phrase grammar exists anywhere on this path; the middle job was given its
@@ -2190,6 +2194,20 @@ property of the registry (``TOOLS`` holds no mutating tool and
    path.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/api-capture.ts>`__
    · → :doc:`07-api-and-data-fetching`
+
+#. **The result does the arithmetic, the model does the reading.**
+   ``list_events`` output leads with a code-built ``summary`` sentence
+   (``buildResultSummary``, ``result-summary.ts``) the model is told to quote
+   as its first sentence. ``matchCount`` is the server's TRUE total from ZM
+   pagination, not the page: two capped results both used to say 25 and the
+   model compared the caps as totals, so the sentence now leads with the real
+   count ("142 events ... The 25 most recent are listed.") and the
+   per-monitor and per-object tallies say "(listed rows)" whenever rows were
+   capped. ``busiestHour``/``countsByHour`` are tallied app-side from the
+   listed rows and ride OUTSIDE the summary, so quoting the summary never
+   narrows the result cards to one hour unless the question asked for it.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/result-summary.ts>`__
+   · → :doc:`12-shared-services-and-components`
 
 #. **Grounding is checked by code, not by a judge model.** When a turn that
    fetched data answers, ``retryIsUnusable`` (``grounding.ts``) checks two
@@ -2218,7 +2236,14 @@ property of the registry (``TOOLS`` holds no mutating tool and
    and renders assistant text as Markdown, except the ``__i18n:`` sentinels
    (iteration cap, context cleared), which
    ``renderAssistantText`` localizes with ``t()`` instead of treating as
-   literal text.
+   literal text. Result cards under the answer are selected by the answer
+   itself: an answer about specific rows ends with one machine-readable
+   ``SHOW: events=<ids> monitors=<ids>`` line, which
+   ``extractShowDirective`` (``display.ts``) strips before display and
+   ``filterDisplayByShow`` uses to pick which cards render; ids no tool
+   produced select nothing, and an answer with no directive shows every
+   card. Monitor cards render live previews (``LiveMonitorPlayer``), capped
+   at ``ASSISTANT.maxLiveMonitorCards``.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/assistant/AskPanel.tsx#L180>`__
    · → :doc:`05-component-architecture`
 


### PR DESCRIPTION
Doc audit (user + developer guides vs code) after the #265 work merged. User guide was clean; the developer guide had three stale sections and two missing steps, plus two stale code comments. Refs #265, refs #246.

- 12-shared: single-model claims replaced with the two-model list, Qwen3 4B default, and the `extra_body: enable_thinking:false` switch.
- 05-component: the destructive-tool confirmation subsection described removed functionality; replaced with the read-only reality.
- call-flows Flow 19: interpreter field list gains `fromDate`/`toDate`; new steps for result assembly (true matchCount, summary-leads, busiestHour outside the summary) and answer-driven result cards (SHOW directive, live previews).
- Code comments: constants no longer claims Llama is the default; webllm.ts header names Qwen3 4B and the real thinking switch.

Gates: 2663 unit tests, tsc, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYupXUqt5boWVdss5fMsdc