### PR TITLE
fix(events): bind gestures in the portal-rendered frame viewer

### DIFF
--- a/app/src/components/events/EventFrameCarousel.tsx
+++ b/app/src/components/events/EventFrameCarousel.tsx
@@ -164,6 +164,9 @@ function EventFrameViewer({
       <DialogContent
         className="max-w-[95vw] w-full p-2 bg-black border-0"
         data-testid="event-frame-viewer"
+        // The frame itself is the content; the title names it, so Radix's
+        // description slot has nothing to add.
+        aria-describedby={undefined}
       >
         <DialogTitle className="text-sm text-white">{label}</DialogTitle>
         <div ref={ref} className="relative overflow-hidden touch-none">

--- a/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
+++ b/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
@@ -82,6 +82,18 @@ describe('EventFrameCarousel', () => {
     expect(screen.queryByTestId('event-frame-viewer-image')).toBeNull();
   });
 
+  // The viewer lives in a portal, where a container that binds gestures only on
+  // its first commit would end up with working buttons and dead gestures.
+  it('zooms the full-size frame on wheel, not only through the buttons', () => {
+    renderCarousel();
+    fireEvent.click(screen.getByTestId('event-frame-thumb-alarm'));
+
+    const zoomTarget = screen.getByTestId('event-frame-viewer-image').parentElement!;
+    fireEvent.wheel(zoomTarget.parentElement!, { deltaY: -120, clientX: 10, clientY: 10 });
+
+    expect(zoomTarget.style.transform).toMatch(/scale\((?!1\))/);
+  });
+
   it('persists the collapsed state', () => {
     const { unmount } = renderCarousel();
 

--- a/app/src/hooks/useZoomPan.ts
+++ b/app/src/hooks/useZoomPan.ts
@@ -42,6 +42,18 @@ export function useZoomPan({
   const innerElRef = useRef<HTMLDivElement | null>(null);
   const stateRef = useRef<TransformState>({ scale: 1, x: 0, y: 0 });
 
+  // The container is tracked in state as well as in a ref. useGesture binds to
+  // `target` from an effect that runs on every render and reads `.current` at
+  // that moment, so a container that only enters the DOM in a later commit -
+  // anything rendered through a portal, such as a Radix dialog - is null on the
+  // first bind and would never be retried without a re-render (refs #272).
+  // The effects below depend on this value for the same reason.
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+  const setContainer = useCallback((el: HTMLDivElement | null) => {
+    containerRef.current = el;
+    setContainerEl(el);
+  }, []);
+
   // Callback ref for the inner (transformed) element
   const innerRef = useCallback((el: HTMLDivElement | null) => {
     innerElRef.current = el;
@@ -291,14 +303,20 @@ export function useZoomPan({
 
   // Grab cursor when zoomed so desktop users discover drag-to-pan.
   useEffect(() => {
+    // Read through the ref: `containerEl` is only the dependency that re-runs
+    // this once the node exists, and styling a value held in state trips
+    // react-hooks/immutability.
     const el = containerRef.current;
     if (!el) return;
     el.style.cursor = isZoomed ? 'grab' : '';
-  }, [isZoomed]);
+  }, [isZoomed, containerEl]);
 
   // Apply touch/drag styles to container and block the browser's native image
   // drag (ghost image) so a mouse drag pans instead of dragging the picture.
   useEffect(() => {
+    // Read through the ref: `containerEl` is only the dependency that re-runs
+    // this once the node exists, and styling a value held in state trips
+    // react-hooks/immutability.
     const el = containerRef.current;
     if (!el) return;
     el.classList.add('no-native-drag');
@@ -310,10 +328,10 @@ export function useZoomPan({
       el.style.touchAction = '';
       el.removeEventListener('dragstart', onDragStart);
     };
-  }, []);
+  }, [containerEl]);
 
   return {
-    ref: containerRef,
+    ref: setContainer,
     innerRef,
     scale: displayScale,
     isZoomed,

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1807,9 +1807,21 @@ Click-and-hold repeats the action on every button.
    </div>
 
 It takes the whole ``ZoomPanControls`` object rather than nine separate handler
-props, so adding a control does not touch three call sites.
+props, so adding a control does not touch three call sites. Pass it the object
+without the two refs (``const { ref, innerRef, ...controls } = useZoomPan()``)
+when the compiler lint is in play: handing a component an object that still
+carries refs trips ``react-hooks/refs``.
 
-**Used by:** MonitorDetail, EventDetail, ZmsEventPlayer.
+The buttons are an accessory, never the interaction itself. ``useZoomPan``
+binds wheel zoom, pinch, drag-to-pan, and arrow-key pan to the ``ref``
+container through ``@use-gesture``, whose binding effect runs on every render
+and reads the ref as it goes. ``ref`` is therefore a callback ref that also
+stores the node in state: a container rendered through a portal (the frame
+viewer in ``EventFrameCarousel``) is absent on the first commit, and without
+that re-render the gestures would never bind, leaving a view where the buttons
+work and nothing else does (refs #272).
+
+**Used by:** MonitorDetail, EventDetail, ZmsEventPlayer, EventFrameCarousel.
 
 PullToRefreshIndicator (``components/ui/pull-to-refresh-indicator.tsx``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -51,7 +51,7 @@ Tap an event to open the event detail view, which includes:
 
 Above the player is a strip of the significant still frames ZoneMinder keeps for the event: the alarm frame, the snapshot, and the annotated object-detection image if machine learning wrote one. Only the frames the server actually has appear, so an event without object detection shows two entries and an event with no stored stills shows no strip at all.
 
-Tap a frame to see it full size. Pinch or use the zoom buttons to inspect detail. Playback stops while the image is open and resumes when you close it, unless you had already paused it.
+Tap a frame to see it full size. Pinch, scroll the mouse wheel, or use the zoom buttons to magnify it, then drag to move around the image, the same as on the live monitor view. Playback stops while the image is open and resumes when you close it, unless you had already paused it.
 
 Tap the strip's header to collapse or expand it. That choice is remembered for the next event you open.
 


### PR DESCRIPTION
Follow-up to #272, reported by @pliablepixels: the full-size frame viewer had working zoom buttons and dead gestures. No pinch, no wheel zoom, no drag-to-pan, unlike the live monitor view which has buttons *and* gestures.

## Cause

`useZoomPan` binds its gestures through `useGesture({ target: containerRef })`. `@use-gesture` binds from `React.useEffect(ctrl.effect)` with no dependency array: it re-binds on every render and reads `ref.current` as it runs.

The viewer renders inside a Radix dialog, i.e. a portal, whose DOM arrives in a later commit driven by the portal's own render, not the viewer's. So when the viewer's effects ran the ref was still `null`, the binding found no element, and nothing re-rendered the viewer afterwards to retry. Every other consumer (MonitorDetail, EventDetail, ZmsEventPlayer) has its node on the first commit, which is why only the overlay was affected. The same gap also skipped the container's `touch-action: none` and native-drag suppression.

## Fix

`useZoomPan` returns a callback ref that stores the node in state alongside the ref, so the node's arrival triggers a render and the binding effect finds it. The two container effects key off that state value for the same reason. One hook change; no call site had to change.

Also silences the Radix `aria-describedby` warning the viewer was logging.

## Verification

- New regression test: wheel over the open viewer scales the image. It fails on `main` (transform stays empty) and passes here.
- `npm test` — 2923 passed, 2 skipped
- `npx tsc -b`, `npm run build` — clean
- `npm run test:e2e -- monitor-detail.feature --grep zoom` — 2 passed, so the callback ref did not regress live-monitor zoom or pan
- `npm run test:e2e -- events.feature --grep "frames carousel"` — 1 passed
- The PTZ scenario in `monitor-detail.feature` fails on this branch and on a clean tree alike: the test server's monitors are not controllable
- Touch gestures on a real device are a manual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)