### PR TITLE
feat(events): frame carousel with a full-size viewer on event detail

### DIFF
--- a/app/src/components/events/EventFrameCarousel.tsx
+++ b/app/src/components/events/EventFrameCarousel.tsx
@@ -1,0 +1,183 @@
+/**
+ * Event Frame Carousel
+ *
+ * Collapsible strip of the significant frames ZoneMinder keeps for an event:
+ * the alarm frame, the snapshot, and the annotated object-detection image
+ * (issue #272). Tapping one opens it full size in a zoomable viewer.
+ *
+ * ZoneMinder exposes no API that reports which of these frames exist, so each
+ * candidate is rendered and removed when its image fails to load. The card
+ * renders nothing once every candidate has failed.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Images } from 'lucide-react';
+import { getEventImageUrl } from '../../api/events';
+import { CollapsibleCard } from '../ui/collapsible-card';
+import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
+import { ZoomControls } from '../ui/zoom-controls';
+import { useZoomPan } from '../../hooks/useZoomPan';
+import {
+  EVENT_FRAMES_OPEN_STORAGE_KEY,
+  EVENT_FRAME_THUMB_WIDTH,
+  EVENT_FRAME_TYPES,
+} from '../../lib/zmninja-ng-constants';
+
+type EventFrameType = (typeof EVENT_FRAME_TYPES)[number];
+
+interface EventFrameCarouselProps {
+  portalUrl: string;
+  eventId: string;
+  token?: string;
+  apiUrl?: string;
+  minStreamingPort?: number;
+  monitorId?: string;
+  /** Whether the event recorded an alarm frame. Skips that candidate when false. */
+  hasAlarmFrame: boolean;
+  /**
+   * Called when the full-size viewer opens or closes, so the page can pause
+   * playback while the image covers the player and resume it afterwards.
+   */
+  onViewerOpenChange?: (open: boolean) => void;
+}
+
+export function EventFrameCarousel({
+  portalUrl,
+  eventId,
+  token,
+  apiUrl,
+  minStreamingPort,
+  monitorId,
+  hasAlarmFrame,
+  onViewerOpenChange,
+}: EventFrameCarouselProps) {
+  const { t } = useTranslation();
+  const [failed, setFailed] = useState<EventFrameType[]>([]);
+  const [activeFrame, setActiveFrame] = useState<EventFrameType | null>(null);
+
+  const frames = useMemo(
+    () =>
+      EVENT_FRAME_TYPES.filter(
+        (type) => (type !== 'alarm' || hasAlarmFrame) && !failed.includes(type)
+      ),
+    [hasAlarmFrame, failed]
+  );
+
+  const imageUrl = useCallback(
+    (type: EventFrameType, width?: number) =>
+      getEventImageUrl(portalUrl, eventId, type, {
+        token,
+        width,
+        apiUrl,
+        minStreamingPort,
+        monitorId,
+      }),
+    [portalUrl, eventId, token, apiUrl, minStreamingPort, monitorId]
+  );
+
+  const handleViewerOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) setActiveFrame(null);
+      onViewerOpenChange?.(open);
+    },
+    [onViewerOpenChange]
+  );
+
+  const openFrame = useCallback(
+    (type: EventFrameType) => {
+      setActiveFrame(type);
+      onViewerOpenChange?.(true);
+    },
+    [onViewerOpenChange]
+  );
+
+  if (frames.length === 0) return null;
+
+  return (
+    <>
+      <CollapsibleCard
+        data-testid="event-frames-card"
+        storageKey={EVENT_FRAMES_OPEN_STORAGE_KEY}
+        header={
+          <div className="flex items-center gap-2">
+            <Images className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-semibold">{t('event_detail.frames_title')}</span>
+          </div>
+        }
+      >
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {frames.map((type) => (
+            <button
+              key={type}
+              type="button"
+              className="flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
+              onClick={() => openFrame(type)}
+              aria-label={t('event_detail.view_frame', { type: t(`event_detail.frame_type.${type}`) })}
+              data-testid={`event-frame-thumb-${type}`}
+            >
+              <img
+                src={imageUrl(type, EVENT_FRAME_THUMB_WIDTH)}
+                alt={t(`event_detail.frame_type.${type}`)}
+                className="w-30 h-20 object-cover rounded border"
+                onError={() => setFailed((prev) => (prev.includes(type) ? prev : [...prev, type]))}
+              />
+              <p className="text-xs text-center mt-1 text-muted-foreground min-w-0 truncate w-30">
+                {t(`event_detail.frame_type.${type}`)}
+              </p>
+            </button>
+          ))}
+        </div>
+      </CollapsibleCard>
+
+      {activeFrame && (
+        <EventFrameViewer
+          src={imageUrl(activeFrame)}
+          label={t(`event_detail.frame_type.${activeFrame}`)}
+          onOpenChange={handleViewerOpenChange}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Full-size view of one frame. Mounted only while a frame is open, so its
+ * zoom/pan state starts fresh each time instead of reopening at the last
+ * scale, and the hook stays out of the carousel's own render.
+ */
+function EventFrameViewer({
+  src,
+  label,
+  onOpenChange,
+}: {
+  src: string;
+  label: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  // Destructured rather than kept whole: handing an object that still carries
+  // the two refs to ZoomControls trips react-hooks/refs (rule 31).
+  const { ref, innerRef, ...controls } = useZoomPan({ maxScale: 4 });
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-[95vw] w-full p-2 bg-black border-0"
+        data-testid="event-frame-viewer"
+      >
+        <DialogTitle className="text-sm text-white">{label}</DialogTitle>
+        <div ref={ref} className="relative overflow-hidden touch-none">
+          <div ref={innerRef}>
+            <img
+              src={src}
+              alt={label}
+              className="w-full max-h-[80vh] object-contain"
+              data-testid="event-frame-viewer-image"
+            />
+          </div>
+          <ZoomControls zoomPan={controls} className="bottom-2 left-2" />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/events/ZmsEventPlayer.tsx
+++ b/app/src/components/events/ZmsEventPlayer.tsx
@@ -55,6 +55,9 @@ interface ZmsEventPlayerProps {
   playbackRate?: number;
   /** Called when the user picks a speed preset, so it can be persisted. */
   onRateChange?: (rate: number) => void;
+  /** Pauses the stream while something covers it, such as the full-size frame
+   * viewer (#272). Playback resumes on release only if it was running. */
+  suspended?: boolean;
 }
 
 export function ZmsEventPlayer({
@@ -73,6 +76,7 @@ export function ZmsEventPlayer({
   onEnded,
   playbackRate,
   onRateChange,
+  suspended = false,
 }: ZmsEventPlayerProps) {
   const { t } = useTranslation();
   const bandwidth = useBandwidthSettings();
@@ -316,6 +320,25 @@ export function ZmsEventPlayer({
       setIsPlaying(true);
     }
   }, [isPlaying, sendCommand]);
+
+  // Pause while suspended and resume on release, but only for a stream that was
+  // running: a stream the user had paused stays paused. isPlaying and sendCommand
+  // are read, not depended on, so a normal play/pause does not re-run this.
+  const resumeAfterSuspendRef = useRef(false);
+  useEffect(() => {
+    if (suspended) {
+      resumeAfterSuspendRef.current = isPlaying;
+      if (isPlaying) {
+        sendCommand(ZMS_COMMANDS.cmdPause);
+        setIsPlaying(false);
+      }
+    } else if (resumeAfterSuspendRef.current) {
+      resumeAfterSuspendRef.current = false;
+      sendCommand(ZMS_COMMANDS.cmdPlay);
+      setIsPlaying(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [suspended]);
 
   // Change playback speed with CMD_VARPLAY on the existing connkey, matching
   // ZoneMinder's own event UI. zms resumes playing after a VARPLAY.

--- a/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
+++ b/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EventFrameCarousel } from '../EventFrameCarousel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseProps = {
+  portalUrl: 'https://zm.example.com',
+  eventId: '4242',
+  token: 'tok',
+  hasAlarmFrame: true,
+};
+
+function renderCarousel(props: Partial<React.ComponentProps<typeof EventFrameCarousel>> = {}) {
+  return render(<EventFrameCarousel {...baseProps} {...props} />);
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('EventFrameCarousel', () => {
+  it('shows a thumbnail per candidate frame with the event image URL', () => {
+    renderCarousel();
+
+    expect(screen.getByTestId('event-frame-thumb-alarm')).toBeTruthy();
+    expect(screen.getByTestId('event-frame-thumb-snapshot')).toBeTruthy();
+    // The dev image proxy percent-encodes the ZoneMinder URL into a query
+    // parameter, so assert against the decoded form.
+    const objdetect = decodeURIComponent(
+      screen.getByTestId('event-frame-thumb-objdetect').querySelector('img')!.getAttribute('src')!
+    );
+    expect(objdetect).toContain('fid=objdetect');
+    expect(objdetect).toContain('eid=4242');
+  });
+
+  it('skips the alarm frame when the event has none', () => {
+    renderCarousel({ hasAlarmFrame: false });
+
+    expect(screen.queryByTestId('event-frame-thumb-alarm')).toBeNull();
+    expect(screen.getByTestId('event-frame-thumb-snapshot')).toBeTruthy();
+  });
+
+  it('drops a frame whose image fails to load', () => {
+    renderCarousel();
+
+    const objdetect = screen.getByTestId('event-frame-thumb-objdetect').querySelector('img')!;
+    fireEvent.error(objdetect);
+
+    expect(screen.queryByTestId('event-frame-thumb-objdetect')).toBeNull();
+    expect(screen.getByTestId('event-frame-thumb-snapshot')).toBeTruthy();
+  });
+
+  it('renders nothing once every frame has failed', () => {
+    renderCarousel();
+
+    for (const type of ['alarm', 'snapshot', 'objdetect']) {
+      fireEvent.error(screen.getByTestId(`event-frame-thumb-${type}`).querySelector('img')!);
+    }
+
+    expect(screen.queryByTestId('event-frames-card')).toBeNull();
+  });
+
+  it('reports the viewer opening and closing so playback can pause and resume', () => {
+    const onViewerOpenChange = vi.fn();
+    renderCarousel({ onViewerOpenChange });
+
+    fireEvent.click(screen.getByTestId('event-frame-thumb-alarm'));
+    expect(onViewerOpenChange).toHaveBeenLastCalledWith(true);
+
+    const fullImage = decodeURIComponent(
+      screen.getByTestId('event-frame-viewer-image').getAttribute('src')!
+    );
+    expect(fullImage).toContain('fid=alarm');
+    expect(fullImage).not.toContain('width=');
+
+    fireEvent.click(screen.getByTestId('dialog-close-button'));
+    expect(onViewerOpenChange).toHaveBeenLastCalledWith(false);
+    expect(screen.queryByTestId('event-frame-viewer-image')).toBeNull();
+  });
+
+  it('persists the collapsed state', () => {
+    const { unmount } = renderCarousel();
+
+    fireEvent.click(screen.getByText('event_detail.frames_title'));
+    expect(screen.queryByTestId('event-frame-thumb-alarm')).toBeNull();
+
+    unmount();
+    renderCarousel();
+    expect(screen.queryByTestId('event-frame-thumb-alarm')).toBeNull();
+  });
+});

--- a/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
+++ b/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../../../api/events', () => ({
   getEventImageUrl: vi.fn().mockReturnValue('https://zm.test/image.jpg'),
 }));
 
-function renderPlayer() {
+function renderPlayer(props: { suspended?: boolean } = {}) {
   return render(
     <ZmsEventPlayer
       portalUrl="https://zm.test"
@@ -75,6 +75,7 @@ function renderPlayer() {
       totalFrames={100}
       alarmFrames={0}
       eventLength={10}
+      {...props}
     />
   );
 }
@@ -128,6 +129,42 @@ describe('ZmsEventPlayer', () => {
     // implementation must not leak into the next one.
     httpGetMock.mockReset();
     httpGetMock.mockResolvedValue({ data: {} });
+  });
+
+  // Suspension (#272): the frame viewer covers the stream, so it pauses while
+  // open and resumes on close. CMD_PAUSE is 1 and CMD_PLAY is 2.
+  it('pauses a running stream while suspended and resumes it on release', () => {
+    const { rerender } = renderPlayer();
+
+    rerender(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={0} eventLength={10} suspended />
+    );
+    expect(callsForCommand('1')).toHaveLength(1);
+
+    rerender(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={0} eventLength={10} suspended={false} />
+    );
+    expect(callsForCommand('2')).toHaveLength(1);
+  });
+
+  it('leaves an already paused stream paused after suspension', () => {
+    const { rerender } = renderPlayer();
+    fireEvent.click(screen.getByTitle('event_detail.pause'));
+    expect(callsForCommand('1')).toHaveLength(1);
+
+    rerender(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={0} eventLength={10} suspended />
+    );
+    rerender(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={0} eventLength={10} suspended={false} />
+    );
+
+    expect(callsForCommand('1')).toHaveLength(1);
+    expect(callsForCommand('2')).toHaveLength(0);
   });
 
   it('stops at the event end instead of requesting a ZMS replay loop', () => {

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -299,6 +299,20 @@ export const EVENT_SCRUB_SEEK_DEBOUNCE_MS = 200;
 export const EVENT_SEEK_FLUSH_DELAY_MS = 400;
 
 /**
+ * Significant frames ZoneMinder can serve for an event (issue #272), in the
+ * order the event frame carousel shows them. ZoneMinder has no API that reports
+ * which of these exist for a given event, so the carousel renders each one and
+ * drops the ones whose image fails to load.
+ */
+export const EVENT_FRAME_TYPES = ['alarm', 'snapshot', 'objdetect'] as const;
+
+/** Width requested for carousel thumbnails, in pixels. */
+export const EVENT_FRAME_THUMB_WIDTH = 240;
+
+/** localStorage key holding the event frame carousel's expanded state. */
+export const EVENT_FRAMES_OPEN_STORAGE_KEY = 'zmninja-event-frames-open';
+
+/**
  * Relative time labels on events (issue #210).
  * List chip only renders for events within this many days; older events read
  * fine from the absolute date. Below the just-now threshold we show "just now".

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -294,7 +294,14 @@
     "alarm_frame_marker": "Alarm-Frame {{frameId}}",
     "max_score_marker": "Max Score Frame {{frameId}}",
     "marker_jumped": "Gesprungen zu {{text}}",
-    "tags": "Tags"
+    "tags": "Tags",
+    "frames_title": "Ereignisbilder",
+    "view_frame": "Bild {{type}} ansehen",
+    "frame_type": {
+      "alarm": "Alarm",
+      "snapshot": "Schnappschuss",
+      "objdetect": "Objekterkennung"
+    }
   },
   "settings": {
     "server": "Server",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -294,7 +294,14 @@
     "alarm_frame_marker": "Alarm Frame {{frameId}}",
     "max_score_marker": "Max Score Frame {{frameId}}",
     "marker_jumped": "Jumped to {{text}}",
-    "tags": "Tags"
+    "tags": "Tags",
+    "frames_title": "Event frames",
+    "view_frame": "View {{type}} frame",
+    "frame_type": {
+      "alarm": "Alarm",
+      "snapshot": "Snapshot",
+      "objdetect": "Object detection"
+    }
   },
   "settings": {
     "server": "Server",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -294,7 +294,14 @@
     "alarm_frame_marker": "Fotograma de Alarma {{frameId}}",
     "max_score_marker": "Fotograma de Máxima Puntuación {{frameId}}",
     "marker_jumped": "Saltado a {{text}}",
-    "tags": "Etiquetas"
+    "tags": "Etiquetas",
+    "frames_title": "Fotogramas del evento",
+    "view_frame": "Ver fotograma {{type}}",
+    "frame_type": {
+      "alarm": "Alarma",
+      "snapshot": "Instantánea",
+      "objdetect": "Detección de objetos"
+    }
   },
   "settings": {
     "server": "Servidor",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -294,7 +294,14 @@
     "alarm_frame_marker": "Image d'Alarme {{frameId}}",
     "max_score_marker": "Image Score Maximum {{frameId}}",
     "marker_jumped": "Sauté à {{text}}",
-    "tags": "Tags"
+    "tags": "Tags",
+    "frames_title": "Images de l'événement",
+    "view_frame": "Voir image {{type}}",
+    "frame_type": {
+      "alarm": "Alarme",
+      "snapshot": "Instantané",
+      "objdetect": "Détection d'objets"
+    }
   },
   "settings": {
     "server": "Serveur",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -294,7 +294,14 @@
     "alarm_frame_marker": "报警帧 {{frameId}}",
     "max_score_marker": "最高分数帧 {{frameId}}",
     "marker_jumped": "跳转到 {{text}}",
-    "tags": "标签"
+    "tags": "标签",
+    "frames_title": "事件画面",
+    "view_frame": "查看{{type}}画面",
+    "frame_type": {
+      "alarm": "报警",
+      "snapshot": "快照",
+      "objdetect": "目标检测"
+    }
   },
   "settings": {
     "server": "服务器",

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -21,6 +21,7 @@ import { Card } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Mp4EventPlayer } from '../components/events/Mp4EventPlayer';
 import { ZmsEventPlayer } from '../components/events/ZmsEventPlayer';
+import { EventFrameCarousel } from '../components/events/EventFrameCarousel';
 import { TagChip } from '../components/events/TagChip';
 import { ArrowLeft, Calendar, Clock, HardDrive, AlertTriangle, Download, Archive, Video, Star, Timer, Tag, ChevronLeft, ChevronRight, Loader2, ListVideo } from 'lucide-react';
 import { getEventCauseIcon } from '../lib/event/event-icons';
@@ -233,6 +234,28 @@ export default function EventDetail() {
 
   // Pinch-to-zoom and pan for event video/image
   const zoomPan = useZoomPan({ maxScale: 4 });
+
+  // Frame carousel viewer (#272): the full-size image covers the player, so
+  // playback pauses while it is open and resumes on close if it was running.
+  // The player is held structurally so this page does not import video.js.
+  const mp4PlayerRef = useRef<{
+    paused: () => boolean;
+    play: () => void | Promise<void>;
+    pause: () => void;
+  } | null>(null);
+  const [frameViewerOpen, setFrameViewerOpen] = useState(false);
+  const resumeAfterViewerRef = useRef(false);
+  const handleFrameViewerOpenChange = useCallback((open: boolean) => {
+    setFrameViewerOpen(open);
+    const player = mp4PlayerRef.current;
+    if (open) {
+      resumeAfterViewerRef.current = !!player && !player.paused();
+      player?.pause();
+    } else if (resumeAfterViewerRef.current) {
+      resumeAfterViewerRef.current = false;
+      void player?.play();
+    }
+  }, []);
 
   const orientedResolution = useMemo(
     () => getOrientedResolution(
@@ -475,6 +498,21 @@ export default function EventDetail() {
         )}
       >
         <div className="w-full max-w-5xl space-y-3 sm:space-y-4 md:space-y-6">
+          {/* Significant frames for this event (#272). Gated on a fresh token so
+              the thumbnails are not all dropped as failures during a refresh. */}
+          {currentProfile && isAccessTokenFresh && (
+            <EventFrameCarousel
+              portalUrl={resolvedPortalUrl}
+              eventId={event.Event.Id}
+              token={accessToken || undefined}
+              apiUrl={currentProfile.apiUrl}
+              minStreamingPort={effectiveMinStreamingPort}
+              monitorId={event.Event.MonitorId}
+              hasAlarmFrame={!!event.Event.AlarmFrameId}
+              onViewerOpenChange={handleFrameViewerOpenChange}
+            />
+          )}
+
           {/* Video Player or ZMS Playback */}
           {hasVideo ? (
             useZmsFallback ? (
@@ -484,6 +522,7 @@ export default function EventDetail() {
                   portalUrl={resolvedPortalUrl}
                   eventId={event.Event.Id}
                   token={isAccessTokenFresh ? accessToken ?? undefined : undefined}
+                  suspended={frameViewerOpen}
                   apiUrl={currentProfile.apiUrl}
                   totalFrames={parseInt(event.Event.Frames)}
                   alarmFrames={parseInt(event.Event.AlarmFrames)}
@@ -516,6 +555,7 @@ export default function EventDetail() {
                         markers={videoMarkers}
                         onMarkerClick={handleMarkerClick}
                         eventId={event.Event.Id}
+                        onReady={(player) => { mp4PlayerRef.current = player; }}
                         onError={handleVideoError}
                         onEnded={handleVideoEnded}
                         playbackRate={settings.eventPlaybackRate}
@@ -538,6 +578,7 @@ export default function EventDetail() {
                 portalUrl={resolvedPortalUrl}
                 eventId={event.Event.Id}
                 token={accessToken || undefined}
+                suspended={frameViewerOpen}
                 apiUrl={currentProfile.apiUrl}
                 totalFrames={parseInt(event.Event.Frames)}
                 alarmFrames={parseInt(event.Event.AlarmFrames)}

--- a/app/tests/features/events.feature
+++ b/app/tests/features/events.feature
@@ -165,3 +165,12 @@ Feature: Event Browsing and Management
     When I switch events view to montage
     Then I should see the events montage grid
     And any relative time labels in the montage read as a duration
+
+  @all
+  Scenario: Event frames carousel opens a frame full size
+    When I click into the first event if events exist
+    Then I should see the event frames carousel if events exist
+    When I open the first event frame if events exist
+    Then I should see the full-size event frame if events exist
+    When I close the full-size event frame if events exist
+    Then the full-size event frame is gone if events exist

--- a/app/tests/steps/events.steps.ts
+++ b/app/tests/steps/events.steps.ts
@@ -789,3 +789,31 @@ Then('I should see the background task drawer if download was triggered', async 
   await expect(drawer.first()).toBeVisible({ timeout: testConfig.timeouts.transition * 2 });
   log.info('E2E: Background task drawer visible', { component: 'e2e' });
 });
+
+// Event frame carousel (#272). Every stored event has a snapshot frame, so the
+// card must appear for any event the server has; the only genuine skip is a
+// server with no events at all, which serverHasEvents() answers from the API.
+Then('I should see the event frames carousel if events exist', async ({ page }) => {
+  if (!(await serverHasEvents())) return;
+  await expect(page.getByTestId('event-frames-card')).toBeVisible({ timeout: testConfig.timeouts.element });
+});
+
+When('I open the first event frame if events exist', async ({ page }) => {
+  if (!(await serverHasEvents())) return;
+  await page.locator('[data-testid^="event-frame-thumb-"]').first().click();
+});
+
+Then('I should see the full-size event frame if events exist', async ({ page }) => {
+  if (!(await serverHasEvents())) return;
+  await expect(page.getByTestId('event-frame-viewer-image')).toBeVisible({ timeout: testConfig.timeouts.element });
+});
+
+When('I close the full-size event frame if events exist', async ({ page }) => {
+  if (!(await serverHasEvents())) return;
+  await page.getByTestId('dialog-close-button').click();
+});
+
+Then('the full-size event frame is gone if events exist', async ({ page }) => {
+  if (!(await serverHasEvents())) return;
+  await expect(page.getByTestId('event-frame-viewer-image')).toBeHidden({ timeout: testConfig.timeouts.element });
+});

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -543,7 +543,14 @@ the user-forced-ZMS branch.
 
 **Props:** ``portalUrl``, ``eventId``, ``token``, ``apiUrl``, ``totalFrames``,
 ``alarmFrames``, ``alarmFrameId``, ``maxScoreFrameId``, ``eventLength``,
-``minStreamingPort``, ``monitorId``, ``className``.
+``minStreamingPort``, ``monitorId``, ``className``, ``suspended``.
+
+``suspended`` pauses the stream while something covers it, currently the
+full-size viewer in ``EventFrameCarousel``. The effect remembers whether the
+stream was running when suspension began and only sends ``CMD_PLAY`` on release
+if it was, so a stream the user paused stays paused. It depends on ``suspended``
+alone and reads ``isPlaying`` without depending on it; taking ``isPlaying`` as a
+dependency would re-run the effect on every ordinary play/pause.
 
 The player exposes transport controls (start, seek back 5s, play / pause, seek
 forward 5s, end), speed presets (0.25x, 0.5x, 1x, 2x, 4x), a frame-position
@@ -579,6 +586,44 @@ When the token is stale, ``zmsUrl`` evaluates to ``''`` and the ``<img>`` does
 not render until the auth store returns a refreshed value. See the access-token
 freshness gate in :doc:`07-api-and-data-fetching` for why this gate exists and
 what counts as fresh.
+
+EventFrameCarousel
+~~~~~~~~~~~~~~~~~~
+
+**Location**: ``src/components/events/EventFrameCarousel.tsx``
+
+Strip of the significant still frames for an event, rendered above the player in
+``EventDetail`` (refs #272). The candidates are ``EVENT_FRAME_TYPES``
+(``lib/zmninja-ng-constants.ts``): ``alarm``, ``snapshot``, ``objdetect``. Each
+one becomes a thumbnail through ``getEventImageUrl`` at
+``EVENT_FRAME_THUMB_WIDTH`` (240 px), and the full-size viewer requests the same
+URL without a width.
+
+**Props:** ``portalUrl``, ``eventId``, ``token``, ``apiUrl``,
+``minStreamingPort``, ``monitorId``, ``hasAlarmFrame``, ``onViewerOpenChange``.
+
+ZoneMinder has no endpoint that reports which of these frames a given event has.
+``objdetect`` only exists when the Event Server or ``zm_detect`` wrote one, and
+the alarm frame only exists for an event that alarmed. So presence is discovered
+by rendering: a thumbnail whose ``<img>`` fires ``onError`` adds its type to a
+``failed`` list and disappears, and the component returns ``null`` once nothing
+is left, which removes the card entirely. ``hasAlarmFrame`` skips the alarm
+candidate up front when the event carries no ``AlarmFrameId``, so the common
+non-alarm case costs no failed request. ``EventDetail`` renders the carousel
+only while ``isAccessTokenFresh``, otherwise a token refresh would fail every
+image at once and hide the card for the rest of the visit.
+
+Collapse state lives in ``CollapsibleCard`` under
+``EVENT_FRAMES_OPEN_STORAGE_KEY``, so it is a device preference in
+``localStorage`` rather than a profile setting: it describes screen layout, not
+server behavior.
+
+``onViewerOpenChange`` is how the covered player gets stopped. ``EventDetail``
+holds the Video.js instance from ``Mp4EventPlayer``'s ``onReady`` in a ref typed
+structurally (``paused``/``play``/``pause``) so the page does not import
+``video.js`` itself, pauses it when the viewer opens, and resumes it on close
+only if it had been playing. The ZMS branches receive the same state through
+``suspended``.
 
 Player selection in EventDetail
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -606,6 +606,16 @@ MJPEG player.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/events/ZmsEventPlayer.tsx#L51>`__
    · → :doc:`05-component-architecture`
 
+#. **The still frames above the player.** ``EventFrameCarousel`` renders the
+   alarm, snapshot, and objdetect frames as thumbnails. ZoneMinder reports no
+   list of which ones exist, so each is requested and any whose image errors
+   removes itself; when all of them error the card disappears. Opening one calls
+   ``onViewerOpenChange``, and ``EventDetail`` pauses the Video.js player it kept
+   from ``onReady`` (or passes ``suspended`` to ``ZmsEventPlayer``), resuming on
+   close only if playback was running.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/events/EventFrameCarousel.tsx#L45>`__
+   · → :doc:`05-component-architecture`
+
 Flow 6: The access-token lifecycle
 ----------------------------------
 

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -47,6 +47,14 @@ Filter events using the controls at the top:
 
 Tap an event to open the event detail view, which includes:
 
+### Event Frames
+
+Above the player is a strip of the significant still frames ZoneMinder keeps for the event: the alarm frame, the snapshot, and the annotated object-detection image if machine learning wrote one. Only the frames the server actually has appear, so an event without object detection shows two entries and an event with no stored stills shows no strip at all.
+
+Tap a frame to see it full size. Pinch or use the zoom buttons to inspect detail. Playback stops while the image is open and resumes when you close it, unless you had already paused it.
+
+Tap the strip's header to collapse or expand it. That choice is remembered for the next event you open.
+
 ### Video Player
 
 The event player selects the playback mode based on the event's format:


### PR DESCRIPTION
Closes nothing on its own; work for #272.

## What

Adds a collapsible strip of the significant still frames above the event player: the alarm frame, the snapshot, and the annotated objdetect image, matching what legacy zmNinja showed. Tapping one opens it full size with pinch/zoom.

## How

- `EventFrameCarousel` builds one thumbnail per candidate in `EVENT_FRAME_TYPES` through the existing `getEventImageUrl`. ZoneMinder has no endpoint that says which frames an event has, so a thumbnail whose image errors removes itself and the card disappears once none are left. The alarm candidate is skipped up front when the event has no `AlarmFrameId`.
- Collapse state persists via the existing `CollapsibleCard` `storageKey` (localStorage; it describes screen layout, not server behavior).
- Opening a frame stops playback and closing resumes it, but only if it was running: `EventDetail` keeps the Video.js instance from `Mp4EventPlayer`'s `onReady`, and `ZmsEventPlayer` gained a `suspended` prop that sends CMD_PAUSE / CMD_PLAY.
- The carousel only renders while the access token is fresh, otherwise a refresh would fail every image at once and hide the card for the rest of the visit.

## Verification

- `npm test` — 2922 passed, 2 skipped
- `npx tsc -b` — clean
- `npm run build` — exit 0
- `npm run test:e2e -- events.feature` — 22 passed (the pre-existing archive scenario is flaky and passed on retry); the new "Event frames carousel opens a frame full size" scenario passes against a server with 612 events
- `npx eslint` on the edited files — no new violations
- Not verified on device: iOS/Android manual suites are manual-only

Docs updated: user guide events page, `05-component-architecture.rst`, and Flow 5 in `call-flows.rst`. Translations added for en, de, es, fr, zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)