### PR TITLE
refactor(events): drop the ZMS alarm-frame thumbnail

### DIFF
--- a/app/src/components/events/ZmsEventPlayer.tsx
+++ b/app/src/components/events/ZmsEventPlayer.tsx
@@ -625,59 +625,33 @@ export function ZmsEventPlayer({
         )}
       </Card>
 
-      {/* Alarm Frames Timeline */}
-      {alarmFrames > 0 && alarmFrameId && (
+      {/* Max score frame. The first alarm frame is no longer shown here: the
+          event frame carousel above the player already leads with it (refs
+          #272), and the quick-jump button above still seeks to it. */}
+      {maxScoreFrameId && maxScoreFrameId !== alarmFrameId && (
         <Card className="p-4 mt-4">
-          <h3 className="text-sm font-semibold mb-3">{t('event_detail.alarm_frames')}</h3>
-          <div className="flex gap-2 overflow-x-auto pb-2">
-            {/* First alarm frame */}
-            <button
-              type="button"
-              className="flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={jumpToAlarmFrame}
-              data-testid="zms-jump-to-alarm-frame"
-            >
-              <img
-                src={isAccessTokenFresh ? getEventImageUrl(portalUrl, eventId, parseInt(alarmFrameId), {
-                  token,
-                  width: 120,
-                  apiUrl,
-                  minStreamingPort,
-                  monitorId,
-                }) : undefined}
-                alt={t('event_detail.first_alarm_frame')}
-                className="w-30 h-20 object-cover rounded border-2 border-destructive"
-              />
-              <p className="text-xs text-center mt-1 text-muted-foreground">
-                {t('event_detail.frame')} {alarmFrameId}
-              </p>
-            </button>
-
-            {/* Max score frame if different from alarm frame */}
-            {maxScoreFrameId && maxScoreFrameId !== alarmFrameId && (
-              <button
-                type="button"
-                className="flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={jumpToMaxScoreFrame}
-                data-testid="zms-jump-to-max-score-frame"
-              >
-                <img
-                  src={isAccessTokenFresh ? getEventImageUrl(portalUrl, eventId, parseInt(maxScoreFrameId), {
-                    token,
-                    width: 120,
-                    apiUrl,
-                    minStreamingPort,
-                    monitorId,
-                  }) : undefined}
-                  alt={t('event_detail.max_score_frame')}
-                  className="w-30 h-20 object-cover rounded border-2 border-yellow-500"
-                />
-                <p className="text-xs text-center mt-1 text-muted-foreground">
-                  {t('event_detail.frame')} {maxScoreFrameId}
-                </p>
-              </button>
-            )}
-          </div>
+          <h3 className="text-sm font-semibold mb-3">{t('event_detail.max_score_frame')}</h3>
+          <button
+            type="button"
+            className="cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={jumpToMaxScoreFrame}
+            data-testid="zms-jump-to-max-score-frame"
+          >
+            <img
+              src={isAccessTokenFresh ? getEventImageUrl(portalUrl, eventId, parseInt(maxScoreFrameId), {
+                token,
+                width: 120,
+                apiUrl,
+                minStreamingPort,
+                monitorId,
+              }) : undefined}
+              alt={t('event_detail.max_score_frame')}
+              className="w-30 h-20 object-cover rounded border-2 border-yellow-500"
+            />
+            <p className="text-xs text-center mt-1 text-muted-foreground">
+              {t('event_detail.frame')} {maxScoreFrameId}
+            </p>
+          </button>
         </Card>
       )}
     </div>

--- a/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
+++ b/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
@@ -167,6 +167,28 @@ describe('ZmsEventPlayer', () => {
     expect(callsForCommand('2')).toHaveLength(0);
   });
 
+  // The frame carousel above the player owns the alarm-frame thumbnail now
+  // (refs #272); only the quick-jump button remains here for seeking to it.
+  it('shows no alarm-frame thumbnail, only the quick-jump button', () => {
+    render(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={5} alarmFrameId="10" maxScoreFrameId="20" eventLength={10} />
+    );
+
+    expect(screen.queryByTestId('zms-jump-to-alarm-frame')).toBeNull();
+    expect(screen.getByTestId('zms-quick-jump-alarm-frame')).toBeTruthy();
+    expect(screen.getByTestId('zms-jump-to-max-score-frame')).toBeTruthy();
+  });
+
+  it('drops the max-score card when it is the same frame as the alarm', () => {
+    render(
+      <ZmsEventPlayer portalUrl="https://zm.test" eventId="42" token="tok" totalFrames={100}
+        alarmFrames={5} alarmFrameId="10" maxScoreFrameId="10" eventLength={10} />
+    );
+
+    expect(screen.queryByTestId('zms-jump-to-max-score-frame')).toBeNull();
+  });
+
   it('stops at the event end instead of requesting a ZMS replay loop', () => {
     renderPlayer();
 

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -289,7 +289,6 @@
     "playback_speed": "Wiedergabegeschwindigkeit",
     "first_alarm_frame": "Erstes Alarm-Frame",
     "max_score_frame": "Frame mit Höchstwertung",
-    "alarm_frames": "Alarm-Frames",
     "alarm_frames_count": "{{count}} von {{total}} Frames mit Alarm",
     "alarm_frame_marker": "Alarm-Frame {{frameId}}",
     "max_score_marker": "Max Score Frame {{frameId}}",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -289,7 +289,6 @@
     "playback_speed": "Playback Speed",
     "first_alarm_frame": "First Alarm Frame",
     "max_score_frame": "Max Score Frame",
-    "alarm_frames": "Alarm Frames",
     "alarm_frames_count": "{{count}} of {{total}} frames alarmed",
     "alarm_frame_marker": "Alarm Frame {{frameId}}",
     "max_score_marker": "Max Score Frame {{frameId}}",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -289,7 +289,6 @@
     "playback_speed": "Velocidad de Reproducción",
     "first_alarm_frame": "Primer Fotograma de Alarma",
     "max_score_frame": "Fotograma de Máxima Puntuación",
-    "alarm_frames": "Fotogramas de Alarma",
     "alarm_frames_count": "{{count}} de {{total}} fotogramas con alarma",
     "alarm_frame_marker": "Fotograma de Alarma {{frameId}}",
     "max_score_marker": "Fotograma de Máxima Puntuación {{frameId}}",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -289,7 +289,6 @@
     "playback_speed": "Vitesse de Lecture",
     "first_alarm_frame": "Première Image d'Alarme",
     "max_score_frame": "Image Score Maximum",
-    "alarm_frames": "Images d'Alarme",
     "alarm_frames_count": "{{count}} sur {{total}} images avec alarme",
     "alarm_frame_marker": "Image d'Alarme {{frameId}}",
     "max_score_marker": "Image Score Maximum {{frameId}}",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -289,7 +289,6 @@
     "playback_speed": "播放速度",
     "first_alarm_frame": "首个报警帧",
     "max_score_frame": "最高分数帧",
-    "alarm_frames": "报警帧",
     "alarm_frames_count": "{{total}}帧中有{{count}}个报警帧",
     "alarm_frame_marker": "报警帧 {{frameId}}",
     "max_score_marker": "最高分数帧 {{frameId}}",

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -555,7 +555,11 @@ dependency would re-run the effect on every ordinary play/pause.
 The player exposes transport controls (start, seek back 5s, play / pause, seek
 forward 5s, end), speed presets (0.25x, 0.5x, 1x, 2x, 4x), a frame-position
 scrubber with alarm-frame markers, and jump buttons for the first alarm frame
-and the max-score frame. Playback position is tracked by polling
+and the max-score frame. Below the player sits a thumbnail for the max-score
+frame, shown only when that frame differs from the alarm frame. The alarm frame
+had a thumbnail here too until ``EventFrameCarousel`` began leading with it
+above the player (refs #272); the quick-jump button still seeks to it, so
+nothing was lost with the picture. Playback position is tracked by polling
 ``ZMS_COMMANDS.cmdQuery`` (``lib/zm/zm-constants.ts``) through
 ``getZmsControlUrl`` at the bandwidth-aware ``zmsStatusInterval``; the poll
 shares an ``AbortController`` with its in-flight ``httpGet`` calls so unmount


### PR DESCRIPTION
Work for #272, requested by @pliablepixels.

The frame carousel above the player already shows the alarm frame, so the thumbnail at the bottom of the ZMS player was the same picture a second time. Removed it. The quick-jump button above (`zms-quick-jump-alarm-frame`) still seeks playback to that frame, so no capability was lost with the picture.

What is left below the player is the max-score frame, and only when it differs from the alarm frame. The card previously rendered whenever the event had an alarm frame, and its heading read "Alarm Frames" for what is now a single max-score thumbnail, so the gate and the heading both moved to that frame. The orphaned `event_detail.alarm_frames` string is removed from all five locales.

## Verification

- Two new tests: the alarm thumbnail is gone while the quick-jump button remains, and the max-score card does not render when both frames are the same
- `npm test` — 2924 passed, 2 skipped
- `npx tsc -b`, `npm run lint:a11y`, `npm run build` — clean
- `npm run test:e2e -- events.feature` — 21 passed. The archive scenario is flaky on this server (it toggles persistent state) and passes on retry; it failed the same way before this change
- Not verified on device: the ZMS player on iOS/Android is a manual check

Branches off `main`, independent of #277 and #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)