### PR TITLE
Stop requesting alarm frames events never recorded

### DIFF
--- a/app/src/components/events/EventListView.tsx
+++ b/app/src/components/events/EventListView.tsx
@@ -11,7 +11,7 @@ import { Button } from '../ui/button';
 import { EventCard } from './EventCard';
 import { type EventFilters } from '../../api/events';
 import { getPortalUrlForMonitor, getServerMapVersion, subscribeServerMap } from '../../lib/zm/server-resolver';
-import { buildThumbnailChain } from '../../lib/event/thumbnail-chain';
+import { buildThumbnailChain, eventHasAlarmFrame } from '../../lib/event/thumbnail-chain';
 import { calculateThumbnailDimensions, EVENT_GRID_CONSTANTS, getMonitorDimensions } from '../../lib/event/event-utils';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import type { EventData, Monitor, Tag } from '../../api/types';
@@ -80,6 +80,7 @@ const EventItem = memo(function EventItem({
     height: thumbnailHeight,
     minStreamingPort,
     monitorId: Event.MonitorId,
+    hasAlarmFrame: eventHasAlarmFrame(Event),
   });
 
   // Full-size image chain used by the desktop hover preview. No width/height
@@ -88,6 +89,7 @@ const EventItem = memo(function EventItem({
     token: accessToken,
     minStreamingPort,
     monitorId: Event.MonitorId,
+    hasAlarmFrame: eventHasAlarmFrame(Event),
   });
 
   const monitorName = monitorData?.Name || `Camera ${Event.MonitorId}`;

--- a/app/src/components/events/EventMontageView.tsx
+++ b/app/src/components/events/EventMontageView.tsx
@@ -23,7 +23,7 @@ import { EventThumbnail } from './EventThumbnail';
 import { downloadEventVideo } from '../../services/download';
 import { type EventFilters } from '../../api/events';
 import { getPortalUrlForEvent } from '../../lib/zm/server-resolver';
-import { buildThumbnailChain } from '../../lib/event/thumbnail-chain';
+import { buildThumbnailChain, eventHasAlarmFrame } from '../../lib/event/thumbnail-chain';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { EventThumbnailHoverPreview } from './EventThumbnailHoverPreview';
 import { calculateThumbnailDimensions, getMonitorDimensions } from '../../lib/event/event-utils';
@@ -104,6 +104,7 @@ const EventMontageTile = memo(function EventMontageTile({
     height: thumbnailHeight,
     minStreamingPort,
     monitorId: event.MonitorId,
+    hasAlarmFrame: eventHasAlarmFrame(event),
   });
 
   const hasVideo = event.Videoed === '1';

--- a/app/src/components/monitors/MonitorRecentEvents.tsx
+++ b/app/src/components/monitors/MonitorRecentEvents.tsx
@@ -16,7 +16,7 @@ import { useMonitorSeenStore } from '../../stores/monitorSeen';
 import { useFreshAccessToken } from '../../hooks/useFreshAccessToken';
 import { resolveMinStreamingPort } from '../../lib/monitor/multiport';
 import { getPortalUrlForEvent } from '../../lib/zm/server-resolver';
-import { buildThumbnailChain } from '../../lib/event/thumbnail-chain';
+import { buildThumbnailChain, eventHasAlarmFrame } from '../../lib/event/thumbnail-chain';
 import {
   calculateThumbnailDimensions,
   getMonitorDimensions,
@@ -70,6 +70,7 @@ export function MonitorRecentEvents({ monitor }: MonitorRecentEventsProps) {
       height: th,
       minStreamingPort,
       monitorId: ev.MonitorId,
+      hasAlarmFrame: eventHasAlarmFrame(ev),
     });
     return { urls, aspectRatio: tw / th };
   };

--- a/app/src/components/timeline/TimelineScrubber.tsx
+++ b/app/src/components/timeline/TimelineScrubber.tsx
@@ -101,6 +101,9 @@ function ScrubberThumbnail({
     token: isAccessTokenFresh ? accessToken ?? undefined : undefined,
     minStreamingPort: resolveMinStreamingPort(currentProfile?.minStreamingPort, settings.forceDisableMultiPort),
     monitorId: event.monitorId,
+    // A timeline row carries the ratio rather than the raw count, but zero
+    // still means no alarm frame to ask for (refs #331).
+    hasAlarmFrame: event.alarmRatio > 0,
   });
 
   const button = (

--- a/app/src/components/ui/collapsible-card.tsx
+++ b/app/src/components/ui/collapsible-card.tsx
@@ -55,7 +55,10 @@ export function CollapsibleCard({
     <Card data-testid={props['data-testid']}>
       <Collapsible open={open} onOpenChange={handleOpenChange}>
         <CollapsibleTrigger asChild>
-          <CardHeader className="cursor-pointer select-none">
+          <CardHeader
+            className="cursor-pointer select-none"
+            data-testid={props['data-testid'] ? `${props['data-testid']}-toggle` : undefined}
+          >
             <div className="flex items-center justify-between">
               <div className="flex-1">{header}</div>
               <ChevronDown

--- a/app/src/lib/assistant/display.ts
+++ b/app/src/lib/assistant/display.ts
@@ -15,12 +15,12 @@
  */
 import type { Event, MonitorData } from '../../api/types';
 import { getPortalUrlForEvent } from '../zm/server-resolver';
-import { buildThumbnailChain } from '../event/thumbnail-chain';
+import { buildThumbnailChain, eventHasAlarmFrame } from '../event/thumbnail-chain';
 import { parseDetectedObjects } from '../event/event-detection';
 import { formatAppDateTimeShort } from '../format-date-time';
 import type { DisplayEntity, ToolContext } from './types';
 
-type EventLike = Pick<Event, 'Id' | 'MonitorId' | 'StartDateTime' | 'Notes' | 'Cause'>;
+type EventLike = Pick<Event, 'Id' | 'MonitorId' | 'StartDateTime' | 'Notes' | 'Cause' | 'AlarmFrames'>;
 
 /** Builds one event result card. `monitorName` is already resolved by the
  *  caller (list_events/get_event both build a monitor id -> name map for the
@@ -44,6 +44,7 @@ export function buildEventDisplayEntity(
       token: ctx.accessToken ?? undefined,
       minStreamingPort: ctx.minStreamingPort,
       monitorId: e.MonitorId,
+      hasAlarmFrame: eventHasAlarmFrame(e),
     });
   }
 

--- a/app/src/lib/event/__tests__/thumbnail-chain.test.ts
+++ b/app/src/lib/event/__tests__/thumbnail-chain.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveFallbackFids, buildThumbnailChain } from '../thumbnail-chain';
+import { resolveFallbackFids, buildThumbnailChain, eventHasAlarmFrame } from '../thumbnail-chain';
 import type { ThumbnailFallbackEntry } from '../../../stores/settings';
 
 describe('resolveFallbackFids', () => {
@@ -94,5 +94,47 @@ describe('buildThumbnailChain', () => {
       { type: 'snapshot', enabled: false },
     ];
     expect(buildThumbnailChain('https://zm.example.com/zm', '42', chain)).toEqual([]);
+  });
+});
+
+describe('skipping the alarm frame an event does not have', () => {
+  const chain: ThumbnailFallbackEntry[] = [
+    { type: 'alarm', enabled: true },
+    { type: 'snapshot', enabled: true },
+  ];
+
+  it('drops the alarm fid when the event recorded no alarm frames', () => {
+    expect(resolveFallbackFids(chain, { hasAlarmFrame: false })).toEqual(['snapshot']);
+  });
+
+  it('keeps the alarm fid when the event recorded alarm frames', () => {
+    expect(resolveFallbackFids(chain, { hasAlarmFrame: true })).toEqual(['alarm', 'snapshot']);
+  });
+
+  it('keeps the alarm fid when the caller cannot say, so nothing regresses', () => {
+    expect(resolveFallbackFids(chain)).toEqual(['alarm', 'snapshot']);
+  });
+
+  it('builds no alarm URL for an event with no alarm frames', () => {
+    // Decoded first: under dev the real URL is nested percent-encoded inside
+    // the image proxy, so a raw substring check would never match.
+    const urls = buildThumbnailChain('https://zm.example/zm', '42', chain, {
+      hasAlarmFrame: false,
+    }).map(decodeURIComponent);
+    expect(urls.some((url) => url.includes('fid=alarm'))).toBe(false);
+    expect(urls.some((url) => url.includes('fid=snapshot'))).toBe(true);
+  });
+});
+
+describe('eventHasAlarmFrame', () => {
+  it('reads the recorded alarm frame count', () => {
+    expect(eventHasAlarmFrame({ AlarmFrames: '3' })).toBe(true);
+    expect(eventHasAlarmFrame({ AlarmFrames: '0' })).toBe(false);
+  });
+
+  it('assumes an alarm frame when the count is missing or unparsable', () => {
+    // Better one wasted request than a silently missing alarm thumbnail.
+    expect(eventHasAlarmFrame({})).toBe(true);
+    expect(eventHasAlarmFrame({ AlarmFrames: '' })).toBe(true);
   });
 });

--- a/app/src/lib/event/thumbnail-chain.ts
+++ b/app/src/lib/event/thumbnail-chain.ts
@@ -17,13 +17,54 @@ export interface ThumbnailChainOptions {
   apiUrl?: string;
   minStreamingPort?: number;
   monitorId?: string;
+  /**
+   * Whether this event has an alarm frame at all. When false the `alarm`
+   * candidate is dropped instead of requested (refs #331): ZoneMinder answers
+   * 404 for an alarm frame that was never recorded, and the chain only falls
+   * through to `snapshot` after the browser reports that failure. One list of
+   * events therefore costs one 404 per event, which reads to a reverse proxy
+   * as an attack; one reporter was IP-banned by their own proxy for it.
+   *
+   * Omit it when the caller has no event record to consult, such as a push
+   * notification: the alarm candidate is then kept and behaviour is unchanged.
+   */
+  hasAlarmFrame?: boolean;
 }
 
-export function resolveFallbackFids(chain: ThumbnailFallbackEntry[] | undefined): string[] {
+/** The event fields this module needs. Kept structural so callers can pass an
+ *  `Event`, a timeline row, or a notification payload without converting. */
+interface AlarmFrameCountLike {
+  AlarmFrames?: string | number | null;
+}
+
+/**
+ * Whether ZoneMinder recorded an alarm frame for this event.
+ *
+ * `AlarmFrames` is a required field on `EventSchema`, so it rides along with
+ * every list response already; this costs no extra request. An absent or
+ * unparsable count returns true, because a wasted request is cheaper than
+ * silently dropping the alarm thumbnail of an event that does have one.
+ *
+ * Note this is the count, not `AlarmFrameId`: that field is optional on the
+ * schema and missing from some servers' list responses, so branching on it
+ * would skip alarm frames for events that really have them.
+ */
+export function eventHasAlarmFrame(event: AlarmFrameCountLike): boolean {
+  const parsed = Number(event.AlarmFrames);
+  if (!Number.isFinite(parsed)) return true;
+  if (event.AlarmFrames === '' || event.AlarmFrames === null) return true;
+  return parsed > 0;
+}
+
+export function resolveFallbackFids(
+  chain: ThumbnailFallbackEntry[] | undefined,
+  options: Pick<ThumbnailChainOptions, 'hasAlarmFrame'> = {}
+): string[] {
   const fids: string[] = [];
   if (!Array.isArray(chain)) return fids;
   for (const entry of chain) {
     if (!entry.enabled) continue;
+    if (entry.type === 'alarm' && options.hasAlarmFrame === false) continue;
     if (entry.type === 'custom') {
       const fid = entry.customFid?.trim();
       if (fid) fids.push(fid);
@@ -40,7 +81,7 @@ export function buildThumbnailChain(
   chain: ThumbnailFallbackEntry[] | undefined,
   options: ThumbnailChainOptions = {}
 ): string[] {
-  return resolveFallbackFids(chain).map((fid) =>
+  return resolveFallbackFids(chain, options).map((fid) =>
     getEventImageUrl(portalUrl, eventId, fid, options)
   );
 }

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -9,6 +9,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../lib/query/query-keys';
 import { getEvent, getEventVideoUrl, getEventImageUrl, setEventArchived } from '../api/events';
+import { eventHasAlarmFrame } from '../lib/event/thumbnail-chain';
 import { resolveFallbackFids } from '../lib/event/thumbnail-chain';
 import { resolveBackNavigation } from '../lib/back-navigation';
 import { getMonitor } from '../api/monitors';
@@ -626,7 +627,7 @@ export default function EventDetail() {
               apiUrl={currentProfile.apiUrl}
               minStreamingPort={effectiveMinStreamingPort}
               monitorId={event.Event.MonitorId}
-              hasAlarmFrame={!!event.Event.AlarmFrameId}
+              hasAlarmFrame={eventHasAlarmFrame(event.Event)}
               onViewerOpenChange={handleFrameViewerOpenChange}
             />
           )}

--- a/app/tests/features/events.feature
+++ b/app/tests/features/events.feature
@@ -174,3 +174,17 @@ Feature: Event Browsing and Management
     Then I should see the full-size event frame if events exist
     When I close the full-size event frame if events exist
     Then the full-size event frame is gone if events exist
+
+  @all
+  Scenario: Collapsed frame carousel fetches no frame images
+    When I click into the first event if events exist
+    Then I should see the event frames carousel if events exist
+    When I toggle the event frames carousel
+    Then the event frames carousel should be collapsed
+    When I start recording event thumbnail requests
+    And I refresh the page
+    Then the event frames carousel should be collapsed
+    When I give the app its chance to fetch thumbnails
+    Then no event frame thumbnails should have been requested
+    When I toggle the event frames carousel
+    Then event frame thumbnails should be requested

--- a/app/tests/features/monitor-detail.feature
+++ b/app/tests/features/monitor-detail.feature
@@ -117,6 +117,22 @@ Feature: Monitor Detail Page
     When I tap "All events"
     Then I should be on the events page filtered to that monitor
 
+  @all
+  Scenario: Collapsed recent events fetch no event thumbnails
+    Given I am logged into zmNinjaNg
+    When I open the first monitor's detail view
+    Then the recent events list should be visible
+    When I tap the recent events collapse toggle
+    Then the recent events body should be hidden
+    When I start recording event thumbnail requests
+    And I refresh the page
+    Then the recent events body should still be hidden
+    When I give the app its chance to fetch thumbnails
+    Then no event thumbnails should have been requested
+    When I tap the recent events collapse toggle
+    Then the recent events body should be visible
+    And event thumbnails should be requested
+
   @web
   Scenario: Scroll position on monitor detail is restored after returning from an event
     Given I am logged into zmNinjaNg

--- a/app/tests/steps/thumbnail-probing.steps.ts
+++ b/app/tests/steps/thumbnail-probing.steps.ts
@@ -1,0 +1,107 @@
+import { createBdd } from 'playwright-bdd';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { testConfig } from '../helpers/config';
+import { getEventCount } from '../helpers/zm-api';
+import { EVENT_FRAME_THUMB_WIDTH } from '../../src/lib/zmninja-ng-constants';
+import { log } from '../../src/lib/logger';
+
+const { When, Then } = createBdd();
+
+// Collapsed lists must not fetch event thumbnails (refs #331).
+//
+// This matters beyond wasted bandwidth: the first fid in the fallback chain is
+// `alarm`, and an event with no alarm frame answers 404 before the chain falls
+// through to `snapshot`. A reporter's reverse proxy read that stream of 404s as
+// an attack and banned them. So the outcome worth asserting is the request
+// itself, not whether a thumbnail element is on screen.
+//
+// URLs are decoded first: in dev the real URL is nested percent-encoded inside
+// the image proxy, the same way the analysis-frame steps handle it (refs #328).
+const listenerPages = new WeakSet<Page>();
+let thumbnailUrls: string[] = [];
+
+/** Only the carousel asks for a width, so this tells its frames apart from the
+ *  video poster, which requests the same view with no size. */
+const CAROUSEL_THUMB = `width=${EVENT_FRAME_THUMB_WIDTH}`;
+
+function attachThumbnailCapture(page: Page): void {
+  if (listenerPages.has(page)) return;
+  listenerPages.add(page);
+  page.on('request', (req) => {
+    const url = decodeURIComponent(req.url());
+    if (url.includes('view=image') && url.includes('eid=')) thumbnailUrls.push(url);
+  });
+}
+
+When('I start recording event thumbnail requests', async ({ page }) => {
+  attachThumbnailCapture(page);
+  thumbnailUrls = [];
+});
+
+/**
+ * Waits for a thumbnail response rather than asserting straight away.
+ *
+ * Asserting immediately after the reload passes for the wrong reason: the list
+ * renders its thumbnails only once the events query resolves, so an assertion
+ * that runs first sees an empty array whether or not the list is collapsed.
+ * Verified by re-rendering the collapsed body with `display: none` and enabling
+ * its query, a change that does fetch every thumbnail; the immediate assertion
+ * still passed. Waiting for the response the regression would produce is what
+ * makes the empty case mean something.
+ */
+When('I give the app its chance to fetch thumbnails', async ({ page }) => {
+  await page
+    .waitForResponse((res) => decodeURIComponent(res.url()).includes('view=image'), {
+      timeout: testConfig.timeouts.element,
+    })
+    .catch(() => { /* nothing came, which is the outcome the next step asserts */ });
+});
+
+Then('no event thumbnails should have been requested', async () => {
+  expect(
+    thumbnailUrls,
+    'a collapsed list fetched event thumbnails, which is what gets users IP-banned'
+  ).toEqual([]);
+});
+
+// Runs after the list is expanded again. It doubles as proof the recorder above
+// actually sees these requests, so the empty assertion cannot pass vacuously.
+Then('event thumbnails should be requested', async () => {
+  await expect
+    .poll(() => thumbnailUrls.length, { timeout: testConfig.timeouts.element })
+    .toBeGreaterThan(0);
+  log.info('E2E recorded event thumbnail requests', {
+    component: 'e2e',
+    count: thumbnailUrls.length,
+  });
+});
+
+Then('no event frame thumbnails should have been requested', async () => {
+  expect(
+    thumbnailUrls.filter((url) => url.includes(CAROUSEL_THUMB)),
+    'a collapsed frame carousel fetched its frames'
+  ).toEqual([]);
+});
+
+Then('event frame thumbnails should be requested', async () => {
+  await expect
+    .poll(() => thumbnailUrls.filter((url) => url.includes(CAROUSEL_THUMB)).length, {
+      timeout: testConfig.timeouts.element,
+    })
+    .toBeGreaterThan(0);
+});
+
+When('I toggle the event frames carousel', async ({ page }) => {
+  if ((await getEventCount()) === 0) return;
+  await page.getByTestId('event-frames-card-toggle').click();
+});
+
+Then('the event frames carousel should be collapsed', async ({ page }) => {
+  if ((await getEventCount()) === 0) return;
+  await expect(page.getByTestId('event-frames-card-toggle')).toHaveAttribute(
+    'aria-expanded',
+    'false',
+    { timeout: testConfig.timeouts.element }
+  );
+});

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1679,6 +1679,19 @@ a chain that already resolved.
 ``thumbnailFallbackChain`` setting into ordered frame IDs and full URLs,
 skipping disabled entries and empty custom rows.
 
+Walking the chain costs a real failed request per candidate, which is why
+callers that hold an event record pass ``hasAlarmFrame`` (refs #331). The
+default chain starts at ``alarm``, and ZoneMinder answers 404 for an alarm
+frame it never recorded, so a list of such events spends one 404 each before
+falling through to ``snapshot``. A reverse proxy reads that as an attack; one
+reporter's proxy banned them for it. ``eventHasAlarmFrame`` answers from
+``AlarmFrames``, a required field on ``EventSchema`` that every list response
+already carries, so the check costs no request of its own. Branch on that count
+rather than ``AlarmFrameId``, which is optional on the schema and absent from
+some servers' list responses, and would drop the alarm frame of events that
+have one. Omitting the option keeps the alarm candidate, which is what callers
+with no event record to consult, such as push notifications, want.
+
 **Used by:** EventCard (via EventListView and EventMontageView), the
 TimelineScrubber thumbnails, NotificationHistory. The EventDetail hero poster
 and EventPreviewPopover take the first frame ID from the resolved chain rather


### PR DESCRIPTION
Refs #331.

`DEFAULT_THUMBNAIL_FALLBACK_CHAIN` starts at `alarm`, and `EventThumbnail.handleError` advances to the next candidate only after the browser reports a failure. So an event with no alarm frame costs a real 404 before falling through to `snapshot`. Browsing a list spends one 404 per such event, and the reporter on #331 had their own reverse proxy ban them for the resulting traffic.

## The fix

`eventHasAlarmFrame` reads `AlarmFrames`, a **required** field on `EventSchema` that already rides along with every list response, so the check costs no request. Callers holding an event record pass it through a new `hasAlarmFrame` option on `buildThumbnailChain`, and the alarm candidate is dropped rather than probed.

Wired up at the call sites that have an event: `EventListView` (both chains), `EventMontageView`, `MonitorRecentEvents`, `TimelineScrubber` (via `alarmRatio`), and the assistant's result cards. `NotificationHandler` and `NotificationHistory` are deliberately left alone: they have no event record to consult, and omitting the option keeps the previous behaviour.

Two details worth a reviewer's attention:

- **The count, not `AlarmFrameId`.** That field is `.optional()` on the schema and absent from some servers' list responses, so branching on it drops the alarm frame of events that do have one. `EventFrameCarousel` was doing exactly that; it now shares the predicate.
- **An unparsable or absent count returns true.** A wasted request is cheaper than silently losing a real alarm thumbnail.

## Scope

This removes the 404s for events ZoneMinder reports as having no alarm frame. An event that recorded alarm frames but stores no JPEGs can still 404 — that is a separate question for the reporter's server, which is why this refs #331 rather than closing it.

## Regression tests

The second commit covers something adjacent that was already working but ungated: neither the monitor-detail recent events list nor the frame carousel fetches anything while collapsed. Both new scenarios assert on requests rather than absent elements, because traffic is what causes the ban.

Getting them to fail honestly took two corrections, both noted in the commit:

1. Asserting straight after the reload passed for the wrong reason — the list renders thumbnails only once its query resolves, so the assertion ran first and saw an empty array either way. There is now a step that waits for the response a regression would produce.
2. Even then it still passed, because `CompactEventRow` sets `loading="lazy"` and Chromium never fetches a lazy image inside `display: none`. Only after breaking all three protections (query gate, unmount, lazy attribute) did the test fail with the intended message.

## Verification

- `npm run gates` passes: 3257 unit tests, build, three blocking lints. Ratchet holds at 213.
- `monitor-detail.feature` 19/19, `timeline.feature` 7/7.
- `events.feature` has one pre-existing flake, "Tap event navigates to detail with video player". It fails identically on a clean baseline with this branch stashed, and its step uses 500ms visibility timeouts. Not introduced here, but it will keep biting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)