### PR TITLE
docs: exclude superpowers dir from sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,9 @@ autosectionlabel_maxdepth = 3
 suppress_warnings = ['autosectionlabel.*', 'misc.highlighting_failure']
 
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+# superpowers/ holds internal design specs and implementation plans; they
+# are versioned for the repo, not rendered on the docs site.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'superpowers']
 
 # Source file suffixes
 source_suffix = {


### PR DESCRIPTION
Fixes the toctree warning flood from committed spec/plan markdown under docs/superpowers/. refs #283

Claude assisting @pliablepixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)