### PR TITLE
docs: LLM model playbook and assistant preamble

### DIFF
--- a/AGENTS.project.md
+++ b/AGENTS.project.md
@@ -132,6 +132,7 @@ Read each listed playbook before work in that area.
 | Developer or user documentation | `agents/project/documentation.md` |
 | Capacitor, TLS, Electron, downloads, or native paths | `agents/project/native.md` |
 | Assistant tools, WebLLM, or ZoneMinder schemas | `agents/project/data-integrity.md` |
+| Prompts, providers, or LLM model choices | `agents/project/llm-models.md` |
 | ZoneMinder APIs, streaming, or platform quirks | `agents/project/domain-context.md` |
 
 Portable playbooks live in `agents/generic/`; project ones in

--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -1,0 +1,55 @@
+# LLM model playbook
+
+Model-selection and model-behavior facts for the in-app assistant. Read
+before changing prompts, providers, tool schemas, or model defaults.
+Measured claims come from `app/scripts/prompt-eval.mts` runs (temp 0,
+2026-07) and carry issue or commit references; re-run the eval before and
+after any prompt or provider change and put both scores in the PR.
+
+## Backends
+
+- Ollama (user's own server): the recommended remote path. WebLLM runs the
+  on-device path in the browser and on Android; it is gated off on iOS
+  (WKWebView's ~2GB jetsam limit kills model load), where remote Ollama is
+  the supported path. Apple Foundation Models is the native Apple backend;
+  a broader native on-device backend is tracked in issue #270.
+
+## Measured model floor (prompt-eval, temp 0, 2026-07)
+
+- `qwen3:8b`, `qwen3:30b-a3b`, `qwen3:4b`: 33/33 native tool-calling,
+  24/24 constrained envelope. `qwen3:8b` is the recommended Ollama model.
+- `llama3.2`: 33/33 native, 21/24 envelope.
+- `qwen3:1.7b`: 21/33; below the 4b tier models fail the harness and are
+  not worth supporting.
+
+## Reasoning control
+
+- The Ollama tag `qwen3:4b` resolves to Thinking-2507, whose reasoning
+  cannot be disabled; use `qwen3:4b-instruct` when reasoning is unwanted.
+- `/no_think` in a prompt is a placebo on Ollama: it hides the tag and
+  still reasons at full latency. The real switch is
+  `reasoning_effort: "none"` on the /v1 endpoint (about 5x faster, same
+  eval scores); the adapter sends it only to confirmed-Ollama servers.
+- WebLLM disables thinking with `extra_body: { enable_thinking: false }`.
+
+## Patterns by model size
+
+- Small and on-device models ignore prompt-only guardrails. Structural
+  fixes are the ones that hold: the turn schema makes the answer branch
+  unreachable without a real tool result (4ee2bbbf), failure paths append
+  a correct-and-retry guard instead of echoing raw errors (0a720c01).
+- Small models copy phrases perfectly but fail direct field-filling: time
+  windows use copy-interpret-compute (model copies the phrase verbatim, a
+  constrained interpreter call maps it to fields, code does arithmetic);
+  measured direct fills scored 27/36 (qwen) and 15/36 (llama), refs #265.
+- Prompt classification teaches dimensions (intent by subject), never
+  instance lists; instance-based triage misclassified every combination
+  outside its examples, four times.
+- Apple Foundation Models invents tool arguments (validate before use) and
+  calls real tools on greeting turns; the first tool call on a tool-less
+  turn gets a no-tools pushback (578787dc).
+
+The code-path conduct rules behind several of these entries (tool-loop
+gating, markup parse failures, locale-gated nudges) live in
+`domain-context.md` and the Assistant tool loop contract; this file is for
+choosing and configuring models.

--- a/app/src/tests/agents-contracts.test.ts
+++ b/app/src/tests/agents-contracts.test.ts
@@ -115,7 +115,11 @@ describe('AGENTS.md stays portable', () => {
 });
 
 describe('knowledge files stay evidence-backed and private-data-free (M5)', () => {
-  const knowledgeFiles = ['agents/project/domain-context.md', 'agents/generic/claude-workflows.md'];
+  const knowledgeFiles = [
+    'agents/project/domain-context.md',
+    'agents/project/llm-models.md',
+    'agents/generic/claude-workflows.md',
+  ];
 
   it('every commit hash cited in domain-context exists in this repo', () => {
     const md = fs.readFileSync(path.join(repoRoot, 'agents/project/domain-context.md'), 'utf8');

--- a/docs/developer-guide/14-agent-development-model.rst
+++ b/docs/developer-guide/14-agent-development-model.rst
@@ -12,7 +12,17 @@ Scope, platforms, and release guardrails
 One React/TypeScript codebase ships everywhere zmNinjaNg runs: iOS and
 Android through Capacitor, macOS, Windows, and Linux through Electron, and
 the browser directly. There is no backend of our own; everything talks to
-a ZoneMinder server the user configures. That breadth is the reason the
+a ZoneMinder server the user configures. The app also ships an AI
+assistant (Ask) that answers questions about the user's cameras and
+events by calling tools against that server, on the user's choice of
+backend: their own Ollama server, on-device WebLLM, or Apple Foundation
+Models. That subsystem gets its own guardrails, because language models
+fabricate where code merely crashes: the Assistant tool loop contract
+gates whether a turn may answer at all, and two playbooks
+(`data-integrity <https://github.com/ZoneMinder/zmNinjaNg/blob/main/agents/project/data-integrity.md>`__
+and
+`llm-models <https://github.com/ZoneMinder/zmNinjaNg/blob/main/agents/project/llm-models.md>`__)
+carry the schema rules and the measured model-behavior facts. That breadth is the reason the
 guardrails exist: a change to a shared component can misbehave on five
 platforms at once, and no single machine can verify all of them. Platform
 divergence is therefore written down where agents will find it (the Native


### PR DESCRIPTION
Adds the model-behavior playbook distilled from the past week's assistant work (measured eval scores, reasoning switches, size-dependent patterns), routes prompt/provider work to it, extends the privacy gate over it, and gives the in-app assistant its place in chapter 14's scope preamble. refs #283

Claude assisting @pliablepixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)