### PR TITLE
docs: heading-voice gate, system diagram, contract walk-through

### DIFF
--- a/app/src/tests/agents-contracts.test.ts
+++ b/app/src/tests/agents-contracts.test.ts
@@ -138,6 +138,32 @@ describe('knowledge files stay evidence-backed and private-data-free (M5)', () =
   });
 });
 
+describe('prose stays in developer voice (P10)', () => {
+  it('no rst or agent-playbook heading starts with "The "', () => {
+    const offenders: string[] = [];
+    const guideDir = path.join(repoRoot, 'docs/developer-guide');
+    for (const file of fs.readdirSync(guideDir).filter((f) => f.endsWith('.rst'))) {
+      const lines = fs.readFileSync(path.join(guideDir, file), 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        const next = lines[i + 1] ?? '';
+        const isHeading = /^[=\-~^"]{3,}\s*$/.test(next) && next.trim().length >= line.trim().length - 2;
+        if (isHeading && /^The /.test(line)) offenders.push(`${file}:${i + 1} ${line}`);
+      });
+    }
+    for (const dir of ['agents/generic', 'agents/project']) {
+      const full = path.join(repoRoot, dir);
+      for (const file of fs.readdirSync(full).filter((f) => f.endsWith('.md'))) {
+        fs.readFileSync(path.join(full, file), 'utf8')
+          .split('\n')
+          .forEach((line, i) => {
+            if (/^#+ The /.test(line)) offenders.push(`${dir}/${file}:${i + 1} ${line}`);
+          });
+      }
+    }
+    expect(offenders, offenders.join('; ')).toEqual([]);
+  });
+});
+
 describe('developer docs reference valid rule IDs', () => {
   it('every "rule <id>" reference resolves', () => {
     // Derived from AGENTS.md so adding or removing a rule cannot desync

--- a/docs/developer-guide/02-react-fundamentals.rst
+++ b/docs/developer-guide/02-react-fundamentals.rst
@@ -7,8 +7,8 @@ first time. Written in roughly the order you need to know things.
 zmNinjaNg renders to the DOM on every platform (web, Electron desktop,
 Capacitor mobile webview). Examples below use plain HTML tags.
 
-The mental shift
-----------------
+Mental shift
+------------
 
 In a typical web stack you tell the DOM what to change:
 

--- a/docs/developer-guide/03-state-management-zustand.rst
+++ b/docs/developer-guide/03-state-management-zustand.rst
@@ -48,8 +48,8 @@ That is the whole store. ``useDeleteSelectionStore`` is both a React hook
 and an object with ``.getState()`` / ``.setState()`` on it, which is what
 makes the same store usable from non-React code later in this chapter.
 
-The ``set`` Function
-~~~~~~~~~~~~~~~~~~~~
+Writing state with ``set``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``set`` takes either an object, which merges into state, or a function
 receiving the current state. Both forms must return *new* objects and

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -856,8 +856,8 @@ reads ``isLoading``, when ``hidden`` is ``false``.
 ``monitor-recent-events-toggle``, refresh ``monitor-recent-events-refresh``,
 "All events" ``monitor-recent-events-all``, body ``monitor-recent-events-body``.
 
-The dashboard
--------------
+Dashboard
+---------
 
 DashboardWidget
 ~~~~~~~~~~~~~~~
@@ -1289,8 +1289,8 @@ on first run so a backlog present at mount does not fire a burst of invalidation
 :doc:`call-flows` traces both halves: "A push notification, from registration to
 tap" and "Live notifications over the Event Server websocket".
 
-The in-app assistant (Ask)
----------------------------
+In-app assistant (Ask)
+-----------------------
 
 Pressing ``?`` (or typing a leading ``?`` in the command palette, or its "Ask"
 item) swaps the command palette into a chat, ``AskPanel``

--- a/docs/developer-guide/14-agent-development-model.rst
+++ b/docs/developer-guide/14-agent-development-model.rst
@@ -85,6 +85,26 @@ arrived, through a PR.
 How the pieces fit
 ------------------
 
+.. mermaid::
+
+   graph TD
+     CL["CLAUDE.md<br/>(Claude Code shim)"] --> AG["AGENTS.md<br/>rules I / P / C / M"]
+     CL --> AP["AGENTS.project.md<br/>14 contracts + project rules"]
+     AG -. "read before any work" .-> AP
+     AP -- "table: read for your area" --> PP["agents/project/<br/>testing, docs, native,<br/>data-integrity, domain-context"]
+     CL -- "multi-agent work" --> GP["agents/generic/<br/>claude-workflows.md"]
+     AG === GATE["agents-contracts.test.ts<br/>symbols exist, purity, word budget,<br/>evidence hashes, privacy, doc refs, headings"]
+     AP === GATE
+     PP === GATE
+     PR["every PR"] === LG["label-guard.yml<br/>core / refactor label"]
+     PR === CI["ci.yml<br/>tests, lints, build"]
+     GATE --> CI
+     FAIL["breakage or review finding"] -- "fix PR proposes rule + gate<br/>(self-improvement protocol)" --> AG
+     FAIL -- "durable fact (M5)" --> PP
+
+Solid arrows are load order in a session; the double lines are
+enforcement; the bottom edges are the feedback loop that grows the files.
+
 `AGENTS.md <https://github.com/ZoneMinder/zmNinjaNg/blob/main/AGENTS.md>`__
 at the repo root is the portable core; it contains nothing specific to
 zmNinjaNg.
@@ -123,6 +143,49 @@ would have prevented the break (with its gate, per M1), and any durable
 fact learned along the way goes into ``domain-context.md`` (per M5). The
 maintainer ends up reviewing small instruction diffs instead of large code
 diffs, and each failure gets absorbed once.
+
+A contract, end to end
+----------------------
+
+A concrete walk-through, using the Polling contract. In
+`AGENTS.project.md <https://github.com/ZoneMinder/zmNinjaNg/blob/main/AGENTS.project.md>`__
+it reads:
+
+.. code-block:: markdown
+
+   ### Polling
+   Owns: every recurring refresh interval.
+   Path: `useBandwidthSettings` / `getBandwidthSettings` (`app/src/hooks/useBandwidthSettings.ts`).
+   Never: literal interval values; users tune bandwidth globally.
+   Gate: `app/src/tests/agents-contracts.test.ts`; review.
+
+That block is the *instruction*. An agent asked to add, say, a
+refresh-every-30-seconds feature reads it and knows three things without
+opening any source: recurring intervals belong to this subsystem, the only
+sanctioned way to get one is the two named functions, and hardcoding
+``30000`` is a bug even if it works.
+
+The *gate* is one TypeScript test file,
+`agents-contracts.test.ts <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/tests/agents-contracts.test.ts>`__,
+which runs with the normal unit suite. For this contract it parses the
+block, pulls every backticked token out of the ``Path:`` and ``Gate:``
+lines, and checks each one against reality: tokens containing a slash must
+exist as files (``app/src/hooks/useBandwidthSettings.ts``), bare tokens
+must appear as words somewhere in ``app/src``
+(``useBandwidthSettings``, ``getBandwidthSettings``). Rename or delete the
+hook without updating the contract and the suite fails with
+``Polling: symbol useBandwidthSettings not found in app/src`` until the
+contract matches the code again. That is the property the contracts
+depend on: they cannot silently rot, so an agent can trust them instead of
+re-deriving the design.
+
+What the gate cannot check, review covers: nothing mechanical proves a new
+``setInterval(30000)`` violates the ``Never:`` line, which is why the
+``Gate:`` field says ``review`` too, and why review ceremony concentrates
+on judgment. The same file carries the checks on the instruction system
+itself (core purity, word budget, evidence hashes, privacy, doc
+references, headings), so the files this chapter describes are gated by
+the same mechanism they document.
 
 Monthly scorecard review
 ------------------------

--- a/docs/developer-guide/go2rtc-integration.rst
+++ b/docs/developer-guide/go2rtc-integration.rst
@@ -78,8 +78,8 @@ demotes every tile to MJPEG on the next profile bootstrap. See
 :doc:`07-api-and-data-fetching` for the config-fetch layer and
 :doc:`11-application-lifecycle` for when bootstrap runs.
 
-The WebSocket URL and the stream name
--------------------------------------
+WebSocket URL and stream name
+-----------------------------
 
 ``getGo2RTCWebSocketUrl`` in ``lib/zm/url-builder.ts`` turns the configured path
 into a signaling URL. It takes the path, the monitor id, and a channel:
@@ -387,8 +387,8 @@ and read through the settings store. See
 ``bypassGo2rtcFailureCache`` is not a setting. It is a prop, and only
 ``MonitorDetail`` passes it.
 
-The video element
------------------
+Video element
+-------------
 
 The hook wraps ``video-rtc``'s ``oninit`` to configure the ``<video>`` the moment
 the element creates it, and wraps ``onpcvideo`` to re-apply muting after the


### PR DESCRIPTION
Per maintainer review of the published playbook: headline-style headings gated (P10, M1), six legacy headings renamed, chapter 14 gains a diagram of how the pieces engage and a worked Polling-contract example distinguishing instructions from gates. refs #283

Claude assisting @pliablepixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)