### PR TITLE
Trim the social and search descriptions

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Free open-source ZoneMinder client for iOS, Android, Windows, macOS, Linux and web. Live view, events, montage, timeline, push notifications. Rewrite of zmNinja.">
+  <meta name="description" content="Free open-source ZoneMinder client for iOS, Android, Windows, macOS, Linux and web. Live view, events, montage, timeline, push. Rewrite of zmNinja.">
   <meta name="theme-color" content="hsl(220, 20%, 12%)">
   <title>zmNinjaNg — ZoneMinder Client for iOS, Android, Windows, macOS &amp; Linux</title>
   <link rel="canonical" href="https://zmninjang.zoneminder.com/">
@@ -14,7 +14,7 @@
   <meta property="og:site_name" content="zmNinjaNg">
   <meta property="og:url" content="https://zmninjang.zoneminder.com/">
   <meta property="og:title" content="zmNinjaNg — ZoneMinder Client for Every Platform">
-  <meta property="og:description" content="Live camera view, event review, montage, timeline, push notifications and a local AI agent for ZoneMinder. Free and open source, on iOS, Android, Windows, macOS, Linux and web.">
+  <meta property="og:description" content="Live camera view, event review, montage, timeline, push notifications and a local AI agent for ZoneMinder. Free and open source.">
   <meta property="og:image" content="https://zmninjang.zoneminder.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">


### PR DESCRIPTION
Follow-up to #318, from an opengraph.xyz audit of the deployed page.

- `og:description` ran 176 characters. Discord and X show roughly 125 before truncating, so the tail was being cut. It now reuses the `twitter:description` string, which was already the right length at 128 — one string, both tags.
- The meta description drops from 161 to 147, inside where Google truncates.

Two other audit findings were left alone on purpose.

The `<title>` at 74 characters is past Google's roughly 60-character display cut. That is deliberate: the keywords are front-loaded, so truncation only clips "Windows, macOS & Linux", and the full string is still indexed and matched for long-tail queries like "zoneminder client linux". Shortening it would trade real query coverage for a tidier preview.

The audit also flagged the absence of a call-to-action on `og:image`. A "Download now" badge is brochure convention that reads as spam to the self-hosted audience this page is aimed at, and the finding is attached to the tool's own paid image service. Skipped.

## Verification

No app code is touched. Metadata-only change to the landing page, verified by hand: meta description 147, `og:description` 128, `twitter:description` 128, and the two now match.

Posted by Claude, assisting @pliablepixels.