### PR TITLE
Explain icon-only buttons on touch with a long-press hint

### DIFF
--- a/app/src/components/BackgroundTaskDrawer.tsx
+++ b/app/src/components/BackgroundTaskDrawer.tsx
@@ -93,6 +93,8 @@ function TaskItem({ task }: TaskItemProps) {
               size="sm"
               onClick={() => cancelTask(task.id)}
               className="h-6 w-6 p-0"
+              title={t('common.cancel')}
+              aria-label={t('common.cancel')}
               data-testid="task-cancel-button"
             >
               <X className="h-3 w-3" />
@@ -104,6 +106,8 @@ function TaskItem({ task }: TaskItemProps) {
               size="sm"
               onClick={() => removeTask(task.id)}
               className="h-6 w-6 p-0"
+              title={t('common.remove')}
+              aria-label={t('common.remove')}
               data-testid="task-remove-button"
             >
               <X className="h-3 w-3" />
@@ -253,6 +257,8 @@ export function BackgroundTaskDrawer() {
             size="sm"
             onClick={() => setDrawerState(active.length > 0 ? 'collapsed' : 'badge')}
             className="h-7 w-7 p-0"
+            title={t('common.collapse')}
+            aria-label={t('common.collapse')}
             data-testid="collapse-drawer-button"
           >
             <ChevronDown className="h-4 w-4" />

--- a/app/src/components/CertTrustBanner.tsx
+++ b/app/src/components/CertTrustBanner.tsx
@@ -15,6 +15,7 @@ import { useCurrentProfile } from '../hooks/useCurrentProfile';
 import { useCertTrustPrompt } from '../hooks/useCertTrustPrompt';
 import { CertTrustDialog } from './CertTrustDialog';
 import { Button } from './ui/button';
+import { HintButton } from './ui/button';
 
 export function CertTrustBanner() {
   const { t } = useTranslation();
@@ -47,15 +48,16 @@ export function CertTrustBanner() {
           >
             {t('ssl.verify_button')}
           </Button>
-          <button
+          <HintButton
             type="button"
+            title={t('common.close')}
             aria-label={t('common.close')}
             className="shrink-0 text-muted-foreground hover:text-foreground"
             onClick={() => setDismissed(true)}
             data-testid="cert-trust-banner-dismiss"
           >
             <X className="h-4 w-4" />
-          </button>
+          </HintButton>
         </div>
       )}
       <CertTrustDialog {...dialogProps} />

--- a/app/src/components/NotificationBadge.tsx
+++ b/app/src/components/NotificationBadge.tsx
@@ -5,17 +5,20 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Bell } from 'lucide-react';
 import { useProfileStore } from '../stores/profile';
 import { useNotificationStore } from '../stores/notifications';
 import { NOTIFICATION_UI } from '../lib/zmninja-ng-constants';
+import { HintButton } from './ui/button';
 
 // Module-level: persists across component mount/unmount cycles so
 // navigating between pages doesn't re-trigger the animation.
 let lastKnownUnreadCount = 0;
 
 export function NotificationBadge() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const currentProfileId = useProfileStore((state) => state.currentProfileId);
   const unreadCount = useNotificationStore((state) => {
@@ -46,14 +49,15 @@ export function NotificationBadge() {
   if (unreadCount === 0) return null;
 
   return (
-    <button
+    <HintButton
       className={
         isRinging
           ? "relative inline-flex items-center justify-center h-7 w-7 rounded-full bg-destructive/20 transition-colors duration-500"
           : "relative inline-flex items-center justify-center h-7 w-7 rounded-full bg-muted hover:bg-muted/80 transition-colors duration-500"
       }
       onClick={(e) => { e.stopPropagation(); navigate('/notifications/history'); }}
-      aria-label={`${unreadCount} unread notifications`}
+      title={t('notification_history.unread_count', { count: unreadCount })}
+      aria-label={t('notification_history.unread_count', { count: unreadCount })}
       data-testid="notification-badge"
     >
       <Bell
@@ -67,6 +71,6 @@ export function NotificationBadge() {
       <span className="absolute -top-1 -right-1 h-4 min-w-4 px-0.5 flex items-center justify-center text-[9px] font-bold rounded-full bg-destructive text-destructive-foreground">
         {unreadCount > 99 ? '99+' : unreadCount}
       </span>
-    </button>
+    </HintButton>
   );
 }

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -837,6 +837,7 @@ export function AskPanel() {
             variant="outline"
             size="icon"
             onClick={handleAbort}
+            title={t('assistant.abort')}
             aria-label={t('assistant.abort')}
             data-testid="assistant-abort"
           >
@@ -848,6 +849,7 @@ export function AskPanel() {
             size="icon"
             onClick={() => void handleSend()}
             disabled={!input.trim() || !profileId}
+            title={t('assistant.send')}
             aria-label={t('assistant.send')}
             data-testid="assistant-send"
           >

--- a/app/src/components/assistant/AssistantDesktopPanel.tsx
+++ b/app/src/components/assistant/AssistantDesktopPanel.tsx
@@ -117,6 +117,7 @@ export function AssistantDesktopPanel() {
             className="h-7 w-7"
             onClick={clear}
             disabled={!canClear}
+            title={t('assistant.clear')}
             aria-label={t('assistant.clear')}
             data-testid="assistant-clear"
           >
@@ -128,6 +129,7 @@ export function AssistantDesktopPanel() {
             size="icon"
             className="h-7 w-7"
             onClick={minimize}
+            title={t('assistant.minimize')}
             aria-label={t('assistant.minimize')}
             data-testid="assistant-minimize"
           >
@@ -139,6 +141,7 @@ export function AssistantDesktopPanel() {
             size="icon"
             className="h-7 w-7"
             onClick={close}
+            title={t('common.close')}
             aria-label={t('common.close')}
             data-testid="assistant-close"
           >

--- a/app/src/components/assistant/AssistantMobileSheet.tsx
+++ b/app/src/components/assistant/AssistantMobileSheet.tsx
@@ -137,6 +137,7 @@ export function AssistantMobileSheet() {
             className="h-7 w-7"
             onClick={clear}
             disabled={!canClear}
+            title={t('assistant.clear')}
             aria-label={t('assistant.clear')}
             data-testid="assistant-mobile-clear"
           >
@@ -148,6 +149,7 @@ export function AssistantMobileSheet() {
             size="icon"
             className="h-7 w-7"
             onClick={minimize}
+            title={t('assistant.minimize')}
             aria-label={t('assistant.minimize')}
             data-testid="assistant-mobile-minimize"
           >
@@ -159,6 +161,7 @@ export function AssistantMobileSheet() {
             size="icon"
             className="h-7 w-7"
             onClick={close}
+            title={t('common.close')}
             aria-label={t('common.close')}
             data-testid="assistant-mobile-close"
           >

--- a/app/src/components/dashboard/DashboardWidget.tsx
+++ b/app/src/components/dashboard/DashboardWidget.tsx
@@ -96,6 +96,7 @@ export function DashboardWidget({
                             variant="secondary"
                             size="icon"
                             className="h-6 w-6"
+                            title={t('common.edit')}
                             aria-label={t('common.edit')}
                             onClick={(e) => {
                                 e.stopPropagation(); // Prevent drag start
@@ -109,6 +110,7 @@ export function DashboardWidget({
                             variant="destructive"
                             size="icon"
                             className="h-6 w-6"
+                            title={t('common.delete')}
                             aria-label={t('common.delete')}
                             onClick={(e) => {
                                 e.stopPropagation(); // Prevent drag start

--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -34,6 +34,7 @@ import { ReturnFlashArrow } from './ReturnFlashArrow';
 import { useReturnFlash } from '../../hooks/useReturnFlash';
 import { useReturnHighlightStore } from '../../stores/returnHighlight';
 import { useDeleteSelectionStore } from '../../stores/deleteSelection';
+import { HintButton } from '../ui/button';
 
 /**
  * EventCard component.
@@ -181,12 +182,13 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
                 {event.Name}
               </h3>
               <div className="flex items-center gap-1 sm:gap-2 shrink-0">
-                <button
+                <HintButton
                   onClick={handleFavoriteClick}
                   className={cn(
                     "p-1 rounded-full hover:bg-accent transition-colors",
                     "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                   )}
+                  title={isFav ? t('events.unfavorite') : t('events.favorite')}
                   aria-label={isFav ? t('events.unfavorite') : t('events.favorite')}
                   data-testid="event-favorite-button"
                 >
@@ -198,8 +200,8 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
                         : "stroke-muted-foreground hover:stroke-yellow-500"
                     )}
                   />
-                </button>
-                <button
+                </HintButton>
+                <HintButton
                   onClick={handleArchiveClick}
                   disabled={isArchiving}
                   className={cn(
@@ -219,7 +221,7 @@ function EventCardComponent({ event, monitorName, thumbnailUrls, largeThumbnailU
                         : "stroke-muted-foreground hover:stroke-primary"
                     )}
                   />
-                </button>
+                </HintButton>
                 <EventDeleteButton eventId={event.Id} />
                 {(() => {
                   const CauseIcon = getEventCauseIcon(event.Cause);

--- a/app/src/components/events/EventDeleteButton.tsx
+++ b/app/src/components/events/EventDeleteButton.tsx
@@ -7,6 +7,7 @@ import { Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
 import { useDeleteSelectionStore } from '../../stores/deleteSelection';
+import { HintButton } from '../ui/button';
 
 interface EventDeleteButtonProps {
   eventId: string;
@@ -21,7 +22,7 @@ export function EventDeleteButton({ eventId, size = 'md', className }: EventDele
   const iconSize = size === 'sm' ? 'h-4 w-4' : 'h-4 w-4 sm:h-5 sm:w-5';
 
   return (
-    <button
+    <HintButton
       type="button"
       onClick={(e) => {
         e.stopPropagation();
@@ -44,6 +45,6 @@ export function EventDeleteButton({ eventId, size = 'md', className }: EventDele
           selected ? 'text-destructive' : 'stroke-muted-foreground hover:stroke-destructive'
         )}
       />
-    </button>
+    </HintButton>
   );
 }

--- a/app/src/components/events/EventHeatmap.tsx
+++ b/app/src/components/events/EventHeatmap.tsx
@@ -156,6 +156,8 @@ export function EventHeatmap({
             size="sm"
             onClick={() => setIsExpanded(!isExpanded)}
             className="h-8 w-8 p-0"
+            title={isExpanded ? t('common.collapse') : t('common.expand')}
+            aria-label={isExpanded ? t('common.collapse') : t('common.expand')}
           >
             {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
           </Button>

--- a/app/src/components/events/TagChip.tsx
+++ b/app/src/components/events/TagChip.tsx
@@ -6,9 +6,11 @@
  */
 
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import type { Tag } from '../../api/types';
+import { HintButton } from '../ui/button';
 
 interface TagChipProps {
   /** Tag to display */
@@ -46,6 +48,7 @@ function TagChipComponent({
   className,
   size = 'sm',
 }: TagChipProps) {
+  const { t } = useTranslation();
   const hue = getTagColorHue(tag.Name);
 
   const handleRemove = (e: React.MouseEvent) => {
@@ -70,18 +73,19 @@ function TagChipComponent({
         {tag.Name}
       </span>
       {removable && onRemove && (
-        <button
+        <HintButton
           type="button"
           onClick={handleRemove}
           className={cn(
             'rounded-full hover:bg-black/10 transition-colors flex-shrink-0',
             size === 'sm' ? 'p-0.5' : 'p-0.5'
           )}
-          aria-label={`Remove ${tag.Name}`}
+          title={t('events.remove_tag', { name: tag.Name })}
+          aria-label={t('events.remove_tag', { name: tag.Name })}
           data-testid="tag-chip-remove"
         >
           <X className={cn(size === 'sm' ? 'h-2.5 w-2.5' : 'h-3 w-3')} />
-        </button>
+        </HintButton>
       )}
     </span>
   );

--- a/app/src/components/kiosk/KioskOverlay.tsx
+++ b/app/src/components/kiosk/KioskOverlay.tsx
@@ -19,6 +19,7 @@ import { log, LogLevel } from '../../lib/logger';
 import { Platform } from '../../lib/platform';
 import { KIOSK, Z_INDEX } from '../../lib/zmninja-ng-constants';
 import { useCapacitorListener } from '../../hooks/useCapacitorListener';
+import { HintButton } from '../ui/button';
 
 interface KioskOverlayProps {
   onUnlock: () => void;
@@ -168,14 +169,14 @@ export function KioskOverlay({ onUnlock }: KioskOverlayProps) {
         data-testid="kiosk-overlay"
       >
         {/* Unlock button: bottom-right, theme-aware */}
-        <button
+        <HintButton
           onClick={handleUnlockTap}
           className="absolute bottom-6 right-6 w-14 h-14 rounded-full flex items-center justify-center transition-all hover:scale-110 active:scale-95 bg-primary/80 hover:bg-primary border-2 border-primary-foreground/30 shadow-lg shadow-primary/30"
           title={t('kiosk.unlock_label')}
           data-testid="kiosk-unlock-button"
         >
           <LockOpen className="h-6 w-6 text-primary-foreground" />
-        </button>
+        </HintButton>
       </div>
 
       {/* PIN pad dialog */}

--- a/app/src/components/kiosk/PinPad.tsx
+++ b/app/src/components/kiosk/PinPad.tsx
@@ -160,6 +160,8 @@ export function PinPad({ mode, onSubmit, onCancel, error, cooldownSeconds }: Pin
             className="h-12"
             onClick={handleDelete}
             disabled={isCooling}
+            title={t('kiosk.pin_backspace')}
+            aria-label={t('kiosk.pin_backspace')}
             data-testid="kiosk-pin-delete"
           >
             <Delete className="h-5 w-5" />

--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -218,7 +218,7 @@ export default function AppLayout() {
           {/* Menu on the left so the button sits on the side the drawer opens from. */}
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label={t('app.navigation_menu')} data-testid="mobile-menu-button">
+              <Button variant="ghost" size="icon" title={t('app.navigation_menu')} aria-label={t('app.navigation_menu')} data-testid="mobile-menu-button">
                 <Menu className="h-5 w-5" />
               </Button>
             </SheetTrigger>

--- a/app/src/components/live-activity/LiveActivityTile.tsx
+++ b/app/src/components/live-activity/LiveActivityTile.tsx
@@ -18,6 +18,7 @@ import { getMonitorAspectRatio } from '../../lib/monitor/monitor-rotation';
 import { MONITOR_UI } from '../../lib/zmninja-ng-constants';
 import { MontageMonitor } from '../monitors/MontageMonitor';
 import { LiveActivityStateIcon } from './LiveActivityStateIcon';
+import { HintButton } from '../ui/button';
 
 interface LiveActivityTileProps {
   entry: ActiveMonitorEntry;
@@ -126,7 +127,7 @@ export function LiveActivityTile({
       {/* Sits where the alarm-count badge used to, clear of the tile header's
           own buttons. stopPropagation so clearing a tile never doubles as a
           click through to the monitor underneath. */}
-      <button
+      <HintButton
         type="button"
         onClick={(event) => {
           event.stopPropagation();
@@ -138,7 +139,7 @@ export function LiveActivityTile({
         data-testid={`live-activity-dismiss-${entry.monitorId}`}
       >
         <X className="h-3.5 w-3.5" />
-      </button>
+      </HintButton>
 
       {/* Siblings of the tile rather than props of it, so the value that
           changes every second never reaches the memo'd component. */}

--- a/app/src/components/monitors/MonitorCard.tsx
+++ b/app/src/components/monitors/MonitorCard.tsx
@@ -10,7 +10,7 @@ import { memo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '../ui/card';
 import { Badge } from '../ui/badge';
-import { Button } from '../ui/button';
+import { Button, HintButton } from '../ui/button';
 import { Activity, Settings, Download, Clock, Video, Eye, Disc, Volume2, VolumeX } from 'lucide-react';
 import { cn, formatEventCount } from '../../lib/utils';
 import { handleKeyClick } from '../../lib/tv/tv-a11y';
@@ -140,7 +140,7 @@ function MonitorCardComponent({
           <div className="flex items-center gap-1.5">
             <div className="text-xs font-semibold truncate flex-1 min-w-0" title={monitor.Name} data-testid="monitor-name">{monitor.Name}</div>
             {isRTC && (
-              <button
+              <HintButton
                 type="button"
                 className="h-4 w-4 shrink-0 text-muted-foreground hover:text-foreground"
                 onClick={(e) => { e.stopPropagation(); setIsMuted((m) => !m); }}
@@ -149,7 +149,7 @@ function MonitorCardComponent({
                 data-testid="monitor-volume-btn"
               >
                 {isMuted ? <VolumeX className="h-3 w-3" /> : <Volume2 className="h-3 w-3" />}
-              </button>
+              </HintButton>
             )}
             <Badge variant="outline" className="text-[9px] px-1 py-0 h-4 shrink-0">
               {monitor.Id}
@@ -289,7 +289,7 @@ function MonitorCardComponent({
                 ID: {monitor.Id}
               </Badge>
               {isRTC && (
-                <button
+                <HintButton
                   type="button"
                   className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
                   onClick={(e) => { e.stopPropagation(); setIsMuted((m) => !m); }}
@@ -298,7 +298,7 @@ function MonitorCardComponent({
                   data-testid="monitor-volume-btn"
                 >
                   {isMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
-                </button>
+                </HintButton>
               )}
             </div>
             <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">

--- a/app/src/components/monitors/MontageMonitor.tsx
+++ b/app/src/components/monitors/MontageMonitor.tsx
@@ -290,6 +290,7 @@ function MontageMonitorComponent({
                   isFullscreen ? "text-white hover:bg-white/20" : "text-muted-foreground hover:text-foreground"
                 )}
                 onClick={(e) => e.stopPropagation()}
+                title={t('montage.menu_more')}
                 aria-label={t('montage.menu_more')}
                 data-testid="montage-more-btn"
               >

--- a/app/src/components/montage/GridLayoutControls.tsx
+++ b/app/src/components/montage/GridLayoutControls.tsx
@@ -139,6 +139,7 @@ export function GridLayoutControls({
                       variant="ghost"
                       size="icon"
                       className="h-9 w-9 text-destructive shrink-0"
+                      title={`${t('common.delete')}: ${saved.name}`}
                       aria-label={`${t('common.delete')}: ${saved.name}`}
                       onClick={(e) => handleDeleteLayout(index, saved.name, e)}
                       data-testid={`montage-delete-layout-sheet-${index}`}
@@ -188,6 +189,7 @@ export function GridLayoutControls({
                       // Visible icon stays 20px (h-5 w-5); ::before expands
                       // the hit area to the 44px WCAG target size. refs #217.
                       className="relative h-5 w-5 text-destructive hover:text-destructive ml-2 shrink-0 before:absolute before:-inset-3 before:content-['']"
+                      title={`${t('common.delete')}: ${saved.name}`}
                       aria-label={`${t('common.delete')}: ${saved.name}`}
                       onClick={(e) => handleDeleteLayout(index, saved.name, e)}
                       data-testid={`montage-delete-layout-menu-${index}`}

--- a/app/src/components/settings/AppearanceSection.tsx
+++ b/app/src/components/settings/AppearanceSection.tsx
@@ -435,6 +435,7 @@ function ThumbnailFallbackChainEditor({ chain, onChange }: ThumbnailFallbackChai
                 className="h-5 w-5"
                 disabled={index === 0}
                 onClick={() => move(index, -1)}
+                title={t('settings.appearance.thumbnail_chain.move_up')}
                 aria-label={t('settings.appearance.thumbnail_chain.move_up')}
                 data-testid={`settings-thumbnail-chain-${entry.type}-up`}
               >
@@ -447,6 +448,7 @@ function ThumbnailFallbackChainEditor({ chain, onChange }: ThumbnailFallbackChai
                 className="h-5 w-5"
                 disabled={index === safeChain.length - 1}
                 onClick={() => move(index, 1)}
+                title={t('settings.appearance.thumbnail_chain.move_down')}
                 aria-label={t('settings.appearance.thumbnail_chain.move_down')}
                 data-testid={`settings-thumbnail-chain-${entry.type}-down`}
               >

--- a/app/src/components/timeline/TimelineToolbar.tsx
+++ b/app/src/components/timeline/TimelineToolbar.tsx
@@ -104,6 +104,7 @@ export function TimelineToolbar({
               variant="ghost"
               size="icon"
               className="h-6 w-6 text-muted-foreground"
+              title={t('sidebar.help')}
               aria-label={t('sidebar.help')}
               data-testid="timeline-help-button"
             >

--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -10,6 +10,7 @@ import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "../../lib/utils"
+import { useLongPressHint } from "../../hooks/useLongPressHint"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -49,15 +50,29 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
+    // Touch screens never show `title` on hover, so hold-to-explain stands in.
+    const hint = useLongPressHint(props)
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
+        {...hint}
       />
     )
   }
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+/**
+ * A plain `<button>` carrying the same long-press hint as `Button`. Drop it in
+ * where a control is icon-only but styles itself instead of using the variants
+ * above, such as an overlay control on a video tile.
+ */
+const HintButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>((props, ref) => <button ref={ref} {...props} {...useLongPressHint(props)} />)
+HintButton.displayName = "HintButton"
+
+export { Button, HintButton, buttonVariants }

--- a/app/src/components/ui/password-input.tsx
+++ b/app/src/components/ui/password-input.tsx
@@ -56,6 +56,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
             size="sm"
             className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
             onClick={() => setShowPassword((prev) => !prev)}
+            title={showPassword ? t('common.hide_password') : t('common.show_password')}
             aria-label={showPassword ? t('common.hide_password') : t('common.show_password')}
             tabIndex={-1}
           >

--- a/app/src/hooks/__tests__/useLongPressHint.test.tsx
+++ b/app/src/hooks/__tests__/useLongPressHint.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { toast } from 'sonner';
+import { Button } from '../../components/ui/button';
+import { UI_INTERACTIONS } from '../../lib/zmninja-ng-constants';
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { dismiss: vi.fn() }),
+}));
+
+/** Press, hold past the long-press threshold, then release. */
+function longPress(el: HTMLElement) {
+  fireEvent.pointerDown(el, { pointerId: 1, pointerType: 'touch', clientX: 10, clientY: 10 });
+  act(() => {
+    vi.advanceTimersByTime(UI_INTERACTIONS.longPressMs);
+  });
+  fireEvent.pointerUp(el, { pointerId: 1, pointerType: 'touch' });
+}
+
+describe('useLongPressHint via Button', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(toast).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the title as a toast after a long press on a touch screen', () => {
+    render(<Button title="Save snapshot" data-testid="btn" />);
+
+    longPress(screen.getByTestId('btn'));
+
+    expect(vi.mocked(toast)).toHaveBeenCalledWith(
+      'Save snapshot',
+      expect.objectContaining({ duration: UI_INTERACTIONS.hintDurationMs }),
+    );
+  });
+
+  it('stays quiet when the press is released before the threshold', () => {
+    render(<Button title="Save snapshot" data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+
+    fireEvent.pointerDown(btn, { pointerId: 1, pointerType: 'touch', clientX: 10, clientY: 10 });
+    act(() => {
+      vi.advanceTimersByTime(UI_INTERACTIONS.longPressMs - 50);
+    });
+    fireEvent.pointerUp(btn, { pointerId: 1, pointerType: 'touch' });
+
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('cancels the hint when the finger drags away, so scrolls do not fire it', () => {
+    render(<Button title="Save snapshot" data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+
+    fireEvent.pointerDown(btn, { pointerId: 1, pointerType: 'touch', clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(btn, {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 10 + UI_INTERACTIONS.moveCancelPx + 5,
+    });
+    act(() => {
+      vi.advanceTimersByTime(UI_INTERACTIONS.longPressMs);
+    });
+
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('swallows the click that follows a hint so the action does not run', () => {
+    const onClick = vi.fn();
+    render(<Button title="Save snapshot" onClick={onClick} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+
+    longPress(btn);
+    fireEvent.click(btn);
+
+    expect(vi.mocked(toast)).toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('lets a normal tap through untouched', () => {
+    const onClick = vi.fn();
+    render(<Button title="Save snapshot" onClick={onClick} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+
+    fireEvent.pointerDown(btn, { pointerId: 1, pointerType: 'touch', clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(btn, { pointerId: 1, pointerType: 'touch' });
+    fireEvent.click(btn);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('leaves hold-to-repeat buttons alone, since they own the press gesture', () => {
+    const onPointerDown = vi.fn();
+    render(<Button title="Zoom in" onPointerDown={onPointerDown} data-testid="btn" />);
+
+    longPress(screen.getByTestId('btn'));
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a mouse, where hover already shows the title', () => {
+    render(<Button title="Save snapshot" data-testid="btn" />);
+
+    fireEvent.pointerDown(screen.getByTestId('btn'), {
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 10,
+      clientY: 10,
+    });
+    act(() => {
+      vi.advanceTimersByTime(UI_INTERACTIONS.longPressMs);
+    });
+
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the button has no title to explain', () => {
+    render(<Button data-testid="btn" />);
+
+    longPress(screen.getByTestId('btn'));
+
+    expect(vi.mocked(toast)).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/hooks/useLongPressHint.ts
+++ b/app/src/hooks/useLongPressHint.ts
@@ -1,0 +1,104 @@
+/**
+ * useLongPressHint
+ *
+ * Icon-only buttons explain themselves through `title`, which browsers only
+ * reveal on hover. A touch screen has no hover, so on phones and tablets those
+ * buttons say nothing at all. This hook gives them a touch equivalent: hold the
+ * button and its `title` appears as a brief toast, the same affordance Android
+ * gives a view with `tooltipText`.
+ *
+ * The hint replaces the press rather than accompanying it. The click that would
+ * normally follow the release is swallowed, so holding a button explains it
+ * instead of triggering it. A short tap is left completely alone.
+ *
+ * Pass the props you were going to spread on the element and spread the result
+ * instead; any handlers you already had are called first, then the hint's.
+ *
+ *   <button {...useLongPressHint({ title: t('events.delete'), onClick: remove })} />
+ *
+ * `Button` (`components/ui/button.tsx`) does this for you, so anything using it
+ * with a `title` is already covered.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { MouseEventHandler, PointerEventHandler } from 'react';
+import { toast } from 'sonner';
+import { UI_INTERACTIONS } from '../lib/zmninja-ng-constants';
+
+/** The props the hint reads and composes with. Everything else is untouched. */
+export interface LongPressHintProps<E extends HTMLElement> {
+  title?: string;
+  onPointerDown?: PointerEventHandler<E>;
+  onPointerMove?: PointerEventHandler<E>;
+  onPointerUp?: PointerEventHandler<E>;
+  onPointerCancel?: PointerEventHandler<E>;
+  onClickCapture?: MouseEventHandler<E>;
+}
+
+export function useLongPressHint<E extends HTMLElement>(
+  props: LongPressHintProps<E>,
+): LongPressHintProps<E> {
+  const timerRef = useRef<number | null>(null);
+  const pressRef = useRef<{ x: number; y: number; id: number } | null>(null);
+  const firedRef = useRef(false);
+
+  useEffect(() => () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+  }, []);
+
+  // Nothing to explain, or the caller drives its own press gesture
+  // (hold-to-repeat zoom and PTZ buttons), in which case a hold already means
+  // something else and must keep meaning it.
+  const hint = props.title;
+  if (!hint || props.onPointerDown) return props;
+
+  // Every handler below runs the caller's own handler first, so nothing the
+  // element already did is delayed or dropped.
+  return {
+    ...props,
+    onPointerDown: (event) => {
+      if (event.pointerType === 'mouse') return;
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      firedRef.current = false;
+      pressRef.current = { x: event.clientX, y: event.clientY, id: event.pointerId };
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
+        firedRef.current = true;
+        pressRef.current = null;
+        toast(hint, { duration: UI_INTERACTIONS.hintDurationMs, position: 'bottom-center' });
+      }, UI_INTERACTIONS.longPressMs);
+    },
+    onPointerMove: (event) => {
+      props.onPointerMove?.(event);
+      const press = pressRef.current;
+      if (!press || press.id !== event.pointerId) return;
+      const dx = event.clientX - press.x;
+      const dy = event.clientY - press.y;
+      // A drag is a scroll or a swipe, not a hold.
+      if (dx * dx + dy * dy > UI_INTERACTIONS.moveCancelPx ** 2) {
+        if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+        pressRef.current = null;
+      }
+    },
+    onPointerUp: (event) => {
+      props.onPointerUp?.(event);
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+      pressRef.current = null;
+    },
+    onPointerCancel: (event) => {
+      props.onPointerCancel?.(event);
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+      pressRef.current = null;
+    },
+    onClickCapture: (event) => {
+      props.onClickCapture?.(event);
+      if (!firedRef.current) return;
+      firedRef.current = false;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+  };
+}

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -503,6 +503,10 @@ export const UI_INTERACTIONS = {
 
   // Pointer movement threshold to cancel a long-press (px)
   moveCancelPx: 8,
+
+  // How long a long-press hint toast stays up (ms). Long enough to read a
+  // short label, short enough that it is gone before the next tap.
+  hintDurationMs: 1500,
 } as const;
 
 /**

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -44,7 +44,10 @@
     "running": "Läuft",
     "stopped": "Gestoppt",
     "done": "Fertig",
-    "press_back_again_to_exit": "Zum Beenden erneut zurück"
+    "press_back_again_to_exit": "Zum Beenden erneut zurück",
+    "expand": "Aufklappen",
+    "collapse": "Zuklappen",
+    "remove": "Entfernen"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -236,7 +239,8 @@
       "loading": "Tags werden geladen...",
       "moreCount": "+{{count}} mehr"
     },
-    "now": "jetzt"
+    "now": "jetzt",
+    "remove_tag": "{{name}} entfernen"
   },
   "event_detail": {
     "event_id": "Ereignis ID",
@@ -835,7 +839,9 @@
     "select_profile_first": "Wählen Sie zuerst ein Profil",
     "source_websocket": "Echtzeit",
     "source_push": "Push",
-    "source_poll": "Abgefragt"
+    "source_poll": "Abgefragt",
+    "unread_count_one": "{{count}} ungelesene Benachrichtigung",
+    "unread_count_other": "{{count}} ungelesene Benachrichtigungen"
   },
   "notification_settings": {
     "title": "Benachrichtigungseinstellungen",
@@ -1316,7 +1322,8 @@
     "pin_changed": "Kiosk-PIN aktualisiert",
     "pin_cleared": "Kiosk-PIN entfernt",
     "pin_setting_label": "Kiosk-PIN",
-    "pin_setting_desc": "PIN zum Sperren und Entsperren des Kiosk-Modus"
+    "pin_setting_desc": "PIN zum Sperren und Entsperren des Kiosk-Modus",
+    "pin_backspace": "Letzte Ziffer löschen"
   },
   "command_palette": {
     "title": "Springe zu",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -44,7 +44,10 @@
     "done": "Done",
     "default": "Default",
     "server": "Server",
-    "press_back_again_to_exit": "Press back again to exit"
+    "press_back_again_to_exit": "Press back again to exit",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "remove": "Remove"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -236,7 +239,8 @@
       "loading": "Loading tags...",
       "moreCount": "+{{count}} more"
     },
-    "now": "now"
+    "now": "now",
+    "remove_tag": "Remove {{name}}"
   },
   "event_detail": {
     "event_id": "Event ID",
@@ -835,7 +839,9 @@
     "select_profile_first": "Please select a profile first",
     "source_websocket": "Real-time",
     "source_push": "Push",
-    "source_poll": "Polled"
+    "source_poll": "Polled",
+    "unread_count_one": "{{count}} unread notification",
+    "unread_count_other": "{{count}} unread notifications"
   },
   "notification_settings": {
     "title": "Notification Settings",
@@ -1316,7 +1322,8 @@
     "pin_changed": "Kiosk PIN updated",
     "pin_cleared": "Kiosk PIN removed",
     "pin_setting_label": "Kiosk PIN",
-    "pin_setting_desc": "PIN used to lock and unlock kiosk mode"
+    "pin_setting_desc": "PIN used to lock and unlock kiosk mode",
+    "pin_backspace": "Delete last digit"
   },
   "command_palette": {
     "title": "Jump to",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -44,7 +44,10 @@
     "running": "En ejecución",
     "stopped": "Detenido",
     "done": "Listo",
-    "press_back_again_to_exit": "Pulsa atrás de nuevo para salir"
+    "press_back_again_to_exit": "Pulsa atrás de nuevo para salir",
+    "expand": "Expandir",
+    "collapse": "Contraer",
+    "remove": "Quitar"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -236,7 +239,8 @@
       "loading": "Cargando etiquetas...",
       "moreCount": "+{{count}} más"
     },
-    "now": "ahora"
+    "now": "ahora",
+    "remove_tag": "Quitar {{name}}"
   },
   "event_detail": {
     "event_id": "ID de Evento",
@@ -835,7 +839,9 @@
     "select_profile_first": "Seleccione un perfil primero",
     "source_websocket": "Tiempo real",
     "source_push": "Push",
-    "source_poll": "Consultado"
+    "source_poll": "Consultado",
+    "unread_count_one": "{{count}} notificación sin leer",
+    "unread_count_other": "{{count}} notificaciones sin leer"
   },
   "notification_settings": {
     "title": "Notificaciones",
@@ -1316,7 +1322,8 @@
     "pin_changed": "PIN de kiosco actualizado",
     "pin_cleared": "PIN de kiosco eliminado",
     "pin_setting_label": "PIN de kiosco",
-    "pin_setting_desc": "PIN para bloquear y desbloquear el modo kiosco"
+    "pin_setting_desc": "PIN para bloquear y desbloquear el modo kiosco",
+    "pin_backspace": "Borrar último dígito"
   },
   "command_palette": {
     "title": "Ir a",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -44,7 +44,10 @@
     "running": "En cours d'exécution",
     "stopped": "Arrêté",
     "done": "Terminé",
-    "press_back_again_to_exit": "Appuyez encore pour quitter"
+    "press_back_again_to_exit": "Appuyez encore pour quitter",
+    "expand": "Développer",
+    "collapse": "Réduire",
+    "remove": "Retirer"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -236,7 +239,8 @@
       "loading": "Chargement des tags...",
       "moreCount": "+{{count}} de plus"
     },
-    "now": "maintenant"
+    "now": "maintenant",
+    "remove_tag": "Retirer {{name}}"
   },
   "event_detail": {
     "event_id": "ID Événement",
@@ -835,7 +839,9 @@
     "select_profile_first": "Sélectionnez d'abord un profil",
     "source_websocket": "Temps réel",
     "source_push": "Push",
-    "source_poll": "Interrogé"
+    "source_poll": "Interrogé",
+    "unread_count_one": "{{count}} notification non lue",
+    "unread_count_other": "{{count}} notifications non lues"
   },
   "notification_settings": {
     "title": "Paramètres de notification",
@@ -1316,7 +1322,8 @@
     "pin_changed": "PIN kiosque mis à jour",
     "pin_cleared": "PIN kiosque supprimé",
     "pin_setting_label": "PIN kiosque",
-    "pin_setting_desc": "PIN pour verrouiller et déverrouiller le mode kiosque"
+    "pin_setting_desc": "PIN pour verrouiller et déverrouiller le mode kiosque",
+    "pin_backspace": "Supprimer le dernier chiffre"
   },
   "command_palette": {
     "title": "Aller à",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -44,7 +44,10 @@
     "running": "运行中",
     "stopped": "已停止",
     "done": "完成",
-    "press_back_again_to_exit": "再次返回以退出"
+    "press_back_again_to_exit": "再次返回以退出",
+    "expand": "展开",
+    "collapse": "收起",
+    "remove": "移除"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -236,7 +239,8 @@
       "loading": "正在加载标签...",
       "moreCount": "+{{count}} 更多"
     },
-    "now": "现在"
+    "now": "现在",
+    "remove_tag": "移除 {{name}}"
   },
   "event_detail": {
     "event_id": "事件 ID",
@@ -835,7 +839,9 @@
     "select_profile_first": "请先选择配置",
     "source_websocket": "实时",
     "source_push": "推送",
-    "source_poll": "轮询"
+    "source_poll": "轮询",
+    "unread_count_one": "{{count}} 条未读通知",
+    "unread_count_other": "{{count}} 条未读通知"
   },
   "notification_settings": {
     "title": "通知设置",
@@ -1316,7 +1322,8 @@
     "pin_changed": "展台PIN已更新",
     "pin_cleared": "展台PIN已移除",
     "pin_setting_label": "展台PIN",
-    "pin_setting_desc": "用于锁定和解锁展台模式的PIN"
+    "pin_setting_desc": "用于锁定和解锁展台模式的PIN",
+    "pin_backspace": "删除最后一位"
   },
   "command_palette": {
     "title": "跳转至",

--- a/app/src/pages/DeveloperNotice.tsx
+++ b/app/src/pages/DeveloperNotice.tsx
@@ -11,7 +11,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
-import { Button } from '../components/ui/button';
+import { Button, HintButton } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { Megaphone, AlertTriangle, AlertCircle, Info, ChevronDown, ChevronUp, ExternalLink, RefreshCw, Eye, EyeOff, CheckCheck, Mail, Trash2, MoreVertical, RotateCcw } from 'lucide-react';
 import { useDeveloperNotices, type DeveloperNoticeView } from '../hooks/useDeveloperNotices';
@@ -96,7 +96,7 @@ function NoticeRow({ notice }: { notice: DeveloperNoticeView }) {
             </div>
           </div>
         </button>
-        <button
+        <HintButton
           type="button"
           onClick={handleReadToggle}
           className="mt-0.5 p-1 rounded hover:bg-accent text-muted-foreground flex-shrink-0"
@@ -105,8 +105,8 @@ function NoticeRow({ notice }: { notice: DeveloperNoticeView }) {
           data-testid={`developer-notice-read-toggle-${notice.id}`}
         >
           {notice.isRead ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-        </button>
-        <button
+        </HintButton>
+        <HintButton
           type="button"
           onClick={(e) => { e.stopPropagation(); deleteNotice(notice.id); }}
           className="mt-0.5 p-1 rounded hover:bg-accent text-muted-foreground flex-shrink-0"
@@ -115,16 +115,17 @@ function NoticeRow({ notice }: { notice: DeveloperNoticeView }) {
           data-testid={`developer-notice-delete-${notice.id}`}
         >
           <Trash2 className="h-3.5 w-3.5" />
-        </button>
-        <button
+        </HintButton>
+        <HintButton
           type="button"
           onClick={handleToggle}
           className="mt-0.5 p-1 rounded hover:bg-accent text-muted-foreground flex-shrink-0"
+          title={expanded ? t('common.close') : t('common.view')}
           aria-label={expanded ? t('common.close') : t('common.view')}
           data-testid={`developer-notice-chevron-${notice.id}`}
         >
           {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-        </button>
+        </HintButton>
       </div>
       {expanded && (
         <div className="px-3 pb-3 pl-10 pt-2 border-t border-border/40 mt-1">
@@ -238,6 +239,7 @@ export default function DeveloperNotice() {
                 variant="outline"
                 size="icon"
                 className="h-9 w-9"
+                title={t('developer_notice.more_actions')}
                 aria-label={t('developer_notice.more_actions')}
                 data-testid="developer-notice-actions-menu"
               >

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -385,6 +385,7 @@ export default function EventDetail() {
             variant="ghost"
             size="icon"
             onClick={goBack}
+            title={t('common.go_back')}
             aria-label={t('common.go_back')}
             className="h-8 w-8"
             data-testid="event-detail-back"
@@ -396,6 +397,7 @@ export default function EventDetail() {
             size="icon"
             onClick={goToPrevEvent}
             disabled={isLoadingPrev}
+            title={t('common.previous')}
             aria-label={t('common.previous')}
             className="h-7 w-7"
             data-testid="event-detail-prev"
@@ -423,6 +425,7 @@ export default function EventDetail() {
             size="icon"
             onClick={() => { void goToNextEvent(); }}
             disabled={isLoadingNext}
+            title={t('common.next')}
             aria-label={t('common.next')}
             className="h-7 w-7"
             data-testid="event-detail-next"

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -411,6 +411,7 @@ export default function Events() {
                 variant="outline"
                 size="icon"
                 onClick={() => handleViewModeChange(viewMode === 'list' ? 'montage' : 'list')}
+                title={viewMode === 'list' ? t('events.view_montage') : t('events.view_list')}
                 aria-label={viewMode === 'list' ? t('events.view_montage') : t('events.view_list')}
                 data-testid="events-view-toggle"
               >
@@ -448,6 +449,7 @@ export default function Events() {
                     variant={activeFilterCount > 0 ? 'default' : 'outline'}
                     size="icon"
                     className="relative"
+                    title={t('events.filters')}
                     aria-label={t('events.filters')}
                     data-testid="events-filter-button"
                   >

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -237,6 +237,7 @@ export default function MonitorDetail() {
             variant="ghost"
             size="icon"
             onClick={goBack}
+            title={t('common.go_back')}
             aria-label={t('common.go_back')}
             className="h-8 w-8"
             data-testid="monitor-detail-back"
@@ -248,6 +249,7 @@ export default function MonitorDetail() {
             size="icon"
             onClick={onSwipeRight}
             disabled={!hasPrev}
+            title={t('common.previous')}
             aria-label={t('common.previous')}
             className="h-7 w-7"
             data-testid="monitor-detail-prev"
@@ -281,6 +283,7 @@ export default function MonitorDetail() {
             size="icon"
             onClick={onSwipeLeft}
             disabled={!hasNext}
+            title={t('common.next')}
             aria-label={t('common.next')}
             className="h-7 w-7"
             data-testid="monitor-detail-next"
@@ -305,6 +308,7 @@ export default function MonitorDetail() {
           <Button
             variant="ghost"
             size="icon"
+            title={t('monitor_detail.settings')}
             aria-label={t('monitor_detail.settings')}
             className="h-8 w-8 sm:h-9 sm:w-9"
             onClick={() => setShowSettingsDialog(true)}
@@ -452,6 +456,7 @@ export default function MonitorDetail() {
               size="icon"
               className="h-8 w-8"
               onClick={handleToggleFullscreen}
+              title={t('monitor_detail.maximize')}
               aria-label={t('monitor_detail.maximize')}
               data-testid="monitor-detail-maximize"
             >

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -183,6 +183,7 @@ export default function Monitors() {
               const next = settings.monitorsViewMode === 'list' ? 'grid' : 'list';
               updateSettings(currentProfile.id, { monitorsViewMode: next });
             }}
+            title={settings.monitorsViewMode === 'list' ? t('events.view_montage') : t('events.view_list')}
             aria-label={settings.monitorsViewMode === 'list' ? t('events.view_montage') : t('events.view_list')}
             data-testid="monitors-view-toggle"
           >

--- a/app/src/pages/ProfileForm.tsx
+++ b/app/src/pages/ProfileForm.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Button } from '../components/ui/button';
+import { Button, HintButton } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -439,15 +439,17 @@ export default function ProfileForm() {
                 data-testid="setup-password"
               />
               {password && (
-                <button
+                <HintButton
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="absolute right-3 top-2.5 text-muted-foreground hover:text-foreground transition-colors"
                   tabIndex={-1}
+                  title={showPassword ? t('common.hide_password') : t('common.show_password')}
+                  aria-label={showPassword ? t('common.hide_password') : t('common.show_password')}
                   data-testid="setup-password-toggle"
                 >
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
+                </HintButton>
               )}
             </div>
             <p className="text-xs text-muted-foreground">

--- a/app/src/pages/Profiles.tsx
+++ b/app/src/pages/Profiles.tsx
@@ -414,6 +414,7 @@ export default function Profiles() {
                         variant="ghost"
                         size="icon"
                         onClick={() => handleOpenEditDialog(profile)}
+                        title={t('common.edit')}
                         aria-label={t('common.edit')}
                         data-testid={`profile-edit-button-${profile.id}`}
                       >
@@ -425,6 +426,7 @@ export default function Profiles() {
                           size="icon"
                           onClick={() => handleOpenDeleteDialog(profile)}
                           className="text-destructive hover:text-destructive"
+                          title={t('common.delete')}
                           aria-label={t('common.delete')}
                           data-testid={`profile-delete-button-${profile.id}`}
                         >
@@ -537,6 +539,8 @@ export default function Profiles() {
                     className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                     onClick={() => setShowPassword(!showPassword)}
                     tabIndex={-1}
+                    title={showPassword ? t('common.hide_password') : t('common.show_password')}
+                    aria-label={showPassword ? t('common.hide_password') : t('common.show_password')}
                     data-testid="profile-edit-password-toggle"
                   >
                     {showPassword ? (

--- a/app/tests/features/monitors.feature
+++ b/app/tests/features/monitors.feature
@@ -51,6 +51,13 @@ Feature: Monitor List and Navigation
     Then I should see at least 1 monitor cards
     And the monitor grid should lay out cards in more than one column
 
+  @web
+  Scenario: Holding an icon button explains it instead of acting on it
+    Then I should see at least 1 monitor cards
+    When I long-press the monitors view toggle
+    Then I should see a hint toast naming the view toggle
+    And the monitors view should not have switched
+
   @all
   Scenario: Opening a monitor's events clears only that monitor's new-event badge
     When I seed old watermarks for monitors with events

--- a/app/tests/steps/monitors.steps.ts
+++ b/app/tests/steps/monitors.steps.ts
@@ -276,3 +276,41 @@ Then('the other badged monitors should keep theirs', async ({ page }) => {
     await expect(card.getByTestId('monitor-new-events-badge')).toHaveCount(1);
   }
 });
+
+// The label the view toggle carried before the long press. The hint should
+// echo it, and it should still be the label afterwards: if the button had
+// acted, the toggle would now advertise the opposite view.
+let heldButtonLabel = '';
+
+When('I long-press the monitors view toggle', async ({ page }) => {
+  const toggle = page.getByTestId('monitors-view-toggle');
+  await expect(toggle).toBeVisible({ timeout: testConfig.timeouts.pageLoad });
+
+  const label = await toggle.getAttribute('title');
+  expect(label, 'the view toggle needs a title for the hint to show').toBeTruthy();
+  heldButtonLabel = label as string;
+
+  const box = await toggle.boundingBox();
+  expect(box, 'the view toggle needs a box to press in the middle of').not.toBeNull();
+  const center = { clientX: box!.x + box!.width / 2, clientY: box!.y + box!.height / 2 };
+
+  // A real finger, not a mouse: the hint deliberately ignores mouse presses
+  // because hover already reveals the title there.
+  await toggle.dispatchEvent('pointerdown', { pointerType: 'touch', pointerId: 1, isPrimary: true, ...center });
+});
+
+Then('I should see a hint toast naming the view toggle', async ({ page }) => {
+  // No fixed wait: the toast only appears once the hold passes the threshold,
+  // so the auto-retrying assertion is what times the press.
+  await expect(page.locator('[data-sonner-toast]')).toHaveText(heldButtonLabel, {
+    timeout: testConfig.timeouts.transition,
+  });
+
+  const toggle = page.getByTestId('monitors-view-toggle');
+  await toggle.dispatchEvent('pointerup', { pointerType: 'touch', pointerId: 1, isPrimary: true });
+  await toggle.dispatchEvent('click');
+});
+
+Then('the monitors view should not have switched', async ({ page }) => {
+  await expect(page.getByTestId('monitors-view-toggle')).toHaveAttribute('title', heldButtonLabel);
+});

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -25,6 +25,7 @@ Navigate from outside a React component         Navigation Service (``lib/naviga
 Save a montage layout per monitor group         Group-Keyed Montage Settings (``stores/settings.ts``)
 Count events the user has not seen yet          Monitor Seen Watermarks (``stores/monitorSeen.ts``)
 Read a profile setting from a non-React module  Profile Settings Accessor (``lib/profile/profile-settings.ts``)
+Explain an icon-only button on a touch screen   useLongPressHint (``hooks/useLongPressHint.ts``)
 ==============================================  ===============================================================
 
 Shared Services (lib/ and services/)
@@ -1342,14 +1343,62 @@ race.
 
 **Used by:** ``components/layout/OfflineBanner.tsx``.
 
+useLongPressHint (``hooks/useLongPressHint.ts``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An icon-only button explains itself through ``title``, which browsers reveal on
+hover. A touch screen has no hover, so on a phone those buttons say nothing.
+This hook gives them a touch equivalent: hold the button and its ``title``
+appears as a brief toast, matching what Android does for a view with
+``tooltipText``.
+
+Pass the props you were about to spread on the element and spread the result
+instead:
+
+.. code:: tsx
+
+   <button {...useLongPressHint({ title: t('events.delete'), onClick: remove })} />
+
+Three decisions are worth knowing before you use it.
+
+The hint fires on hold, not on tap. A tap already runs the action, so a toast
+explaining what just happened would be noise on every use forever. The click
+that would follow the release is swallowed in ``onClickCapture``, so a hold
+explains the button instead of pressing it. A short tap is untouched.
+
+A press whose ``pointerType`` is ``'mouse'`` is ignored, because hover already
+shows the title there. Gating on the pointer rather than on the platform means
+a touchscreen laptop gets the hint from its screen and not from its trackpad.
+
+If the caller already passes ``onPointerDown``, the hook disables itself and
+returns the props unchanged. On those elements a hold already means something:
+``components/ui/zoom-controls.tsx`` and ``monitors/PTZControls.tsx`` repeat
+their action while held, and a hint would fight the gesture. This is why
+neither file needed an opt-out prop.
+
+Timings come from ``UI_INTERACTIONS`` in ``lib/zmninja-ng-constants.ts``:
+``longPressMs`` (500) to trigger, ``moveCancelPx`` (8) of drag to cancel so a
+scroll never fires it, and ``hintDurationMs`` (1500) for how long the toast
+stays up.
+
+**Used by:** ``components/ui/button.tsx``, through both ``Button`` and
+``HintButton``.
+
 Shared Components
 -----------------
 
-``components/ui/`` holds the unmodified shadcn/ui primitives (``button``,
-``card``, ``dialog``, ``popover``, ``select``, ``switch``, ``badge``,
-``progress``, and the rest). They behave as the
+``components/ui/`` holds the shadcn/ui primitives (``button``, ``card``,
+``dialog``, ``popover``, ``select``, ``switch``, ``badge``, ``progress``, and
+the rest). They behave as the
 `shadcn/ui documentation <https://ui.shadcn.com/docs/components>`_ describes
 and this guide does not restate it. What follows is what this project wrote.
+
+``button.tsx`` is the one primitive that diverges. ``Button`` runs its own
+props through ``useLongPressHint``, so any button carrying a ``title`` explains
+itself on a long press without its call site changing. ``HintButton``, exported
+from the same file, is a plain ``<button>`` with the same wiring and no
+variants; reach for it where a control styles itself, such as an overlay on a
+video tile, and would lose that styling as a ``Button``.
 
 PageContainer (``components/common/PageContainer.tsx``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -49,6 +49,14 @@ Controls at the bottom of the sidebar:
 - **Keep screen awake (Insomnia)**: stops the device from sleeping while you watch live feeds. Useful on a wall display or while monitoring.
 - **Kiosk lock**: locks the app into kiosk mode; unlocking requires your PIN or biometrics. See {doc}`kiosk`.
 
+## Finding out what a button does
+
+Much of the app is icon-only buttons: a download arrow on a monitor tile, a magnifier on the timeline, a chevron that collapses a panel. On desktop, resting the mouse on one shows its name.
+
+On a phone or tablet there is nothing to hover, so press and hold the button instead. After about half a second its name appears in a small message at the bottom of the screen, and the button does not act. Let go and nothing happens; tap it normally when you want it to run.
+
+If you start scrolling or swiping instead of holding still, the name does not appear, so the gesture never gets in the way of moving around a list.
+
 ## Supported Features
 
 | Feature | Status |


### PR DESCRIPTION
Closes #332.

`title` only shows on hover, so on a phone or tablet roughly 98 of the app's 112 icon-only buttons explained nothing. Holding one now shows its label as a brief toast, the affordance Android gives a view with `tooltipText`.

## How it works

`useLongPressHint` (`app/src/hooks/useLongPressHint.ts`) takes the props you were about to spread on an element and returns them with the pointer handlers composed in. Three decisions worth reviewing:

- **Hold, not tap.** A tap already runs the action, so a toast explaining it afterwards would be noise on every use. The click that would follow the release is swallowed in `onClickCapture`, so a hold explains the button instead of pressing it. A short tap is untouched.
- **Gated on `pointerType`, not platform.** A `'mouse'` press is ignored because hover already shows the title there. Gating on the pointer means a touchscreen laptop gets the hint from its screen and not from its trackpad.
- **Callers that pass their own `onPointerDown` are skipped.** On those a hold already means something: `ui/zoom-controls.tsx` and `monitors/PTZControls.tsx` repeat their action while held. This is why neither file needed an opt-out prop, and why neither is touched in this diff.

`Button` runs its own props through the hook, so all 51 icon buttons that already had a `title` are covered with no call-site change. `HintButton`, exported from the same file, is a plain `<button>` with the same wiring for the 14 controls that style themselves and would lose that as a `Button`.

## Labels

Buttons that had `aria-label` but no `title` now set `title` to the same string, so most of the backfill needed no new locale keys. Seven new keys across all five locales cover the rest. Two strings that were hardcoded English (`NotificationBadge`, `TagChip`) are localized now that a long press makes them visible.

Coverage went from 61 to 102 of 111 pure-icon controls. Deliberately left out: the montage pin button and the timeline scrubber thumbnails, both of which own their own touch gesture.

## Verification

- `npm run gates` passes: 3244 unit tests, build, and the three blocking lint configs. Ratchet baseline holds at 213.
- `npm run test:e2e -- monitors.feature`: 10 passed, including the new scenario.
- The new scenario was confirmed to fail before the fix. With `{...hint}` removed from `Button`, "Holding an icon button explains it instead of acting on it" fails on the missing toast; it passes once restored.
- Not verified: on-device behavior on iOS and Android, which is manual-only per the testing playbook. The hint path is exercised in Chromium through synthesized touch pointer events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)