### PR TITLE
fix(notifications): reconnect the event server socket on resume

### DIFF
--- a/app/src/hooks/__tests__/useNotificationAutoConnect.test.ts
+++ b/app/src/hooks/__tests__/useNotificationAutoConnect.test.ts
@@ -530,7 +530,9 @@ describe('useNotificationAutoConnect', () => {
         await Promise.resolve();
       });
 
-      expect(params.reconnect).toHaveBeenCalled();
+      // Forced: the socket still reads as connected, so an unforced reconnect
+      // would be refused by the service (refs #274).
+      expect(params.reconnect).toHaveBeenCalledWith(true);
     });
 
     it('does not call reconnect when WebSocket is alive on tab focus', async () => {
@@ -554,7 +556,9 @@ describe('useNotificationAutoConnect', () => {
       expect(params.reconnect).not.toHaveBeenCalled();
     });
 
-    it('does not check liveness when not connected on tab focus', async () => {
+    // A hidden tab has its timers frozen, so the scheduled backoff reconnect
+    // may be minutes out or may never have run. Retry on focus (refs #274).
+    it('reconnects without a liveness check when disconnected on tab focus', async () => {
       const params = makeParams({
         isConnected: false,
         settings: { ...defaultSettings, enabled: true, notificationMode: 'es' },
@@ -571,6 +575,7 @@ describe('useNotificationAutoConnect', () => {
       });
 
       expect(mockCheckAlive).not.toHaveBeenCalled();
+      expect(params.reconnect).toHaveBeenCalledWith();
     });
 
     it('removes visibilitychange listener on unmount', () => {
@@ -584,6 +589,52 @@ describe('useNotificationAutoConnect', () => {
       expect(removed).toBe(true);
 
       removeEventSpy.mockRestore();
+    });
+  });
+
+  describe('app resume reconnect (native)', () => {
+    it('reconnects on app resume while disconnected, without a liveness check', async () => {
+      mockPlatform.isNative = true;
+      const params = makeParams({
+        isConnected: false,
+        settings: { ...defaultSettings, enabled: true, notificationMode: 'es' },
+      });
+      renderHook(() => useNotificationAutoConnect(params));
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const handler = mockAppAddListener.mock.calls.find(([event]) => event === 'appStateChange')?.[1];
+      await act(async () => {
+        await handler({ isActive: true });
+      });
+
+      expect(mockCheckAlive).not.toHaveBeenCalled();
+      expect(params.reconnect).toHaveBeenCalledWith();
+    });
+
+    it('forces a reconnect on app resume when the socket does not answer', async () => {
+      mockPlatform.isNative = true;
+      mockCheckAlive.mockResolvedValue(false);
+      const params = makeParams({
+        isConnected: true,
+        settings: { ...defaultSettings, enabled: true, notificationMode: 'es' },
+      });
+      renderHook(() => useNotificationAutoConnect(params));
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const handler = mockAppAddListener.mock.calls.find(([event]) => event === 'appStateChange')?.[1];
+      await act(async () => {
+        await handler({ isActive: true });
+      });
+
+      expect(params.reconnect).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/app/src/hooks/useNotificationAutoConnect.ts
+++ b/app/src/hooks/useNotificationAutoConnect.ts
@@ -33,7 +33,7 @@ interface AutoConnectParams {
   currentProfileId: string | null;
   connect: (profileId: string, username: string, password: string, portalUrl: string) => Promise<void>;
   disconnect: () => void;
-  reconnect: () => void;
+  reconnect: (force?: boolean) => void;
   getDecryptedPassword: (profileId: string) => Promise<string | null | undefined>;
 }
 
@@ -201,7 +201,15 @@ export function useNotificationAutoConnect({
 
     const handleVisibilityChange = async () => {
       if (document.visibilityState !== 'visible') return;
-      if (!isConnected) return;
+
+      // A hidden tab gets its timers frozen, so a scheduled reconnect can be
+      // arbitrarily late (up to the 2 minute backoff cap) or not have run at
+      // all. Retry now instead of waiting it out (refs #274).
+      if (!isConnected) {
+        log.notificationHandler('Tab visible while disconnected, reconnecting now', LogLevel.INFO);
+        reconnect();
+        return;
+      }
 
       log.notificationHandler('Tab visible, checking WebSocket liveness', LogLevel.DEBUG);
       const service = getNotificationService();
@@ -209,7 +217,7 @@ export function useNotificationAutoConnect({
 
       if (!alive) {
         log.notificationHandler('WebSocket not responding after tab resume, reconnecting', LogLevel.WARN);
-        reconnect();
+        reconnect(true);
       }
     };
 
@@ -222,7 +230,16 @@ export function useNotificationAutoConnect({
     () => import('@capacitor/app').then((m) => m.App),
     'appStateChange',
     async ({ isActive }: { isActive: boolean }) => {
-      if (!isActive || !isConnected) return;
+      if (!isActive) return;
+
+      // Suspending the app kills the socket and freezes the WebView's timers,
+      // so the backoff reconnect either fired into a dead network or never ran.
+      // Resuming is the moment to retry, not to wait for a stale timer (#274).
+      if (!isConnected) {
+        log.notificationHandler('App resumed while disconnected, reconnecting now', LogLevel.INFO);
+        reconnect();
+        return;
+      }
 
       log.notificationHandler('App resumed, checking WebSocket liveness', LogLevel.DEBUG);
       const service = getNotificationService();
@@ -230,7 +247,7 @@ export function useNotificationAutoConnect({
 
       if (!alive) {
         log.notificationHandler('WebSocket not responding after app resume, reconnecting', LogLevel.WARN);
-        reconnect();
+        reconnect(true);
       }
     },
     {

--- a/app/src/services/__tests__/notifications.test.ts
+++ b/app/src/services/__tests__/notifications.test.ts
@@ -236,6 +236,42 @@ describe('ZMNotificationService', () => {
       expect(wsCtor).toHaveBeenCalledTimes(1);
     });
 
+    // A socket that survived an app suspension reads as OPEN with a dead peer,
+    // so the failed liveness check is the only signal it is gone (refs #274).
+    it('reconnectNow(force) replaces a socket the state still calls connected', async () => {
+      const stale = await connectAndAuth();
+
+      service.reconnectNow(true);
+
+      expect(wsCtor).toHaveBeenCalledTimes(2);
+      expect(stale.readyState).toBe(MockWebSocket.CLOSED);
+    });
+
+    it('ignores the stale socket closing after a forced reconnect', async () => {
+      const stale = await connectAndAuth();
+      service.reconnectNow(true);
+
+      // The old socket's close event arrives late; it must not schedule a
+      // second reconnect on top of the one already running.
+      stale._triggerClose(false, 1006);
+      await vi.advanceTimersByTimeAsync(300_000);
+
+      expect(wsCtor).toHaveBeenCalledTimes(2);
+    });
+
+    it('schedules a reconnect when the WebSocket constructor throws', async () => {
+      (wsCtor as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        throw new Error('SecurityError: blocked scheme');
+      });
+
+      await service.connect(testConfig, providers);
+      expect(service.getState()).toBe('error');
+
+      // Nothing produced a close event, so only the catch can retry
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(wsCtor).toHaveBeenCalledTimes(2);
+    });
+
     it('does not auto-reconnect after auth failure', async () => {
       const connectPromise = service.connect(testConfig);
       const ws = wsCtor.instances[0];
@@ -263,6 +299,23 @@ describe('ZMNotificationService', () => {
 
       // State should be error (set by timeout before catch block)
       expect(service.getState()).toBe('error');
+    });
+
+    // The timeout used to null `this.ws` before closing, so the close event
+    // failed the handler's identity guard and no reconnect was ever scheduled:
+    // the app sat in 'error' until the user tapped Connect (refs #274).
+    it('still reconnects after the socket closes following an auth timeout', async () => {
+      const connectPromise = service.connect(testConfig);
+      const ws = wsCtor.instances[0];
+      ws._triggerOpen();
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      await connectPromise;
+
+      ws._triggerClose(false, 1006);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(wsCtor).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/app/src/services/notifications.ts
+++ b/app/src/services/notifications.ts
@@ -381,6 +381,13 @@ export class ZMNotificationService {
       this._setState('error');
       // Don't throw: let _handleClose schedule reconnect for transport failures.
       // For auth failures, disconnect() was already called in _handleMessage.
+      // With no socket left there is no close event coming, so nothing else
+      // would retry: a WebSocket constructor throw (malformed URL, blocked
+      // scheme) used to strand the service in 'error' until the user tapped
+      // Connect (refs #274).
+      if (!this.ws && !this.intentionalDisconnect) {
+        this._scheduleReconnect();
+      }
     }
   }
 
@@ -544,22 +551,34 @@ export class ZMNotificationService {
   /**
    * Trigger an immediate reconnect (e.g., after network comes back online).
    * Cancels any pending scheduled reconnect.
+   *
+   * @param force - Reconnect even while the state says connected. Required
+   *   after a failed liveness check: a socket that survived an app suspension
+   *   can read as OPEN while the peer is long gone, and without this the one
+   *   caller that knows the connection is dead was refused (refs #274).
    */
-  public reconnectNow(): void {
-    if (this.state === 'connected' || this.state === 'connecting' || this.state === 'authenticating') {
+  public reconnectNow(force = false): void {
+    const busy = this.state === 'connected' || this.state === 'connecting' || this.state === 'authenticating';
+    if (busy && !force) {
       return;
     }
     if (!this.config || this.intentionalDisconnect) {
       return;
     }
 
-    log.notifications('Triggering immediate reconnect', LogLevel.INFO);
+    log.notifications('Triggering immediate reconnect', LogLevel.INFO, { force, state: this.state });
 
-    // Cancel any pending scheduled reconnect
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+    // Drop the stale socket before reconnecting. `this.ws` is cleared first so
+    // the close event fails the handler's identity guard: _handleClose must not
+    // schedule a competing reconnect on top of the one starting here.
+    if (this.ws) {
+      const stale = this.ws;
+      this.ws = null;
+      stale.close();
     }
+
+    // Cancel any pending scheduled reconnect and the keepalive of the old socket
+    this._clearTimers();
 
     // Reset attempt counter on explicit reconnect (e.g., network restored)
     this.reconnectAttempts = 0;
@@ -637,11 +656,11 @@ export class ZMNotificationService {
         this.pendingAuth = null;
         this._setState('error');
 
-        // Close the socket: this triggers _handleClose which will schedule reconnect
-        if (this.ws) {
-          this.ws.close();
-          this.ws = null;
-        }
+        // Close the socket and leave `this.ws` set: every socket handler is
+        // guarded by `this.ws !== ws`, so nulling it here would make the close
+        // event skip _handleClose and no reconnect would ever be scheduled
+        // (refs #274). _handleClose nulls it.
+        this.ws?.close();
 
         reject(new Error('Authentication timeout (20 seconds)'));
       }, 20000);

--- a/app/src/stores/notifications.ts
+++ b/app/src/stores/notifications.ts
@@ -78,7 +78,8 @@ interface NotificationState {
   // Actions - Connection
   connect: (profileId: string, username: string, password: string, portalUrl: string) => Promise<void>;
   disconnect: () => void;
-  reconnect: () => Promise<void>;
+  /** @param force - reconnect even while the service still reports connected */
+  reconnect: (force?: boolean) => Promise<void>;
 
   // Actions - Events
   addEvent: (profileId: string, event: ZMAlarmEvent, source?: NotificationSource) => void;
@@ -325,10 +326,10 @@ export const useNotificationStore = create<NotificationState>()(
         });
       },
 
-      reconnect: async () => {
-        log.notifications('Triggering reconnect', LogLevel.INFO);
+      reconnect: async (force = false) => {
+        log.notifications('Triggering reconnect', LogLevel.INFO, { force });
         const service = getNotificationService();
-        service.reconnectNow();
+        service.reconnectNow(force);
       },
 
       // ========== Event Actions ==========

--- a/docs/developer-guide/07-api-and-data-fetching.rst
+++ b/docs/developer-guide/07-api-and-data-fetching.rst
@@ -1657,9 +1657,22 @@ Singleton via ``getNotificationService()``.
   whether a response arrives in time. ``useNotificationAutoConnect`` calls it
   on app resume (mobile ``appStateChange``) and tab visibility change (desktop
   ``visibilitychange``) to detect a socket the OS killed while backgrounded.
-- ``reconnectNow()`` fires on network restore. ``useNotificationAutoConnect``
+  It only runs when the store still believes it is connected; a resume that
+  finds the state already disconnected skips the ping and reconnects at once,
+  because the backoff timer was frozen along with the rest of the WebView.
+- ``reconnectNow(force)`` fires on network restore. ``useNotificationAutoConnect``
   listens to ``window.addEventListener('online')`` on desktop/web and
-  ``@capacitor/network`` on mobile.
+  ``@capacitor/network`` on mobile. Without ``force`` it declines to act while
+  the state is connected, connecting, or authenticating. A failed liveness check
+  passes ``force``: a socket that outlived an app suspension reads as ``OPEN``
+  with a dead peer, so the caller that proved it is gone would otherwise be the
+  one caller turned away (refs #274). Forcing closes the stale socket first,
+  clearing ``this.ws`` so the late close event fails the handler identity guard
+  and cannot schedule a second, competing reconnect.
+- Every failure path ends in either a live socket or a scheduled reconnect. A
+  ``WebSocket`` constructor throw produces no close event, so ``_connect``
+  schedules the retry from its own catch; the auth timeout closes the socket but
+  leaves ``this.ws`` set so ``_handleClose`` runs and schedules it there.
 
 The service imports no stores. ``stores/notifications.ts`` injects a
 ``ZMNotificationProviders`` object at connect time carrying the fresh-token

--- a/docs/developer-guide/11-application-lifecycle.rst
+++ b/docs/developer-guide/11-application-lifecycle.rst
@@ -257,7 +257,10 @@ When the user re-opens the app:
 - **WebSocket Liveness**: ``useNotificationAutoConnect`` calls
   ``service.checkAlive(5000)``, which sends a ping and waits for a response. If
   the server does not respond within those 5 seconds, the connection is treated
-  as dead and an immediate reconnect is triggered.
+  as dead and a forced reconnect is triggered: the socket still reads as open,
+  so an ordinary ``reconnectNow()`` would decline (refs #274). When the store
+  already reads disconnected, resume skips the ping and reconnects immediately
+  rather than waiting on a backoff timer that the suspended WebView froze.
 - **Badge Clear**: ``useNotificationDelivered`` listens for ``appStateChange``,
   ingests any notifications delivered while backgrounded into the history
   store, then clears the native badge via

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -782,7 +782,11 @@ alive, and turns each live alarm into an event in the store and a toast on scree
 
 #. **Reconnect with backoff.** On an unintended close, ``_scheduleReconnect`` waits
    an exponential, jittered delay (capped at two minutes); ``reconnectNow`` jumps
-   the queue on network-restored.
+   the queue on network-restored and on app resume. Resume matters more than it
+   looks: a suspended WebView freezes that timer, so without the resume nudge the
+   app can sit disconnected for the full two-minute cap after a phone unlock.
+   ``reconnectNow(true)`` additionally replaces a socket that still reads as open
+   but failed its liveness ping (refs #274).
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/services/notifications.ts#L518>`__
    · → :doc:`12-shared-services-and-components`
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -74,6 +74,8 @@ Tap a notification entry to jump to the corresponding event.
 - Ensure the server hostname is correct
 - Check app logs for WebSocket connection errors
 
+The connection to the Event Server drops while the app is backgrounded or the phone is locked, because the operating system suspends the app. Reopening the app reconnects it, and the status badge returns to connected within a few seconds. Push notifications are delivered over a separate channel, so they keep arriving even during that gap.
+
 **No in-app notifications (Direct mode, desktop)**
 - Verify ZoneMinder's Notifications API is available (the Direct option will be greyed out if not detected)
 - Check that the polling interval is configured


### PR DESCRIPTION
Work for #274.

## The bug

Backgrounding the app left the Event Server WebSocket disconnected until the user tapped Connect. Reported on Android, but nothing in the code is platform-specific: the same paths serve iOS resume and desktop/web tab visibility.

## Three dead ends, all fixed here

1. **A dead socket that still reads as open.** After an app suspension the socket reports `readyState === OPEN` with a gone peer, so the state is still `connected`. The resume liveness check detected this and called `reconnectNow()`, which declines while the state is connected — the one caller that had proved the connection was dead was the one caller refused. `reconnectNow(force)` now drops the stale socket and reconnects; the liveness failure passes `force`. `this.ws` is cleared before closing so the late close event fails the handler identity guard and cannot schedule a competing reconnect.

2. **Resume gave up when the socket had already closed.** The handler returned on `!isConnected`, leaving recovery to a backoff timer that the suspended WebView froze — up to the two-minute cap after unlock. Resume now reconnects immediately whenever the store is not connected, on native `appStateChange` and on `visibilitychange` alike.

3. **The auth timeout permanently killed reconnection.** It nulled `this.ws` before closing, so the close event failed the `this.ws !== ws` guard, `_handleClose` never ran, and no reconnect was ever scheduled — the service sat in `error` forever. It now leaves the field for `_handleClose`. A `WebSocket` constructor throw schedules its own retry from the catch, since no close event follows it.

## Verification

- `npm test` — 2928 passed, 2 skipped, including 6 new regression tests (forced reconnect replaces a live-looking socket, late close of the stale socket does not double-reconnect, constructor throw still retries, auth timeout still reconnects, resume/visibility reconnect while disconnected, resume forces on liveness failure)
- `npx tsc -b` — clean
- `npm run build` — exit 0
- `npx eslint` on the changed files — no issues
- No e2e: this is service and hook logic with no UI surface, and CI has no Event Server to background against
- Not verified on device: Android and iOS resume are manual-only checks

Docs updated: `07-api-and-data-fetching.rst`, `11-application-lifecycle.rst`, Flow 7 in `call-flows.rst`, and the notifications troubleshooting section for the user-visible part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)