### PR TITLE
fix: cover Android local network permission

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -74,6 +74,13 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Local network access is implicitly granted through INTERNET while we target
+         API 36. From Android 17 (API 37) it becomes a mandatory runtime permission in
+         the NEARBY_DEVICES group, and without it every LAN ZoneMinder server becomes
+         unreachable. Declared now so the bump does not silently break local servers;
+         the matching runtime request must land in the same change that raises
+         targetSdkVersion to 37 (refs #333). -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <!-- @capacitor-community/media saves downloads to the app's own gallery album
          via MediaStore. In basic (non-gallery) mode it requests no storage/media
          permissions, so READ_MEDIA_IMAGES/READ_MEDIA_VIDEO and the legacy

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -50,6 +50,14 @@ zmNinjaNg is a rewrite of zmNinja using React, TypeScript, and Capacitor. Same c
 - Ensure the ZoneMinder API is enabled
 - If using HTTPS with a self-signed certificate, make sure the self-signed certificate toggle is enabled in Settings > Advanced
 
+### Android: "Connection failed" on a local server, but a remote URL works
+
+Some Android devices block an app from reaching your local network until you grant a per-app permission by hand. The giveaway is that the same server works over a public hostname or over cellular through a VPN, other apps on the phone reach it fine, and only the LAN address (`http://192.168.x.x/zm` and the like) fails.
+
+Grant it in Android settings, not in zmNinjaNg: **Settings > Apps > zmNinjaNg > Permissions**, then enable the local network entry. The wording differs by vendor, so look for **Local network**, **LAN**, or **Allow access to local network**. On Xiaomi/HyperOS, OPPO/ColorOS, vivo, and Huawei the toggle may instead sit under a vendor privacy or permission manager screen. Reopen zmNinjaNg afterwards and retry the profile.
+
+If your device has no such toggle anywhere in its settings, this is not your problem, work through the checklist above instead.
+
 ### The app connects but shows no monitors
 
 - Check that your ZoneMinder user has permission to view monitors

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -56,6 +56,7 @@ Passwords are never stored in plaintext.
 - Verify the Portal URL is correct and accessible from your device
 - Check that ZoneMinder API is enabled (`OPT_USE_API = 1` in ZoneMinder options)
 - If using a self-signed certificate, enable **Allow self-signed certificates** in Settings > Advanced (or toggle it when adding the profile)
+- On Android, if only the LAN address fails while a remote URL works, the device may be withholding local network permission, see {doc}`faq`
 
 **"Authentication failed"**
 - Verify username and password


### PR DESCRIPTION
Fixes #333.

Two mechanisms make a LAN ZoneMinder server unreachable on Android, and they need different fixes.

**Vendor ROMs** (Xiaomi/HyperOS, OPPO/ColorOS, vivo, Huawei) have shipped a per-app LAN toggle for years, granted outside Android's permission model. No manifest change reaches it, so this half is documentation: a symptom-first FAQ entry under Connection Issues in `docs/user-guide/faq.md`, keyed on the giveaway that a remote URL works while only the LAN address fails, plus a pointer from the profile troubleshooting list.

**Android's local network protections** are the other half. Per [the local network permission guide](https://developer.android.com/privacy-and-security/local-network-permission), access is implicitly granted through `INTERNET` for apps targeting API 36 or lower and becomes a mandatory runtime permission from Android 17 for apps targeting API 37. The app targets 36, so `ACCESS_LOCAL_NETWORK` is inert today. It is declared now, with a manifest comment, so raising `targetSdkVersion` later does not silently cut off every local server without anyone noticing.

The runtime permission request and any in-app hint that a request looks LAN-blocked are deliberately left out. Both belong with the targetSdk 37 bump, where they can be tested against a device that actually enforces the check.

## Verification

`npx vitest run src/tests/` (18 passed) for the doc gates, `xmllint --noout` on the manifest. No app code changed, so no new test: the FAQ text and an inert manifest declaration have nothing a test could catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)