### PR TITLE
feat(events): lead the frame carousel with the objdetect image

### DIFF
--- a/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
+++ b/app/src/components/events/__tests__/EventFrameCarousel.test.tsx
@@ -37,6 +37,20 @@ describe('EventFrameCarousel', () => {
     expect(objdetect).toContain('eid=4242');
   });
 
+  it('orders the thumbnails objdetect, alarm, snapshot', () => {
+    renderCarousel();
+
+    const order = Array.from(
+      screen.getByTestId('event-frames-card').querySelectorAll('[data-testid^="event-frame-thumb-"]')
+    ).map((el) => el.getAttribute('data-testid'));
+
+    expect(order).toEqual([
+      'event-frame-thumb-objdetect',
+      'event-frame-thumb-alarm',
+      'event-frame-thumb-snapshot',
+    ]);
+  });
+
   it('skips the alarm frame when the event has none', () => {
     renderCarousel({ hasAlarmFrame: false });
 

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -300,11 +300,13 @@ export const EVENT_SEEK_FLUSH_DELAY_MS = 400;
 
 /**
  * Significant frames ZoneMinder can serve for an event (issue #272), in the
- * order the event frame carousel shows them. ZoneMinder has no API that reports
- * which of these exist for a given event, so the carousel renders each one and
- * drops the ones whose image fails to load.
+ * order the event frame carousel shows them: most informative first, so the
+ * annotated detection image leads, then the frame that triggered the alarm,
+ * then the plain snapshot. ZoneMinder has no API that reports which of these
+ * exist for a given event, so the carousel renders each one and drops the ones
+ * whose image fails to load.
  */
-export const EVENT_FRAME_TYPES = ['alarm', 'snapshot', 'objdetect'] as const;
+export const EVENT_FRAME_TYPES = ['objdetect', 'alarm', 'snapshot'] as const;
 
 /** Width requested for carousel thumbnails, in pixels. */
 export const EVENT_FRAME_THUMB_WIDTH = 240;

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -594,7 +594,8 @@ EventFrameCarousel
 
 Strip of the significant still frames for an event, rendered above the player in
 ``EventDetail`` (refs #272). The candidates are ``EVENT_FRAME_TYPES``
-(``lib/zmninja-ng-constants.ts``): ``alarm``, ``snapshot``, ``objdetect``. Each
+(``lib/zmninja-ng-constants.ts``), rendered in that array's order, most
+informative first: ``objdetect``, ``alarm``, ``snapshot``. Each
 one becomes a thumbnail through ``getEventImageUrl`` at
 ``EVENT_FRAME_THUMB_WIDTH`` (240 px), and the full-size viewer requests the same
 URL without a width.

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -607,7 +607,7 @@ MJPEG player.
    · → :doc:`05-component-architecture`
 
 #. **The still frames above the player.** ``EventFrameCarousel`` renders the
-   alarm, snapshot, and objdetect frames as thumbnails. ZoneMinder reports no
+   objdetect, alarm, and snapshot frames as thumbnails, in that order. ZoneMinder reports no
    list of which ones exist, so each is requested and any whose image errors
    removes itself; when all of them error the card disappears. Opening one calls
    ``onViewerOpenChange``, and ``EventDetail`` pauses the Video.js player it kept

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -49,7 +49,7 @@ Tap an event to open the event detail view, which includes:
 
 ### Event Frames
 
-Above the player is a strip of the significant still frames ZoneMinder keeps for the event: the alarm frame, the snapshot, and the annotated object-detection image if machine learning wrote one. Only the frames the server actually has appear, so an event without object detection shows two entries and an event with no stored stills shows no strip at all.
+Above the player is a strip of the significant still frames ZoneMinder keeps for the event, in order: the annotated object-detection image if machine learning wrote one, the alarm frame, then the snapshot. Only the frames the server actually has appear, so an event without object detection shows two entries and an event with no stored stills shows no strip at all.
 
 Tap a frame to see it full size. Pinch or use the zoom buttons to inspect detail. Playback stops while the image is open and resumes when you close it, unless you had already paused it.
 


### PR DESCRIPTION
Work for #272, requested by @pliablepixels.

Reorders `EVENT_FRAME_TYPES` so the strip reads most informative first: `objdetect`, `alarm`, `snapshot`. Everything else is unchanged — frames the server does not have still drop themselves, so an event without object detection simply starts at the alarm frame.

Test asserts the rendered DOM order, so a future edit to the array cannot silently reshuffle the UI.

## Verification

- `npm test` — 2923 passed, 2 skipped
- `npx tsc -b`, `npx eslint` on the changed files, `npm run build` — all clean

Docs updated: user guide events page, `05-component-architecture.rst`, Flow 5 in `call-flows.rst`.

Branches off `main`, so it does not depend on #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)