### PR TITLE
fix(notifications): recover the websocket without a manual Connect

### DIFF
--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -198,6 +198,12 @@ export const NOTIFICATIONS_SERVICE = {
   // Delay before the first ES-mode auto-connect attempt, to let profile/auth
   // store rehydration finish (ms)
   autoConnectInitDelayMs: 500,
+
+  // Ceiling for the reconnect backoff while the app is in the foreground (ms).
+  // Backgrounded, the backoff is free to climb to its 2 minute cap; in the
+  // foreground the user is watching a disconnected badge, so retries stay
+  // frequent enough to recover on their own (refs #274).
+  foregroundMaxReconnectDelayMs: 15000,
 } as const;
 
 /**

--- a/app/src/services/__tests__/notifications.test.ts
+++ b/app/src/services/__tests__/notifications.test.ts
@@ -127,6 +127,9 @@ describe('ZMNotificationService', () => {
     service.disconnect();
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    // Tests that force a hidden document define an own property over jsdom's
+    Reflect.deleteProperty(document, 'visibilityState');
   });
 
   /** Helper: connect and authenticate */
@@ -212,6 +215,45 @@ describe('ZMNotificationService', () => {
       // Might or might not have fired due to jitter, but advance more to be sure
       await vi.advanceTimersByTimeAsync(5000);
       expect(vi.mocked(wsCtor).mock.calls.length).toBeGreaterThanOrEqual(4);
+    });
+
+    // Backoff without jitter: 2s, 4s, 8s, then 15s foregrounded / 16s hidden.
+    async function climbToFourthDelay() {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5); // no jitter
+      await connectAndAuth();
+
+      for (const delay of [2000, 4000, 8000]) {
+        wsCtor.instances[wsCtor.instances.length - 1]._triggerClose(false, 1006);
+        await vi.advanceTimersByTimeAsync(delay);
+      }
+      expect(wsCtor).toHaveBeenCalledTimes(4);
+      wsCtor.instances[3]._triggerClose(false, 1006);
+    }
+
+    // Resume fires one immediate retry. When that one fails, which is normal
+    // right after a wake, nothing else re-triggers while the app stays open,
+    // so the ladder must not climb toward the two minute cap (refs #274).
+    it('caps the reconnect backoff while the app is in the foreground', async () => {
+      await climbToFourthDelay();
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(wsCtor).toHaveBeenCalledTimes(5);
+    });
+
+    it('lets the backoff climb past the foreground cap while hidden', async () => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+
+      await climbToFourthDelay();
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(wsCtor).toHaveBeenCalledTimes(4);
+
+      // The full 16s exponential delay, not the foreground ceiling
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(wsCtor).toHaveBeenCalledTimes(5);
     });
 
     it('reconnectNow triggers immediate reconnect', async () => {
@@ -315,6 +357,50 @@ describe('ZMNotificationService', () => {
       ws._triggerClose(false, 1006);
       await vi.advanceTimersByTimeAsync(3000);
 
+      expect(wsCtor).toHaveBeenCalledTimes(2);
+    });
+
+    // Suspending the app kills the socket while the WebView's timers are
+    // frozen, so this timeout routinely fires on an already-CLOSED socket.
+    // close() on it emits no event, so nothing but the timeout can retry.
+    it('retries when the auth timeout finds the socket already closed', async () => {
+      const connectPromise = service.connect(testConfig);
+      const ws = wsCtor.instances[0];
+      ws._triggerOpen();
+
+      // Peer went away during suspension: closed, with no close event delivered
+      ws.readyState = MockWebSocket.CLOSED;
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      await connectPromise;
+
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(wsCtor).toHaveBeenCalledTimes(2);
+    });
+
+    // reconnectNow drops the socket without routing through _handleClose, so
+    // it must settle the pending auth too: the abandoned 20s timeout would
+    // otherwise close the healthy replacement socket (refs #274).
+    it('does not let an abandoned auth timeout close the replacement socket', async () => {
+      const connectPromise = service.connect(testConfig);
+      wsCtor.instances[0]._triggerOpen();
+
+      // 5s in, a resume forces a fresh attempt that authenticates
+      await vi.advanceTimersByTimeAsync(5000);
+      service.reconnectNow(true);
+      const replacement = wsCtor.instances[1];
+      replacement._triggerOpen();
+      replacement._triggerMessage({ event: 'auth', status: 'Success', version: '1.0' });
+
+      // The abandoned attempt settles without reporting over the live one
+      await connectPromise;
+      expect(service.getState()).toBe('connected');
+
+      // Past the abandoned attempt's 20s auth timeout
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(service.getState()).toBe('connected');
+      expect(replacement.readyState).toBe(MockWebSocket.OPEN);
       expect(wsCtor).toHaveBeenCalledTimes(2);
     });
   });

--- a/app/src/services/notifications.ts
+++ b/app/src/services/notifications.ts
@@ -8,7 +8,7 @@
  */
 
 import { log, LogLevel } from '../lib/logger';
-import { getBandwidthSettings } from '../lib/zmninja-ng-constants';
+import { getBandwidthSettings, NOTIFICATIONS_SERVICE } from '../lib/zmninja-ng-constants';
 
 import type {
   ZMEventServerConfig,
@@ -48,6 +48,8 @@ export class ZMNotificationService {
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private pendingAuth: PendingAuth | null = null;
   private intentionalDisconnect = false;
+  /** Bumped per connect attempt so an abandoned attempt's async tail can bail. */
+  private connectGeneration = 0;
 
   // Event listeners
   private eventCallbacks: Set<NotificationEventCallback> = new Set();
@@ -89,13 +91,7 @@ export class ZMNotificationService {
     log.notifications('Disconnecting from notification server', LogLevel.INFO);
     this.intentionalDisconnect = true;
     this._clearTimers();
-
-    // Reject pending auth
-    if (this.pendingAuth) {
-      clearTimeout(this.pendingAuth.timeout);
-      this.pendingAuth.reject(new Error('Connection closed'));
-      this.pendingAuth = null;
-    }
+    this._rejectPendingAuth(new Error('Connection closed'));
 
     // Close WebSocket
     if (this.ws) {
@@ -327,6 +323,7 @@ export class ZMNotificationService {
       throw new Error('No configuration provided');
     }
 
+    const generation = ++this.connectGeneration;
     this._setState('connecting');
 
     const protocol = this.config.ssl ? 'wss' : 'ws';
@@ -377,6 +374,14 @@ export class ZMNotificationService {
       // Wait for authentication to complete
       await this._waitForAuth();
     } catch (error) {
+      // A newer attempt already took over (reconnectNow settles the abandoned
+      // one so its auth timeout cannot outlive it). Its socket owns the state
+      // now, so this tail must not report an error over it (refs #274).
+      if (generation !== this.connectGeneration) {
+        log.notifications('Abandoned connection attempt failed, newer attempt in progress', LogLevel.INFO, { error });
+        return;
+      }
+
       log.notifications('Failed to connect to notification server', LogLevel.ERROR, error);
       this._setState('error');
       // Don't throw: let _handleClose schedule reconnect for transport failures.
@@ -438,12 +443,7 @@ export class ZMNotificationService {
           const error = new Error(`Authentication failed: ${message.reason || 'Unknown'}`);
           log.notifications('Authentication failed', LogLevel.ERROR, error);
           this._setState('error');
-
-          if (this.pendingAuth) {
-            clearTimeout(this.pendingAuth.timeout);
-            this.pendingAuth.reject(error);
-            this.pendingAuth = null;
-          }
+          this._rejectPendingAuth(error);
 
           this.disconnect();
         }
@@ -506,13 +506,7 @@ export class ZMNotificationService {
 
     this.ws = null;
     this._clearTimers();
-
-    // Reject pending auth if still waiting
-    if (this.pendingAuth) {
-      clearTimeout(this.pendingAuth.timeout);
-      this.pendingAuth.reject(new Error('Connection closed during authentication'));
-      this.pendingAuth = null;
-    }
+    this._rejectPendingAuth(new Error('Connection closed during authentication'));
 
     this._setState('disconnected');
 
@@ -528,9 +522,17 @@ export class ZMNotificationService {
 
     this.reconnectAttempts++;
 
-    // Exponential backoff: 2s, 4s, 8s, 16s, ... capped at maxReconnectDelay
+    // Exponential backoff: 2s, 4s, 8s, 16s, ... capped at maxReconnectDelay.
+    // A foregrounded app uses a much lower ceiling: the resume handler fires a
+    // single immediate retry, and when that one fails (common right after a
+    // wake, while the network is still coming back) nothing re-triggers it, so
+    // the user watched a disconnected badge for up to two minutes and tapped
+    // Connect instead (refs #274).
     const exponentialDelay = this.baseReconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-    const cappedDelay = Math.min(exponentialDelay, this.maxReconnectDelay);
+    const maxDelay = this._isForeground()
+      ? NOTIFICATIONS_SERVICE.foregroundMaxReconnectDelayMs
+      : this.maxReconnectDelay;
+    const cappedDelay = Math.min(exponentialDelay, maxDelay);
     // Add jitter: ±25% to prevent thundering herd
     const jitter = cappedDelay * 0.25 * (Math.random() * 2 - 1);
     const delay = Math.round(cappedDelay + jitter);
@@ -570,12 +572,16 @@ export class ZMNotificationService {
 
     // Drop the stale socket before reconnecting. `this.ws` is cleared first so
     // the close event fails the handler's identity guard: _handleClose must not
-    // schedule a competing reconnect on top of the one starting here.
+    // schedule a competing reconnect on top of the one starting here. That guard
+    // also skips the pending-auth cleanup _handleClose would have done, so do it
+    // here: _waitForAuth overwrites `pendingAuth`, and an orphaned timeout would
+    // later close the healthy socket this call is about to open (refs #274).
     if (this.ws) {
       const stale = this.ws;
       this.ws = null;
       stale.close();
     }
+    this._rejectPendingAuth(new Error('Connection replaced by reconnect'));
 
     // Cancel any pending scheduled reconnect and the keepalive of the old socket
     this._clearTimers();
@@ -586,6 +592,26 @@ export class ZMNotificationService {
     this._connect().catch((error) => {
       log.notifications('Immediate reconnect failed', LogLevel.ERROR, error);
     });
+  }
+
+  /**
+   * Settle a connect() promise still waiting on auth and drop its timeout.
+   * Every path that abandons a socket must call this: a surviving timeout
+   * fires against whatever socket is current 20 seconds later.
+   */
+  private _rejectPendingAuth(error: Error): void {
+    if (!this.pendingAuth) return;
+    clearTimeout(this.pendingAuth.timeout);
+    this.pendingAuth.reject(error);
+    this.pendingAuth = null;
+  }
+
+  /**
+   * Whether the app is on screen. Mobile resume and tab focus both surface
+   * here: a hidden WebView reports 'hidden' and has its timers throttled.
+   */
+  private _isForeground(): boolean {
+    return typeof document === 'undefined' || document.visibilityState !== 'hidden';
   }
 
   private _clearTimers(): void {
@@ -660,7 +686,18 @@ export class ZMNotificationService {
         // guarded by `this.ws !== ws`, so nulling it here would make the close
         // event skip _handleClose and no reconnect would ever be scheduled
         // (refs #274). _handleClose nulls it.
-        this.ws?.close();
+        //
+        // Unless the socket is already gone. Suspending the app kills the
+        // connection while the WebView's timers are frozen, so this timeout
+        // routinely fires on a socket that is already CLOSED, and close() on it
+        // emits no event: _handleClose never runs, and the catch in _connect
+        // sees a non-null `this.ws` and does not retry either. Nulling it here
+        // hands that catch the retry (refs #274).
+        if (this.ws && this.ws.readyState === WebSocket.CLOSED) {
+          this.ws = null;
+        } else {
+          this.ws?.close();
+        }
 
         reject(new Error('Authentication timeout (20 seconds)'));
       }, 20000);

--- a/docs/developer-guide/11-application-lifecycle.rst
+++ b/docs/developer-guide/11-application-lifecycle.rst
@@ -205,8 +205,11 @@ values are given.
    (``services/notifications.ts``) sends a version-request ping every
    ``wsKeepaliveInterval`` (60s / 120s) to maintain the connection. On
    disconnection, it reconnects automatically using exponential backoff with
-   jitter (2s, 4s, 8s, ... capped at ``maxReconnectDelay``, 2 minutes, plus or
-   minus 25%). An ``intentionalDisconnect`` flag ensures only
+   jitter (2s, 4s, 8s, ... plus or minus 25%). The cap depends on whether the
+   app is on screen: ``maxReconnectDelay`` (2 minutes) while the document is
+   hidden, ``NOTIFICATIONS_SERVICE.foregroundMaxReconnectDelayMs`` (15 seconds)
+   while it is visible, so a user watching a disconnected badge is not left
+   waiting on a two-minute timer. An ``intentionalDisconnect`` flag ensures only
    user-initiated disconnects stop reconnection; network drops always
    retry. On mobile, ``@capacitor/network`` triggers immediate reconnect
    when connectivity is restored. On desktop, a ``visibilitychange``
@@ -260,7 +263,9 @@ When the user re-opens the app:
   as dead and a forced reconnect is triggered: the socket still reads as open,
   so an ordinary ``reconnectNow()`` would decline (refs #274). When the store
   already reads disconnected, resume skips the ping and reconnects immediately
-  rather than waiting on a backoff timer that the suspended WebView froze.
+  rather than waiting on a backoff timer that the suspended WebView froze. That
+  resume nudge is a single attempt: when it fails, the foreground backoff cap
+  above is what retries.
 - **Badge Clear**: ``useNotificationDelivered`` listens for ``appStateChange``,
   ingests any notifications delivered while backgrounded into the history
   store, then clears the native badge via

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -781,12 +781,14 @@ alive, and turns each live alarm into an event in the store and a toast on scree
    · → :doc:`12-shared-services-and-components`
 
 #. **Reconnect with backoff.** On an unintended close, ``_scheduleReconnect`` waits
-   an exponential, jittered delay (capped at two minutes); ``reconnectNow`` jumps
-   the queue on network-restored and on app resume. Resume matters more than it
-   looks: a suspended WebView freezes that timer, so without the resume nudge the
-   app can sit disconnected for the full two-minute cap after a phone unlock.
-   ``reconnectNow(true)`` additionally replaces a socket that still reads as open
-   but failed its liveness ping (refs #274).
+   an exponential, jittered delay, capped at two minutes while the document is
+   hidden and at ``foregroundMaxReconnectDelayMs`` (15 seconds) while it is not.
+   The lower ceiling is what keeps a visible app recovering on its own: resume
+   fires a single immediate retry, and if that one attempt fails, which is common
+   while a woken device is still bringing its network up, nothing re-triggers it
+   (refs #274). ``reconnectNow`` jumps the queue on network-restored and on app
+   resume; ``reconnectNow(true)`` additionally replaces a socket that still reads
+   as open but failed its liveness ping.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/services/notifications.ts#L518>`__
    · → :doc:`12-shared-services-and-components`
 


### PR DESCRIPTION
Claude here, assisting @pliablepixels.

Follow-up to #276 for #274. Three remaining ways the socket stayed down until the user tapped Connect.

**Foreground backoff cap.** Resume fires a single immediate retry. When that one attempt fails, which is common while a woken device is still bringing its network up, nothing re-triggers it and the ladder climbs toward the two-minute cap. The cap is now `NOTIFICATIONS_SERVICE.foregroundMaxReconnectDelayMs` (15s) while the document is visible; hidden keeps the two-minute cap. This is the one that matches the reported symptom: badge stuck on disconnected, manual Connect instant.

**Auth timeout on an already-closed socket.** The 20s timeout closed the socket and left `this.ws` set so the close event would route through `_handleClose`. Suspension kills the connection while the WebView's timers are frozen, so the timeout routinely fires on a socket that is already `CLOSED`, and `close()` on one of those emits no event. `_handleClose` never ran, and the catch in `_connect` skipped the retry because `this.ws` was non-null. The timeout now drops the reference when the socket is already gone, and the catch schedules.

**Orphaned pending auth.** `reconnectNow` drops its socket without routing through `_handleClose`, which also skipped the pending-auth cleanup, so `_waitForAuth` overwrote `pendingAuth` and the orphaned timeout closed the healthy replacement socket 20s later. Now settled through a shared helper used by all four call sites. Settling it early means the abandoned attempt's catch runs after a newer one started, so `_connect` tracks a generation and an abandoned tail no longer reports an error over a live connection.

Why this did not reproduce on the maintainer's setup: same code, different odds on attempt #1. A plaintext LAN `ws://` connect completes before the radio is fully back; a `wss://` handshake to a remote or proxied host is far more likely to fail in that window, and it is also more likely to sit long enough to hit the 20s auth timeout.

## Verification

- `npm test` — 2936 passed, 1 file skipped
- `npx tsc -b` — no errors
- `npm run build` — clean
- `npm run lint:a11y` — clean
- 4 new tests, each confirmed failing against the pre-fix service

Android and iOS resume are manual checks, so a device confirmation on the next test build is still what closes this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)