### PR TITLE
feat: toggle analysis frames on live views

### DIFF
--- a/app/src/components/live-activity/LiveActivityChrome.tsx
+++ b/app/src/components/live-activity/LiveActivityChrome.tsx
@@ -11,6 +11,7 @@
 import { useTranslation } from 'react-i18next';
 import { Maximize, Minimize, Settings } from 'lucide-react';
 import { EventMontageGridControls } from '../events/EventMontageGridControls';
+import { AnalysisFramesToggle } from '../monitors/AnalysisFramesToggle';
 import { Button } from '../ui/button';
 
 interface LiveActivityHeaderProps {
@@ -53,6 +54,7 @@ export function LiveActivityHeader({
           onCustomGridDialogOpenChange={onCustomGridDialogOpenChange}
           onCustomGridSubmit={onCustomGridSubmit}
         />
+        <AnalysisFramesToggle />
         <Button
           variant="ghost"
           size="icon"

--- a/app/src/components/monitors/AnalysisFramesToggle.tsx
+++ b/app/src/components/monitors/AnalysisFramesToggle.tsx
@@ -1,0 +1,59 @@
+/**
+ * Toolbar toggle for ZoneMinder's analysis frames.
+ *
+ * The setting is profile-scoped and remembered, so a view that opens with it
+ * already on applies it to each stream as that stream's first frame arrives
+ * (see useAnalysisFrames). One value covers every live view: turning it on in
+ * montage leaves it on in the single-monitor view.
+ *
+ * Snapshot mode gets a disabled button rather than a hidden one. zms serves a
+ * single image straight from the capture buffer and never looks at the frame
+ * type, so the overlay is genuinely unavailable there, and a control that
+ * silently did nothing would read as a bug.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { ScanEye } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useCurrentProfile } from '../../hooks/useCurrentProfile';
+import { useSettingsStore } from '../../stores/settings';
+
+interface AnalysisFramesToggleProps {
+  className?: string;
+  /**
+   * Set by views that stream regardless of the profile's Streaming Mode (the
+   * single-monitor page forces 'streaming'), so the button stays usable there
+   * while the profile sits on snapshot.
+   */
+  alwaysStreaming?: boolean;
+}
+
+export function AnalysisFramesToggle({ className, alwaysStreaming = false }: AnalysisFramesToggleProps) {
+  const { t } = useTranslation();
+  const { currentProfile, settings } = useCurrentProfile();
+  const updateSettings = useSettingsStore((state) => state.updateProfileSettings);
+
+  const unavailable = !alwaysStreaming && settings.viewMode === 'snapshot';
+  const isOn = settings.showAnalysisFrames;
+  const label = t('video.analysis_frames');
+  const title = unavailable ? t('video.analysis_needs_streaming') : t('video.analysis_frames_hint');
+
+  return (
+    <Button
+      variant={isOn ? 'default' : 'outline'}
+      size="icon"
+      className={className}
+      disabled={unavailable || !currentProfile}
+      aria-pressed={isOn}
+      aria-label={label}
+      title={title}
+      onClick={() => {
+        if (!currentProfile) return;
+        updateSettings(currentProfile.id, { showAnalysisFrames: !isOn });
+      }}
+      data-testid="analysis-frames-toggle"
+    >
+      <ScanEye className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/app/src/hooks/__tests__/useAnalysisFrames.test.ts
+++ b/app/src/hooks/__tests__/useAnalysisFrames.test.ts
@@ -1,0 +1,157 @@
+/**
+ * useAnalysisFrames Hook Tests
+ *
+ * Covers the two ways CMD_ANALYZE_ON/OFF reaches a running zms process: the
+ * user flipping the toggle, and the re-apply that keeps the setting alive
+ * across the connkey churn of reconnects, retries, and visibility resumes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnalysisFrames } from '../useAnalysisFrames';
+
+vi.mock('../../lib/logger', () => ({
+  LogLevel: { DEBUG: 'DEBUG', INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR' },
+  log: {
+    monitor: vi.fn(),
+    dedupe: (_key: string, _windowMs: number, emit: (suffix: string) => void) => emit(''),
+  },
+}));
+
+const mockHttpGet = vi.fn().mockResolvedValue({});
+vi.mock('../../lib/http', () => ({
+  httpGet: (...args: unknown[]) => mockHttpGet(...args),
+}));
+
+vi.mock('../../lib/zm/url-builder', () => ({
+  getZmsControlUrl: (portalUrl: string, command: number, connkey: string) =>
+    `${portalUrl}/control?command=${command}&connkey=${connkey}`,
+}));
+
+const BASE = {
+  monitorId: '1',
+  portalUrl: 'https://zm.test/zm',
+  accessToken: 'tok',
+  viewMode: 'streaming' as const,
+  enabled: true,
+  apiTimeoutSeconds: 30,
+};
+
+/** The command numbers ZoneMinder defines for the analysis overlay. */
+const CMD_ANALYZE_ON = 19;
+const CMD_ANALYZE_OFF = 20;
+
+const sentCommands = () => mockHttpGet.mock.calls.map(([url]) => new URL(url as string).searchParams.get('command'));
+
+describe('useAnalysisFrames', () => {
+  beforeEach(() => {
+    mockHttpGet.mockClear();
+  });
+
+  it('sends CMD_ANALYZE_ON for the live connkey when the toggle turns on', async () => {
+    const { rerender } = renderHook(
+      (props: { showAnalysis: boolean }) =>
+        useAnalysisFrames({ ...BASE, connKey: 5001, showAnalysis: props.showAnalysis }),
+      { initialProps: { showAnalysis: false } },
+    );
+
+    expect(mockHttpGet).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rerender({ showAnalysis: true });
+    });
+
+    expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    const url = new URL(mockHttpGet.mock.calls[0][0] as string);
+    expect(url.searchParams.get('command')).toBe(String(CMD_ANALYZE_ON));
+    expect(url.searchParams.get('connkey')).toBe('5001');
+  });
+
+  it('sends CMD_ANALYZE_OFF when the toggle turns back off', async () => {
+    const { rerender } = renderHook(
+      (props: { showAnalysis: boolean }) =>
+        useAnalysisFrames({ ...BASE, connKey: 5001, showAnalysis: props.showAnalysis }),
+      { initialProps: { showAnalysis: false } },
+    );
+
+    await act(async () => { rerender({ showAnalysis: true }); });
+    await act(async () => { rerender({ showAnalysis: false }); });
+
+    expect(sentCommands()).toEqual([String(CMD_ANALYZE_ON), String(CMD_ANALYZE_OFF)]);
+  });
+
+  it('re-applies on the first frame of a new connkey, so a reconnect keeps analysis on', async () => {
+    const { result, rerender } = renderHook(
+      (props: { connKey: number }) =>
+        useAnalysisFrames({ ...BASE, connKey: props.connKey, showAnalysis: true }),
+      { initialProps: { connKey: 5001 } },
+    );
+
+    // Mount with analysis already on (remembered setting): the command waits for
+    // the first frame, which is the only proof zms-<connkey>w.sock exists.
+    expect(mockHttpGet).not.toHaveBeenCalled();
+    act(() => { result.current.applyOnStreamLoad(); });
+    expect(sentCommands()).toEqual([String(CMD_ANALYZE_ON)]);
+
+    // Reconnect: fresh nph-zms process, defaults to analysis off.
+    await act(async () => { rerender({ connKey: 5002 }); });
+    act(() => { result.current.applyOnStreamLoad(); });
+
+    expect(mockHttpGet).toHaveBeenCalledTimes(2);
+    expect(new URL(mockHttpGet.mock.calls[1][0] as string).searchParams.get('connkey')).toBe('5002');
+  });
+
+  it('does not resend on every frame of the same connection', () => {
+    const { result } = renderHook(() =>
+      useAnalysisFrames({ ...BASE, connKey: 5001, showAnalysis: true }),
+    );
+
+    act(() => {
+      result.current.applyOnStreamLoad();
+      result.current.applyOnStreamLoad();
+      result.current.applyOnStreamLoad();
+    });
+
+    expect(mockHttpGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends nothing for a fresh connection while analysis is off', () => {
+    const { result } = renderHook(() =>
+      useAnalysisFrames({ ...BASE, connKey: 5001, showAnalysis: false }),
+    );
+
+    act(() => { result.current.applyOnStreamLoad(); });
+
+    expect(mockHttpGet).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing in snapshot mode, where zms serves a single image and ignores the frame type', async () => {
+    const { result, rerender } = renderHook(
+      (props: { showAnalysis: boolean }) =>
+        useAnalysisFrames({
+          ...BASE,
+          viewMode: 'snapshot',
+          connKey: 5001,
+          showAnalysis: props.showAnalysis,
+        }),
+      { initialProps: { showAnalysis: false } },
+    );
+
+    await act(async () => { rerender({ showAnalysis: true }); });
+    act(() => { result.current.applyOnStreamLoad(); });
+
+    expect(mockHttpGet).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing before a connkey has been minted', async () => {
+    const { rerender } = renderHook(
+      (props: { showAnalysis: boolean }) =>
+        useAnalysisFrames({ ...BASE, connKey: 0, showAnalysis: props.showAnalysis }),
+      { initialProps: { showAnalysis: false } },
+    );
+
+    await act(async () => { rerender({ showAnalysis: true }); });
+
+    expect(mockHttpGet).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/hooks/useAnalysisFrames.ts
+++ b/app/src/hooks/useAnalysisFrames.ts
@@ -1,0 +1,158 @@
+/**
+ * Analysis-frame toggling for one live MJPEG stream.
+ *
+ * ZoneMinder exposes the analysis image (motion overlay, zone boxes) two ways.
+ * The `analysis=1` parameter on the nph-zms URL is read once at process start
+ * (src/zms.cpp), so changing it means tearing the stream down and building a
+ * new one. CMD_ANALYZE_ON/OFF on the stream's command socket changes a running
+ * process (src/zm_monitorstream.cpp), which is what a toggle wants: the frames
+ * swap in place, with no restart and no gap.
+ *
+ * The catch is that the setting lives in the zms process, not in ZoneMinder,
+ * and this app mints a new process constantly: an error backoff, a manual
+ * retry, and a visibility resume each regenerate the connkey, and every fresh
+ * process starts on normal frames. So the command is applied twice: when the
+ * user flips the toggle, and again on the first frame of every connection that
+ * has not had it applied yet. The first frame, rather than the connkey being
+ * minted, because `zms-<connkey>w.sock` does not exist until the process is up.
+ *
+ * Snapshot mode gets nothing. `MonitorStream::SingleImage` reads the capture
+ * buffer directly and never looks at the frame type, so neither the parameter
+ * nor the command can put an overlay on a single image.
+ */
+
+import { useEffect, useRef } from 'react';
+import { httpGet } from '../lib/http';
+import { getZmsControlUrl } from '../lib/zm/url-builder';
+import { ZMS_COMMANDS } from '../lib/zm/zm-constants';
+import { log, LogLevel } from '../lib/logger';
+
+export interface UseAnalysisFramesOptions {
+  monitorId: string;
+  /** Portal URL of the server this stream runs on. */
+  portalUrl: string | undefined;
+  /** Auth token appended to the command request. */
+  accessToken: string | null;
+  /** The connection this stream currently owns. 0 means none yet. */
+  connKey: number;
+  /** Commands only reach a live nph-zms process, so streaming mode only. */
+  viewMode: 'streaming' | 'snapshot';
+  /** False while the owning stream is torn down; no commands are sent. */
+  enabled: boolean;
+  /** The user's toggle: whether this stream should serve analysis frames. */
+  showAnalysis: boolean;
+  /** Base port for multi-port streaming (port = minStreamingPort + monitorId). */
+  minStreamingPort?: number;
+  /** Profile's API request timeout in seconds. 0 disables it. */
+  apiTimeoutSeconds: number;
+}
+
+export interface UseAnalysisFramesReturn {
+  /**
+   * Call from the stream's load handler. Applies the toggle to a connection
+   * that has not had it applied yet, and no-ops otherwise: a multipart MJPEG
+   * `<img>` fires `load` per frame on some engines, and an unguarded send
+   * would be one request per frame per tile.
+   */
+  applyOnStreamLoad: () => void;
+}
+
+/** What was last sent, and for which connection. */
+interface AppliedState {
+  connKey: number;
+  on: boolean;
+}
+
+export function useAnalysisFrames({
+  monitorId,
+  portalUrl,
+  accessToken,
+  connKey,
+  viewMode,
+  enabled,
+  showAnalysis,
+  minStreamingPort,
+  apiTimeoutSeconds,
+}: UseAnalysisFramesOptions): UseAnalysisFramesReturn {
+  const appliedRef = useRef<AppliedState>({ connKey: 0, on: false });
+
+  // The send path reads props through a ref so the toggle effect below can
+  // depend on `showAnalysis` alone. Depending on the rest would re-run it on
+  // every connkey change, which is exactly the case the load handler owns.
+  const stateRef = useRef({
+    monitorId,
+    portalUrl,
+    accessToken,
+    connKey,
+    viewMode,
+    enabled,
+    showAnalysis,
+    minStreamingPort,
+    apiTimeoutSeconds,
+  });
+  // Declared before the toggle effect so it has already refreshed the snapshot
+  // by the time that effect runs: effects in one commit fire in declaration
+  // order, and a flip must be sent against the values of the render it flipped.
+  useEffect(() => {
+    stateRef.current = {
+      monitorId,
+      portalUrl,
+      accessToken,
+      connKey,
+      viewMode,
+      enabled,
+      showAnalysis,
+      minStreamingPort,
+      apiTimeoutSeconds,
+    };
+  });
+
+  const apply = (): void => {
+    const s = stateRef.current;
+    if (!s.enabled || s.viewMode !== 'streaming' || !s.portalUrl || s.connKey === 0) return;
+
+    const applied = appliedRef.current;
+    if (applied.connKey === s.connKey && applied.on === s.showAnalysis) return;
+
+    // A connection we have never touched is already serving normal frames, so
+    // turning analysis off on it would cost a request per tile per reconnect
+    // and change nothing. Record the state and send nothing.
+    if (applied.connKey !== s.connKey && !s.showAnalysis) {
+      appliedRef.current = { connKey: s.connKey, on: false };
+      return;
+    }
+
+    appliedRef.current = { connKey: s.connKey, on: s.showAnalysis };
+
+    const command = s.showAnalysis ? ZMS_COMMANDS.cmdAnalyzeOn : ZMS_COMMANDS.cmdAnalyzeOff;
+    const url = getZmsControlUrl(s.portalUrl, command, s.connKey.toString(), {
+      token: s.accessToken || undefined,
+      minStreamingPort: s.minStreamingPort,
+      monitorId: s.monitorId,
+    });
+
+    log.dedupe('analysis-frames-command', 3000, (suffix) =>
+      log.monitor(`Setting analysis frames ${s.showAnalysis ? 'on' : 'off'}${suffix}`, LogLevel.DEBUG, {
+        monitorId: s.monitorId,
+        connkey: s.connKey,
+      }),
+    );
+
+    httpGet(url, { timeoutMs: s.apiTimeoutSeconds > 0 ? s.apiTimeoutSeconds * 1000 : undefined }).catch(() => {
+      // The stream may have died between the frame and this request. The next
+      // connection re-applies from its own first frame.
+    });
+  };
+
+  // Flipping the toggle acts on the stream the user is watching right now.
+  // Mount is not a flip: a stream that starts with the setting already on has
+  // no command socket yet, so the load handler applies it instead.
+  const prevShowRef = useRef(showAnalysis);
+  useEffect(() => {
+    if (prevShowRef.current === showAnalysis) return;
+    prevShowRef.current = showAnalysis;
+    apply();
+  }, [showAnalysis]);
+
+  return { applyOnStreamLoad: apply };
+}

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -18,6 +18,7 @@ import { resolveMinStreamingPort } from '../lib/monitor/multiport';
 import { useCurrentProfile } from './useCurrentProfile';
 import { useBandwidthSettings } from './useBandwidthSettings';
 import { useStreamLifecycle } from './useStreamLifecycle';
+import { useAnalysisFrames } from './useAnalysisFrames';
 import { useFreshAccessToken } from './useFreshAccessToken';
 import { useServerUrls } from './useServerUrls';
 import { useVisibilityResume } from './useVisibilityResume';
@@ -112,6 +113,20 @@ export function useMonitorStream({
     mediaRef: imgRef,
     logFn: log.monitor,
     enabled,
+    minStreamingPort: effectiveMinStreamingPort,
+    apiTimeoutSeconds: settings.apiTimeoutSeconds,
+  });
+
+  // Analysis frames: applied to the live connection by command, and re-applied
+  // from the load handler below whenever a fresh connkey replaces it.
+  const analysisFrames = useAnalysisFrames({
+    monitorId,
+    portalUrl: resolvedPortalUrl,
+    accessToken,
+    connKey,
+    viewMode: effectiveViewMode,
+    enabled,
+    showAnalysis: settings.showAnalysisFrames,
     minStreamingPort: effectiveMinStreamingPort,
     apiTimeoutSeconds: settings.apiTimeoutSeconds,
   });
@@ -211,8 +226,11 @@ export function useMonitorStream({
   };
 
   // Reset the backoff counter (and cancel any pending reconnect) once a frame
-  // loads, so a later independent drop starts a fresh backoff.
+  // loads, so a later independent drop starts a fresh backoff. A frame is also
+  // the first proof that this connection's zms command socket exists, which is
+  // when a remembered analysis setting can be applied to it.
   const reportStreamLoad = () => {
+    analysisFrames.applyOnStreamLoad();
     reconnectAttemptRef.current = 0;
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);

--- a/app/src/lib/zm/__tests__/zm-constants.test.ts
+++ b/app/src/lib/zm/__tests__/zm-constants.test.ts
@@ -23,6 +23,8 @@ describe('ZMS_COMMANDS', () => {
       cmdGetImage: 16,
       cmdQuit: 17,
       cmdMaxFps: 18,
+      cmdAnalyzeOn: 19,
+      cmdAnalyzeOff: 20,
       cmdQuery: 99,
     });
   });

--- a/app/src/lib/zm/zm-constants.ts
+++ b/app/src/lib/zm/zm-constants.ts
@@ -77,6 +77,12 @@ export const ZMS_COMMANDS = {
   /** Set maximum FPS */
   cmdMaxFps: 18,
 
+  /** Serve analysis frames (motion overlay) instead of the captured image */
+  cmdAnalyzeOn: 19,
+
+  /** Go back to the captured image */
+  cmdAnalyzeOff: 20,
+
   /** Query stream status */
   cmdQuery: 99,
 } as const;

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1265,7 +1265,10 @@
     "connection_error": "Verbindungsfehler",
     "connection_failed": "Stream-Verbindung fehlgeschlagen",
     "fallback_to_mjpeg": "Wechsle zu MJPEG",
-    "retry_connection": "Verbindung wiederholen"
+    "retry_connection": "Verbindung wiederholen",
+    "analysis_frames": "Analysebilder",
+    "analysis_frames_hint": "ZoneMinders Bewegungsanalyse einblenden. Nur bei MJPEG-Livestreams.",
+    "analysis_needs_streaming": "Analysebilder erfordern den Streaming-Modus Live"
   },
   "groups": {
     "all_monitors": "Alle",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1265,7 +1265,10 @@
     "connection_error": "Connection Error",
     "connection_failed": "Stream connection failed",
     "fallback_to_mjpeg": "Falling back to MJPEG",
-    "retry_connection": "Retry Connection"
+    "retry_connection": "Retry Connection",
+    "analysis_frames": "Analysis frames",
+    "analysis_frames_hint": "Show ZoneMinder's motion analysis overlay. MJPEG live streams only.",
+    "analysis_needs_streaming": "Analysis frames need Streaming Mode set to Live"
   },
   "groups": {
     "all_monitors": "All",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1265,7 +1265,10 @@
     "connection_error": "Error de Conexión",
     "connection_failed": "Falló la conexión de transmisión",
     "fallback_to_mjpeg": "Cambiando a MJPEG",
-    "retry_connection": "Reintentar Conexión"
+    "retry_connection": "Reintentar Conexión",
+    "analysis_frames": "Fotogramas de análisis",
+    "analysis_frames_hint": "Muestra la superposición de análisis de movimiento de ZoneMinder. Solo en streams MJPEG en directo.",
+    "analysis_needs_streaming": "Los fotogramas de análisis requieren el modo de streaming en directo"
   },
   "groups": {
     "all_monitors": "Todos",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1265,7 +1265,10 @@
     "connection_error": "Erreur de Connexion",
     "connection_failed": "Échec de la connexion de diffusion",
     "fallback_to_mjpeg": "Passage à MJPEG",
-    "retry_connection": "Réessayer la Connexion"
+    "retry_connection": "Réessayer la Connexion",
+    "analysis_frames": "Images d'analyse",
+    "analysis_frames_hint": "Affiche la surcouche d'analyse de mouvement de ZoneMinder. Uniquement sur les flux MJPEG en direct.",
+    "analysis_needs_streaming": "Les images d'analyse nécessitent le mode de diffusion en direct"
   },
   "groups": {
     "all_monitors": "Tous",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1265,7 +1265,10 @@
     "connection_error": "连接错误",
     "connection_failed": "流媒体连接失败",
     "fallback_to_mjpeg": "切换至 MJPEG",
-    "retry_connection": "重试连接"
+    "retry_connection": "重试连接",
+    "analysis_frames": "分析画面",
+    "analysis_frames_hint": "显示 ZoneMinder 的移动分析叠加层。仅适用于 MJPEG 实时流。",
+    "analysis_needs_streaming": "分析画面需要将串流模式设为实时"
   },
   "groups": {
     "all_monitors": "全部",

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from 'react-i18next';
 import { useInsomnia } from '../hooks/useInsomnia';
 import { PTZControls } from '../components/monitors/PTZControls';
 import { LiveMonitorPlayer } from '../components/monitors/LiveMonitorPlayer';
+import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { ZoneOverlay } from '../components/monitors/ZoneOverlay';
 import { ZoneLegend } from '../components/monitors/ZoneLegend';
 import { log, LogLevel } from '../lib/logger';
@@ -302,6 +303,7 @@ export default function MonitorDetail() {
               </SelectItem>
             </SelectContent>
           </Select>
+          <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" alwaysStreaming />
           <Button
             variant="ghost"
             size="icon"

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -23,6 +23,7 @@ import { EmptyState } from '../components/ui/empty-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { RefreshButton } from '../components/common/RefreshButton';
 import { MonitorCard } from '../components/monitors/MonitorCard';
+import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { filterEnabledMonitors, filterMonitorsByGroup } from '../lib/monitor/filters';
@@ -212,6 +213,7 @@ export default function Monitors() {
               </SelectItem>
             </SelectContent>
           </Select>
+          <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" />
           <RefreshButton
             className="h-8 w-8 sm:h-9 sm:w-9"
             data-testid="monitors-refresh-button"

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -23,6 +23,7 @@ import { MontageMonitor } from '../components/monitors/MontageMonitor';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { Video, Maximize, Pencil, ArrowLeftRight } from 'lucide-react';
 import { RefreshButton } from '../components/common/RefreshButton';
+import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { ErrorBanner } from '../components/ui/query-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { EmptyState } from '../components/ui/empty-state';
@@ -404,6 +405,7 @@ export default function Montage() {
                   <span className="hidden sm:inline">{t('montage.fill_width', 'Fill')}</span>
                 </Button>
               )}
+              <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" />
               <Button
                 onClick={() => handleToggleFullscreen(true)}
                 variant="default"

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -208,6 +208,10 @@ export interface ProfileSettings {
   tvMode: boolean;
   // Show protocol label (MJPEG/MSE/WebRTC) on video streams
   showProtocolLabel: boolean;
+  /** Serve ZoneMinder's analysis image (motion overlay, zone boxes) on live
+   *  views instead of the captured frame. MJPEG streaming only: go2rtc has no
+   *  command socket and zms ignores the frame type for single images. */
+  showAnalysisFrames: boolean;
   // Per-monitor streaming method overrides (monitorId → 'auto' | 'mjpeg')
   // When absent, the monitor uses the profile-level streamingMethod.
   monitorStreamingOverrides: Record<string, StreamingMethod>;
@@ -376,6 +380,7 @@ export const DEFAULT_SETTINGS: ProfileSettings = {
   sidebarWidth: 256,
   tvMode: false,
   showProtocolLabel: true,
+  showAnalysisFrames: false,
   monitorStreamingOverrides: {},
   forceZmsMonitorIds: [],
   // Auto by default: honor the server's ZM_MIN_STREAMING_PORT when present

--- a/app/tests/features/monitor-detail.feature
+++ b/app/tests/features/monitor-detail.feature
@@ -146,3 +146,17 @@ Feature: Monitor Detail Page
     Then the delete batch bar should show 2 events
     When I cancel the delete batch
     Then the delete batch bar should be gone
+
+  @web @all
+  Scenario: Analysis frames toggle switches the running stream and is remembered
+    Then I should see the monitor player
+    When I turn analysis frames on
+    Then the analysis-on command should be sent for the live stream
+    And the analysis frames toggle should be active
+    When I navigate to the "Monitors" page
+    And I click into the first monitor detail page
+    Then the analysis frames toggle should be active
+    And the analysis-on command should be re-sent for the new stream
+    When I turn analysis frames off
+    Then the analysis-off command should be sent for the live stream
+    And the analysis frames toggle should be inactive

--- a/app/tests/steps/analysis-frames.steps.ts
+++ b/app/tests/steps/analysis-frames.steps.ts
@@ -1,0 +1,106 @@
+import { createBdd } from 'playwright-bdd';
+import { expect } from '@playwright/test';
+import { testConfig } from '../helpers/config';
+import { ZMS_COMMANDS } from '../../src/lib/zm/zm-constants';
+import { log } from '../../src/lib/logger';
+
+const { When, Then } = createBdd();
+
+// Analysis-frame steps
+//
+// Turning analysis frames on changes what zms encodes into the MJPEG stream,
+// which the DOM cannot see: the <img> src never changes, and the overlay only
+// appears on frames where a zone alarmed, so asserting on pixels would be
+// asserting on whether a camera happened to move. The observable outcome is the
+// stream command itself (src/hooks/useAnalysisFrames.ts), recorded the same way
+// the PTZ steps record control requests. URLs are decoded first: in dev the
+// real URL can be nested percent-encoded inside the image proxy (refs #328).
+const analysisListenerPages = new WeakSet<import('@playwright/test').Page>();
+let analysisRequestUrls: string[] = [];
+/** Whether this server serves the monitor over MJPEG at all. */
+let mjpegTransport = false;
+
+function attachAnalysisRequestCapture(page: import('@playwright/test').Page): void {
+  if (analysisListenerPages.has(page)) return;
+  analysisListenerPages.add(page);
+  page.on('request', (req) => {
+    const url = decodeURIComponent(req.url());
+    if (url.includes('request=stream') && url.includes('command=')) {
+      analysisRequestUrls.push(url);
+    }
+  });
+}
+
+const sentCommand = (command: number) =>
+  analysisRequestUrls.some((url) => url.includes(`command=${command}`));
+
+/** Distinct connkeys a command was sent for, i.e. distinct nph-zms processes. */
+const connKeysCommanded = (command: number): Set<string> => {
+  const keys = new Set<string>();
+  for (const url of analysisRequestUrls) {
+    if (!url.includes(`command=${command}`)) continue;
+    const connkey = /[?&]connkey=(\d+)/.exec(url)?.[1];
+    if (connkey) keys.add(connkey);
+  }
+  return keys;
+};
+
+async function clickAnalysisToggle(page: import('@playwright/test').Page): Promise<void> {
+  attachAnalysisRequestCapture(page);
+  analysisRequestUrls = [];
+  // The command only exists on an MJPEG stream; a go2rtc/WebRTC feed has no
+  // command socket. Transport, not the control under test, so the toggle's own
+  // assertions below still run either way.
+  mjpegTransport = await page.getByTestId('video-player-mjpeg').isVisible().catch(() => false);
+  if (!mjpegTransport) {
+    log.info('E2E: monitor is not served over MJPEG, skipping stream-command assertions', {
+      component: 'e2e',
+    });
+  }
+  const toggle = page.getByTestId('analysis-frames-toggle');
+  await expect(toggle).toBeEnabled();
+  await toggle.click();
+}
+
+When('I turn analysis frames on', async ({ page }) => {
+  await clickAnalysisToggle(page);
+});
+
+When('I turn analysis frames off', async ({ page }) => {
+  await clickAnalysisToggle(page);
+});
+
+Then('the analysis-on command should be sent for the live stream', async () => {
+  if (!mjpegTransport) return;
+  await expect.poll(() => sentCommand(ZMS_COMMANDS.cmdAnalyzeOn), {
+    timeout: testConfig.timeouts.transition,
+  }).toBeTruthy();
+});
+
+Then('the analysis-off command should be sent for the live stream', async () => {
+  if (!mjpegTransport) return;
+  await expect.poll(() => sentCommand(ZMS_COMMANDS.cmdAnalyzeOff), {
+    timeout: testConfig.timeouts.transition,
+  }).toBeTruthy();
+});
+
+Then('the analysis-on command should be re-sent for the new stream', async ({ page }) => {
+  if (!mjpegTransport) return;
+  // The remembered setting has to reach the fresh nph-zms process this
+  // navigation minted; that process starts on normal frames whatever the
+  // previous one was told. Asserting a second, different connkey rather than
+  // "a request happened" stops the first stream's recorded command from
+  // satisfying this on its own.
+  attachAnalysisRequestCapture(page);
+  await expect.poll(() => connKeysCommanded(ZMS_COMMANDS.cmdAnalyzeOn).size, {
+    timeout: testConfig.timeouts.pageLoad,
+  }).toBeGreaterThan(1);
+});
+
+Then('the analysis frames toggle should be active', async ({ page }) => {
+  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-pressed', 'true');
+});
+
+Then('the analysis frames toggle should be inactive', async ({ page }) => {
+  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-pressed', 'false');
+});

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -369,6 +369,55 @@ deps as proof of an unmount.
 :doc:`call-flows` walks this same code in "Montage opens and a live MJPEG stream
 runs".
 
+Analysis frames on a running stream
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``hooks/useAnalysisFrames.ts`` puts ZoneMinder's analysis image (the motion
+overlay) on a live view. ZoneMinder offers two ways in, and the difference
+decides the design. ``analysis=1`` on the ``nph-zms`` URL is read once when the
+process starts, so changing it means tearing the stream down and building a new
+one. ``CMD_ANALYZE_ON`` and ``CMD_ANALYZE_OFF`` (19 and 20 in ``ZMS_COMMANDS``)
+go to the running process over its command socket, and the frames swap in place
+with no gap. A toggle wants the second.
+
+The cost of the second is that the state lives in the ``nph-zms`` process rather
+than in ZoneMinder, and this app replaces that process often: the reconnect
+backoff in ``useMonitorStream``, a manual retry, and a visibility resume each
+mint a new connkey, and every new process starts on normal frames. So the
+setting, which is profile-scoped and remembered
+(``showAnalysisFrames``), is applied from two places:
+
+.. code:: tsx
+
+   // The flip itself, against the connection the user is watching
+   const prevShowRef = useRef(showAnalysis);
+   useEffect(() => {
+     if (prevShowRef.current === showAnalysis) return;
+     prevShowRef.current = showAnalysis;
+     apply();
+   }, [showAnalysis]);
+
+   // And again for each new connection, from useMonitorStream's load handler
+   const reportStreamLoad = () => {
+     analysisFrames.applyOnStreamLoad();
+     /* ... backoff reset ... */
+   };
+
+The re-apply hangs off the load handler rather than off ``connKey`` changing
+because ``zms-<connkey>w.sock`` does not exist until the process is up; the
+first decoded frame is the earliest proof that it is. ``apply`` keeps a ref of
+what it last sent and for which connkey, which is what stops a multipart
+``<img>`` firing ``load`` per frame from turning into one request per frame per
+tile, and what lets a fresh connection with the setting off cost no request at
+all.
+
+Two absences are deliberate. Snapshot mode sends nothing, because
+``MonitorStream::SingleImage`` in ZoneMinder reads the capture buffer directly
+and never looks at the frame type, so no parameter or command can put an overlay
+on a single image; ``AnalysisFramesToggle`` disables the button there rather than
+letting it do nothing quietly. And a go2rtc stream has no command socket, so the
+hook only runs on the MJPEG path that ``useMonitorStream`` owns.
+
 Video playback
 --------------
 

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -73,6 +73,14 @@ The **Always use ZMS for events** toggle at the top of the Video tab in the moni
 
 The Layers button in the live view toolbar toggles the zone overlay. When active, each detection zone is drawn as a semi-transparent polygon colored by its type: Active (green), Inclusive (blue), Exclusive (red), Preclusive (amber), Inactive (gray), Privacy (purple). A legend in the bottom-left of the player lists the types present on that monitor. Hovering a zone shows its name and type. Inactive zones appear gray.
 
+#### Analysis Frames
+
+The scan button in the toolbar switches the live feed from the captured image to ZoneMinder's analysis image, which draws the motion overlay the analysis daemon produces: the changed pixels it scored and the zones that fired. It is the quickest way to see whether a monitor's zones and sensitivity are set the way you meant.
+
+The same button sits on Montage, the Monitors page, and Live Activity, and all four share one setting, so turning it on in one view turns it on in the others. The app remembers it per profile and applies it again to each stream it opens, including after a reconnect.
+
+Three things to expect. It works on MJPEG streams only, so a monitor served over Go2RTC keeps showing the normal picture. It needs Streaming Mode set to Live; in snapshot mode the button is disabled, because ZoneMinder serves single images straight from the capture buffer and never draws the overlay on them. And a monitor whose Analysing setting is None, or one watching a still scene, looks no different, since the overlay only exists on frames where something actually moved.
+
 ### PTZ Controls
 
 If the monitor has PTZ (Pan-Tilt-Zoom) configured in ZoneMinder, directional controls appear below the live view. Use these to pan, tilt, and zoom the camera.


### PR DESCRIPTION
Adds an analysis-frames toggle to Montage, the Monitors page, the single-monitor page, and Live Activity. Closes #329 once merged.

## How it works

`CMD_ANALYZE_ON`/`CMD_ANALYZE_OFF` (19/20) on the running nph-zms process, not `analysis=1` on the stream URL. The URL parameter is read once at process start, so using it would restart the stream on every flip; the command swaps the frames in place.

The catch is that the state lives in the zms process rather than in ZoneMinder, and this app replaces that process constantly: reconnect backoff, manual retry, and visibility resume each mint a new connkey whose process starts on normal frames. So `useAnalysisFrames` applies the setting from two places: the flip itself, and the stream load handler for any connection that has not had it applied yet. Load rather than connkey change, because `zms-<connkey>w.sock` does not exist until the process is up. A ref of what was last sent, and for which connkey, keeps a multipart `<img>` firing `load` per frame from becoming one request per frame per tile.

The setting is profile-scoped and remembered, shared by all four views.

## Deliberate limits

- **Snapshot mode disables the button.** `MonitorStream::SingleImage` reads the capture buffer and never looks at the frame type, so no parameter or command can overlay a single image. The single-monitor page forces streaming, so its button stays enabled. Note that snapshot is the default Streaming Mode, so the button starts disabled on the other three pages until the user switches to Live.
- **go2rtc streams do nothing.** No command socket. The hook only runs on the MJPEG path.
- **Idle cameras look identical.** The overlay only exists on frames where a zone alarmed.

## Verification

- `npm run gates`: 3243 unit tests pass, build clean, three blocking lints clean (ratchet within baseline, no new entries).
- `npm run test:e2e -- monitor-detail.feature`: 17 passed. The new scenario asserts the on/off commands reach the network and that a second, different connkey gets the command after navigating away and back, so a remembered setting that failed to re-apply would fail the test. Confirmed the MJPEG capability gate did not silently skip those assertions on this server.
- Locales updated together (de, en, es, fr, zh). User guide and developer guide updated.
- Not run: device e2e (iOS, Android, Tauri) is manual-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)