### PR TITLE
test(agents): word budget 2000; orchestration guidance

### DIFF
--- a/agents/generic/claude-workflows.md
+++ b/agents/generic/claude-workflows.md
@@ -8,10 +8,11 @@ above before trusting specifics.
 
 ## Scale ceremony to risk
 
-Multi-agent process below pays off on multi-task plans, refactors with blast
-radius, and anything touching contracts. It does not pay off on small
-bounded changes: for a one-file fix with a covering test, work inline, run
-the gates, commit. Evidence from the restructure run: reviews of mechanical
+What scales with risk is review ceremony, not delegation: implementation
+goes through a subagent either way, but a one-file fix with a covering
+test needs no independent reviewer, while multi-task plans, refactors with
+blast radius, and contract changes do. Evidence from the restructure run:
+reviews of mechanical
 transcription tasks found zero defects; reviews of judgment work (doc
 remapping, whole-branch review) found every real one. Review where judgment
 lives; skip where the gate already proves the result. The final whole-branch
@@ -19,6 +20,19 @@ review before a PR is the one step never skipped. Agent count is a cost,
 never a quality signal: prefer the fewest dispatches that produce the
 evidence, and let the harness parallelize instead of choreographing a
 named fleet.
+
+## Orchestration
+
+- The orchestrator (the main session, or a team lead coordinating others)
+  runs on Opus 4.8 or newer; never a smaller model. Coordination quality
+  bounds everything downstream: a weak orchestrator writes weak briefs,
+  misreads reports, and wastes every strong agent under it.
+- Implementation always delegates to subagents, even for small changes.
+  The orchestrator's context stays clean for briefs, report verdicts, and
+  review decisions; an orchestrator that edits files skips its own review
+  structure.
+- Let the harness decide how many agents run and when they parallelize.
+  Choose what each dispatch is for; do not choreograph counts.
 
 ## Multi-agent execution
 

--- a/app/src/tests/agents-contracts.test.ts
+++ b/app/src/tests/agents-contracts.test.ts
@@ -106,7 +106,7 @@ describe('AGENTS.md stays portable', () => {
     // Claude-only shim). Raising this budget is a deliberate act that needs
     // a reason in the commit message, like the lint ratchet (C7). Lowering
     // it is always welcome.
-    const WORD_BUDGET = 1650;
+    const WORD_BUDGET = 2000;
     const words = (f: string) =>
       fs.readFileSync(path.join(repoRoot, f), 'utf8').split(/\s+/).filter(Boolean).length;
     const total = words('AGENTS.md') + words('AGENTS.project.md') + words('CLAUDE.md');

--- a/docs/developer-guide/14-agent-development-model.rst
+++ b/docs/developer-guide/14-agent-development-model.rst
@@ -31,10 +31,10 @@ full commit history; rule M5 requires the same of every future session.
 Multi-agent ceremony is treated as a cost, not as evidence of rigor.
 Dispatching ten agents at a change looks thorough, but every dispatch
 re-reads the same context, and in practice, agent reviews of mechanical
-work here found nothing that the gates had not already proven. Independent
-agent review is reserved for work that needs judgment, plus one
-whole-branch review before every PR. For a small bounded change, working
-inline and letting the gates run is the normal path.
+work here found nothing that the gates had not already proven. What scales
+with a change's risk is review ceremony, not delegation: independent agent
+review is reserved for work that needs judgment, plus one whole-branch
+review before every PR, while a small bounded change relies on its gates.
 
 Rules, gates, and practices
 ---------------------------


### PR DESCRIPTION
Two commits: the budget raise per maintainer (reason recorded in the commit message per the gate's rule), and orchestration guidance in the workflow playbook: orchestrator/team lead on Opus 4.8 or newer, implementation always delegated to subagents, harness decides agent count. Chapter 14 reworded to match (review ceremony scales with risk, delegation does not). refs #283

Claude assisting @pliablepixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)