### PR TITLE
feat(assistant): let Ninjii answer about every server in a group

### DIFF
--- a/AGENTS.project.md
+++ b/AGENTS.project.md
@@ -42,10 +42,10 @@ Never: constructing `ApiClient` outside the session registry, its gate factory, 
 Gate: `app/src/tests/agents-contracts.test.ts`.
 
 ### Assistant tool loop
-Owns: whether an assistant turn may answer a data question.
-Path: the turn schema makes the answer branch unreachable until a real tool result exists; execution authority is the turn's own `opts.tools`, not the registry.
-Never: prompt-only grounding guards; raw tool-error text fed back to the model; unparsed tool-call markup rendered as an answer.
-Gate: `app/src/lib/assistant/__tests__/agent.test.ts`; `app/src/lib/assistant/__tests__/grounding.test.ts`.
+Owns: whether a turn may answer a data question, and which server answers.
+Path: the turn schema blocks the answer branch until a real tool result exists; execution authority is the turn's own `opts.tools`, not the registry; multi-server turns route through `executeScoped` (`app/src/lib/assistant/server-scope.ts`), so tools stay single-server.
+Never: prompt-only grounding guards; raw tool-error text to the model; unparsed tool-call markup as an answer; a tool reaching a second server; server names without a schema enum.
+Gate: `app/src/lib/assistant/__tests__/agent.test.ts`; `app/src/lib/assistant/__tests__/grounding.test.ts`; `app/src/lib/assistant/__tests__/server-scope.test.ts`.
 
 ### Server queries
 Owns: React Query keys, invalidation, and caching.

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -619,7 +619,10 @@ export function AskPanel() {
       // language interpretation the model does better.
       const kind: RequestKind = isAssistantTestMode()
         ? 'zoneminder'
-        : await classifyRequest(provider, text, controller.signal, collectTrace, (s) => host.onStatus?.(s));
+        : // serverNames too: a question that names a server ("compare warehouse and
+          // cabin") is about this system, and without the roster the classifier
+          // read those as unrelated words and routed the turn to chat (refs #337).
+          await classifyRequest(provider, text, controller.signal, collectTrace, (s) => host.onStatus?.(s), serverNames);
       log.assistant('Request classified', LogLevel.DEBUG, { kind });
 
       // Every timeframe the question names is extracted and resolved BEFORE the
@@ -741,7 +744,7 @@ export function AskPanel() {
           {/* What the pin actually decides once a group can hold several
               servers (refs #337): the model, its settings and the thread come
               from this profile, while the lookups cover every server in the
-              group. Saying "pinned to isaac" there would read as a limit on
+              group. Saying "pinned to warehouse" there would read as a limit on
               the answers, which it no longer is. */}
           <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
             {t(coversAllServers ? 'assistant.covers_all_servers' : 'assistant.pinned_to', {

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -41,7 +41,8 @@ import {
 import { sharedMockProvider } from '../../lib/assistant/providers/mock';
 import { buildSystemPrompt } from '../../lib/assistant/system-prompt';
 import { getObjectLabels } from '../../lib/assistant/object-labels';
-import { TOOLS, specializeToolSchemas } from '../../lib/assistant/tools';
+import { TOOLS, specializeToolSchemas, withServerArg } from '../../lib/assistant/tools';
+import { buildScopedServers } from '../../lib/assistant/scoped-servers';
 import { interpretWhen } from '../../lib/assistant/window-interpreter';
 import { extractTimeframes, buildTimeframeSystemLine } from '../../lib/assistant/timeframe-stage';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
@@ -303,6 +304,9 @@ export function AskPanel() {
   // against an unconfigured backend whenever the user enabled the assistant on
   // some other member of the group (refs #337).
   const { profileId: configuredProfileId } = useAssistantEnabled();
+  // A group of two or more is what turns the tool layer multi-server; a
+  // one-member group answers about that one server, exactly like single mode.
+  const coversAllServers = isAllMode && (scope?.profiles.length ?? 0) > 1;
   const defaultPinnedId = isAllMode ? (pinnedProfileId ?? configuredProfileId) : undefined;
   const { profile: pinnedProfile, settings: pinnedSettings } = useProfileById(defaultPinnedId);
   // Single mode: the page's own current profile/settings, byte-identical to
@@ -534,12 +538,21 @@ export function AskPanel() {
       // guessing at a taxonomy. Cached per profile; never throws.
       const objectLabels = await getObjectLabels(profileId);
 
+      // Every server this view combines, or an empty list outside a group
+      // (refs #337). It drives three things that must agree: the roster in the
+      // prompt, the `server` argument's enum, and which sessions the tool
+      // wrapper may reach. Pinned-profile behavior is unchanged when the group
+      // holds one server, since `buildScopedServers` returns nothing then.
+      const servers = isAllMode ? await buildScopedServers(scope?.profiles ?? []) : [];
+      const serverNames = servers.map((s) => s.name);
+
       const system = buildSystemPrompt({
         objectLabels,
         now: new Date(),
         timezone: currentProfile?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
         locale: i18n.language,
         zmVersion,
+        servers: serverNames,
       });
 
       // Image-building inputs for event result cards (refs #246), mirroring
@@ -547,6 +560,7 @@ export function AskPanel() {
       // returns event rows (list_events/get_event via lib/assistant/display.ts).
       const ctx: ToolContext = {
         profileId,
+        servers,
         queryClient,
         host,
         portalUrl: currentProfile?.portalUrl,
@@ -644,10 +658,11 @@ export function AskPanel() {
         history,
         system: turnSystem,
         signal: controller.signal,
-        // Specialized rather than the bare registry: objectType is pinned to
-        // this install's labels so the model cannot decode an invented one
-        // (refs #270, see specializeToolSchemas).
-        tools: kind === 'zoneminder' ? specializeToolSchemas(TOOLS, objectLabels) : [],
+        // Specialized, then scoped: objectType pinned to this install's labels,
+        // and `server` pinned to the servers this view combines so a model on a
+        // guided-decoding backend cannot name a server that is not there
+        // (refs #270, #337).
+        tools: kind === 'zoneminder' ? withServerArg(specializeToolSchemas(TOOLS, objectLabels), serverNames) : [],
         objectLabels,
         initialTrace,
         historyTurns: settings.assistantHistoryTurns,
@@ -723,8 +738,15 @@ export function AskPanel() {
           className="flex items-center gap-2 border-b bg-muted/50 px-3 py-1.5"
           data-testid="assistant-pinned-banner"
         >
+          {/* What the pin actually decides once a group can hold several
+              servers (refs #337): the model, its settings and the thread come
+              from this profile, while the lookups cover every server in the
+              group. Saying "pinned to isaac" there would read as a limit on
+              the answers, which it no longer is. */}
           <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
-            {t('assistant.pinned_to', { profile: currentProfile?.name ?? '' })}
+            {t(coversAllServers ? 'assistant.covers_all_servers' : 'assistant.pinned_to', {
+              profile: currentProfile?.name ?? '',
+            })}
           </span>
           <ProfilePicker
             profiles={scope?.profiles ?? []}

--- a/app/src/components/assistant/AssistantResultCards.tsx
+++ b/app/src/components/assistant/AssistantResultCards.tsx
@@ -46,8 +46,13 @@ export function AssistantResultCards({ entities, host }: AssistantResultCardsPro
     <div className="flex flex-wrap gap-2" data-testid="assistant-result-cards">
       {entities.map((entity) => {
         const open = () => host.navigate(entity.navigatePath);
+        // `monitors` is the PINNED profile's query, so a card from another
+        // server in the group must not resolve against it: monitor 3 exists on
+        // both servers and is a different camera on each, which would stream
+        // the wrong one (refs #337).
+        const isPinnedServer = !entity.profileId || entity.profileId === currentProfile?.id;
         const liveMonitor =
-          entity.kind === 'monitor' && livePreviews
+          entity.kind === 'monitor' && livePreviews && isPinnedServer
             ? monitors.find((m) => m.Monitor.Id === entity.id)?.Monitor
             : undefined;
         // Set only when this card can actually stream: an event card, previews
@@ -67,7 +72,9 @@ export function AssistantResultCards({ entities, host }: AssistantResultCardsPro
         );
         return (
           <div
-            key={`${entity.kind}-${entity.id}`}
+            // profileId in the key: the same ZM id can arrive from two servers
+            // in one result, and a duplicate key drops one of the cards.
+            key={`${entity.kind}-${entity.profileId ?? ''}-${entity.id}`}
             role="button"
             tabIndex={0}
             onClick={open}
@@ -120,6 +127,18 @@ export function AssistantResultCards({ entities, host }: AssistantResultCardsPro
               </div>
             )}
             <div className="min-w-0 flex-1">
+              {/* Which server this row came from, in a group (refs #337).
+                  "Front Door" is ambiguous the moment two servers are in
+                  scope, and the answer text above names servers too. */}
+              {entity.server && (
+                <p
+                  className="truncate text-[10px] uppercase tracking-wide text-muted-foreground"
+                  title={entity.server}
+                  data-testid="assistant-card-server"
+                >
+                  {entity.server}
+                </p>
+              )}
               <p className="truncate text-xs font-medium" title={entity.title}>
                 {entity.title}
               </p>

--- a/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
@@ -108,3 +108,42 @@ describe('AssistantResultCards event hover playback', () => {
     expect(screen.queryByTestId('hover-preview-stub')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * Cards from a group of servers (refs #337). Two servers can both have a
+ * "Front Door" and both have a monitor 3, so a card has to say which server it
+ * came from, and must not borrow the pinned server's monitor to stream from.
+ */
+describe('AssistantResultCards across servers', () => {
+  const fromServer = (entity: DisplayEntity, server: string, profileId: string): DisplayEntity => ({
+    ...entity,
+    server,
+    profileId: profileId as DisplayEntity['profileId'],
+  });
+
+  it('names the owning server on each card', () => {
+    render(
+      <AssistantResultCards
+        entities={[
+          fromServer(eventCard('77', '3'), 'isaac', 'p-isaac'),
+          fromServer(eventCard('77', '3'), 'home', 'p-home'),
+        ]}
+        host={host}
+      />,
+    );
+    const labels = screen.getAllByTestId('assistant-card-server').map((el) => el.textContent);
+    expect(labels).toEqual(['isaac', 'home']);
+  });
+
+  it('renders no live preview for a monitor on another server', () => {
+    // Monitor id 3 exists in the pinned server's query; this card is server
+    // "home"'s monitor 3, a different camera entirely.
+    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'home', 'p-home')]} host={host} />);
+    expect(screen.queryByTestId('assistant-card-monitor-live')).not.toBeInTheDocument();
+  });
+
+  it('still previews a card belonging to the pinned server', () => {
+    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'isaac', 'p1')]} host={host} />);
+    expect(screen.getByTestId('assistant-card-monitor-live')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
+++ b/app/src/components/assistant/__tests__/AssistantResultCards.test.tsx
@@ -125,25 +125,25 @@ describe('AssistantResultCards across servers', () => {
     render(
       <AssistantResultCards
         entities={[
-          fromServer(eventCard('77', '3'), 'isaac', 'p-isaac'),
-          fromServer(eventCard('77', '3'), 'home', 'p-home'),
+          fromServer(eventCard('77', '3'), 'warehouse', 'p-warehouse'),
+          fromServer(eventCard('77', '3'), 'cabin', 'p-cabin'),
         ]}
         host={host}
       />,
     );
     const labels = screen.getAllByTestId('assistant-card-server').map((el) => el.textContent);
-    expect(labels).toEqual(['isaac', 'home']);
+    expect(labels).toEqual(['warehouse', 'cabin']);
   });
 
   it('renders no live preview for a monitor on another server', () => {
     // Monitor id 3 exists in the pinned server's query; this card is server
-    // "home"'s monitor 3, a different camera entirely.
-    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'home', 'p-home')]} host={host} />);
+    // "cabin"'s monitor 3, a different camera entirely.
+    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'cabin', 'p-cabin')]} host={host} />);
     expect(screen.queryByTestId('assistant-card-monitor-live')).not.toBeInTheDocument();
   });
 
   it('still previews a card belonging to the pinned server', () => {
-    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'isaac', 'p1')]} host={host} />);
+    render(<AssistantResultCards entities={[fromServer(monitorCard('3'), 'warehouse', 'p1')]} host={host} />);
     expect(screen.getByTestId('assistant-card-monitor-live')).toBeInTheDocument();
   });
 });

--- a/app/src/lib/assistant/__tests__/contract-eval.test.ts
+++ b/app/src/lib/assistant/__tests__/contract-eval.test.ts
@@ -89,9 +89,9 @@ function passingCall(q: string): { name: string; input: Record<string, unknown> 
     'is the backyard camera alarmed': {},
     // The group cases (refs #337): a named server scopes the call, and a
     // question naming none must leave `server` off.
-    'compare events in isaac and home today': { when: 'today', server: 'isaac' },
-    'how many events on isaac today': { when: 'today', server: 'isaac' },
-    'which cameras are recording on home': { server: 'home' },
+    'compare events in warehouse and cabin today': { when: 'today', server: 'warehouse' },
+    'how many events on warehouse today': { when: 'today', server: 'warehouse' },
+    'which cameras are recording on cabin': { server: 'cabin' },
     'what happened today': { when: 'today' },
   };
   return { name: c.tool, input: inputs[q] ?? {} };

--- a/app/src/lib/assistant/__tests__/contract-eval.test.ts
+++ b/app/src/lib/assistant/__tests__/contract-eval.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { runContractEval, CONTRACT_EVAL_CASE_COUNT } from '../contract-eval';
-import { TOOL_CASES } from '../contract-eval-cases';
+import { TOOL_CASES, SERVER_TOOL_CASES } from '../contract-eval-cases';
 import type { AssistantMessage, AssistantProvider, AssistantTurn, ExecutedToolCall, ToolDefinition } from '../types';
 
 vi.mock('../../logger', () => ({
@@ -45,7 +45,9 @@ function providerFrom(
 
 /** The expectation the shared case list holds for one question. */
 function caseFor(q: string) {
-  const c = TOOL_CASES.find((x) => x.q === q);
+  // Both lists: the group cases (refs #337) are scored by the same runner, with
+  // a prompt and registry that carry the `server` argument.
+  const c = [...TOOL_CASES, ...SERVER_TOOL_CASES].find((x) => x.q === q);
   if (!c) throw new Error(`no case for ${q}`);
   return c;
 }
@@ -85,6 +87,12 @@ function passingCall(q: string): { name: string; input: Record<string, unknown> 
     'what camera groups exist': {},
     'is everything healthy': {},
     'is the backyard camera alarmed': {},
+    // The group cases (refs #337): a named server scopes the call, and a
+    // question naming none must leave `server` off.
+    'compare events in isaac and home today': { when: 'today', server: 'isaac' },
+    'how many events on isaac today': { when: 'today', server: 'isaac' },
+    'which cameras are recording on home': { server: 'home' },
+    'what happened today': { when: 'today' },
   };
   return { name: c.tool, input: inputs[q] ?? {} };
 }

--- a/app/src/lib/assistant/__tests__/server-scope.test.ts
+++ b/app/src/lib/assistant/__tests__/server-scope.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Multi-server tool execution (refs #337).
+ *
+ * A turn inside a server group has to be able to say WHICH server a number
+ * came from. These cover the three things that makes possible: resolving a
+ * server name the model typed, running one tool against one server's session
+ * and display context, and fanning out over the whole group when the model
+ * named no server at all.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { executeScoped, resolveServerArg, contextForServer } from '../server-scope';
+import { asProfileId } from '../../../api/types';
+import type { ScopedServer, ToolContext, ToolDefinition } from '../types';
+
+const isaac: ScopedServer = {
+  profileId: asProfileId('p-isaac'),
+  name: 'isaac',
+  portalUrl: 'http://isaac',
+  accessToken: 'tok-isaac',
+  timezone: 'America/New_York',
+};
+const home: ScopedServer = {
+  profileId: asProfileId('p-home'),
+  name: 'home',
+  portalUrl: 'http://home',
+  accessToken: 'tok-home',
+  timezone: 'Europe/Berlin',
+};
+
+function ctxWith(servers?: ScopedServer[]): ToolContext {
+  return {
+    profileId: asProfileId('p-isaac'),
+    portalUrl: 'http://isaac',
+    accessToken: 'tok-isaac',
+    timezone: 'America/New_York',
+    servers,
+    queryClient: {} as ToolContext['queryClient'],
+    host: {
+      navigate: vi.fn(),
+      onActivity: vi.fn(),
+    } as unknown as ToolContext['host'],
+  };
+}
+
+/** A tool that reports which profile and portal it ran against, plus one card. */
+function probeTool(): ToolDefinition {
+  return {
+    name: 'probe',
+    description: 'test',
+    schema: { type: 'object', properties: {}, additionalProperties: false },
+    execute: vi.fn(async (input, ctx) => ({
+      output: JSON.stringify({
+        summary: `ran on ${ctx.profileId}`,
+        matchCount: 1,
+        portalUrl: ctx.portalUrl,
+        input,
+      }),
+      display: [
+        {
+          kind: 'event' as const,
+          id: '7',
+          title: 'Front Door',
+          navigatePath: '/events/7',
+          cacheKey: '7',
+        },
+      ],
+    })),
+  };
+}
+
+describe('resolveServerArg', () => {
+  const servers = [isaac, home];
+
+  it('matches a name exactly, ignoring case and surrounding space', () => {
+    expect(resolveServerArg(' Isaac ', servers)).toEqual({ server: isaac });
+  });
+
+  it('matches an unambiguous prefix', () => {
+    expect(resolveServerArg('hom', servers)).toEqual({ server: home });
+  });
+
+  it('names the real servers when the model invents one', () => {
+    const result = resolveServerArg('basement', servers);
+    expect('error' in result && result.error).toContain('isaac');
+    expect('error' in result && result.error).toContain('home');
+  });
+
+  it('refuses an ambiguous prefix rather than guessing', () => {
+    const result = resolveServerArg('h', [home, { ...home, name: 'hallway' }]);
+    expect('error' in result).toBe(true);
+  });
+});
+
+describe('contextForServer', () => {
+  it('swaps in the server\'s own session id and display inputs', () => {
+    const scoped = contextForServer(ctxWith([isaac, home]), home);
+    expect(scoped.profileId).toBe('p-home');
+    expect(scoped.portalUrl).toBe('http://home');
+    expect(scoped.accessToken).toBe('tok-home');
+    expect(scoped.timezone).toBe('Europe/Berlin');
+  });
+});
+
+describe('executeScoped', () => {
+  it('runs the tool untouched when the turn has no server group', async () => {
+    const tool = probeTool();
+    const result = await executeScoped(tool, { limit: 5 }, ctxWith());
+
+    expect(tool.execute).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(result.output).summary).toBe('ran on p-isaac');
+    // No group, so no per-server wrapper and no rewritten card path.
+    expect(result.display?.[0].navigatePath).toBe('/events/7');
+  });
+
+  it('runs against only the named server when the model names one', async () => {
+    const tool = probeTool();
+    const result = await executeScoped(tool, { server: 'home' }, ctxWith([isaac, home]));
+
+    expect(tool.execute).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.servers).toHaveLength(1);
+    expect(parsed.servers[0].server).toBe('home');
+    expect(parsed.servers[0].result.portalUrl).toBe('http://home');
+    // `server` is the wrapper's own argument, never forwarded to the tool.
+    expect(parsed.servers[0].result.input).toEqual({});
+  });
+
+  it('reports the valid server names instead of querying one when the name is unknown', async () => {
+    const tool = probeTool();
+    const result = await executeScoped(tool, { server: 'basement' }, ctxWith([isaac, home]));
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('isaac');
+  });
+
+  it('fans out over every server when the model names none', async () => {
+    const tool = probeTool();
+    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+
+    expect(tool.execute).toHaveBeenCalledTimes(2);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.servers.map((s: { server: string }) => s.server)).toEqual(['isaac', 'home']);
+    expect(parsed.servers.map((s: { result: { summary: string } }) => s.result.summary)).toEqual([
+      'ran on p-isaac',
+      'ran on p-home',
+    ]);
+    // The grounding fallback reads a top-level `summary` (grounding.ts), so the
+    // merged result carries one naming every server.
+    expect(parsed.summary).toContain('isaac');
+    expect(parsed.summary).toContain('home');
+  });
+
+  it('labels each card with its server and points it at that server\'s route', async () => {
+    const result = await executeScoped(probeTool(), {}, ctxWith([isaac, home]));
+
+    expect(result.display?.map((d) => d.server)).toEqual(['isaac', 'home']);
+    expect(result.display?.map((d) => d.navigatePath)).toEqual([
+      '/all/events/p-isaac/7',
+      '/all/events/p-home/7',
+    ]);
+    // Raw ZM ids collide across servers, so the card cache key has to be
+    // composite (aggregation contract).
+    expect(new Set(result.display?.map((d) => d.cacheKey)).size).toBe(2);
+  });
+
+  it('keeps the servers that worked when one of them fails', async () => {
+    const tool = probeTool();
+    vi.mocked(tool.execute).mockImplementation(async (_input, ctx) => {
+      if (ctx.profileId === 'p-home') throw new Error('offline');
+      return { output: JSON.stringify({ summary: 'ran on isaac', matchCount: 2 }) };
+    });
+
+    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.output);
+    expect(parsed.servers[0].result.matchCount).toBe(2);
+    expect(parsed.servers[1].error).toContain('offline');
+  });
+
+  it('is an error only when every server fails', async () => {
+    const tool = probeTool();
+    vi.mocked(tool.execute).mockRejectedValue(new Error('offline'));
+
+    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('offline');
+  });
+});

--- a/app/src/lib/assistant/__tests__/server-scope.test.ts
+++ b/app/src/lib/assistant/__tests__/server-scope.test.ts
@@ -13,26 +13,26 @@ import { executeScoped, resolveServerArg, contextForServer } from '../server-sco
 import { asProfileId } from '../../../api/types';
 import type { ScopedServer, ToolContext, ToolDefinition } from '../types';
 
-const isaac: ScopedServer = {
-  profileId: asProfileId('p-isaac'),
-  name: 'isaac',
-  portalUrl: 'http://isaac',
-  accessToken: 'tok-isaac',
+const warehouse: ScopedServer = {
+  profileId: asProfileId('p-warehouse'),
+  name: 'warehouse',
+  portalUrl: 'http://warehouse',
+  accessToken: 'tok-warehouse',
   timezone: 'America/New_York',
 };
-const home: ScopedServer = {
-  profileId: asProfileId('p-home'),
-  name: 'home',
-  portalUrl: 'http://home',
-  accessToken: 'tok-home',
+const cabin: ScopedServer = {
+  profileId: asProfileId('p-cabin'),
+  name: 'cabin',
+  portalUrl: 'http://cabin',
+  accessToken: 'tok-cabin',
   timezone: 'Europe/Berlin',
 };
 
 function ctxWith(servers?: ScopedServer[]): ToolContext {
   return {
-    profileId: asProfileId('p-isaac'),
-    portalUrl: 'http://isaac',
-    accessToken: 'tok-isaac',
+    profileId: asProfileId('p-warehouse'),
+    portalUrl: 'http://warehouse',
+    accessToken: 'tok-warehouse',
     timezone: 'America/New_York',
     servers,
     queryClient: {} as ToolContext['queryClient'],
@@ -70,34 +70,34 @@ function probeTool(): ToolDefinition {
 }
 
 describe('resolveServerArg', () => {
-  const servers = [isaac, home];
+  const servers = [warehouse, cabin];
 
   it('matches a name exactly, ignoring case and surrounding space', () => {
-    expect(resolveServerArg(' Isaac ', servers)).toEqual({ server: isaac });
+    expect(resolveServerArg(' Warehouse ', servers)).toEqual({ server: warehouse });
   });
 
   it('matches an unambiguous prefix', () => {
-    expect(resolveServerArg('hom', servers)).toEqual({ server: home });
+    expect(resolveServerArg('cab', servers)).toEqual({ server: cabin });
   });
 
   it('names the real servers when the model invents one', () => {
     const result = resolveServerArg('basement', servers);
-    expect('error' in result && result.error).toContain('isaac');
-    expect('error' in result && result.error).toContain('home');
+    expect('error' in result && result.error).toContain('warehouse');
+    expect('error' in result && result.error).toContain('cabin');
   });
 
   it('refuses an ambiguous prefix rather than guessing', () => {
-    const result = resolveServerArg('h', [home, { ...home, name: 'hallway' }]);
+    const result = resolveServerArg('cab', [cabin, { ...cabin, name: 'cabana' }]);
     expect('error' in result).toBe(true);
   });
 });
 
 describe('contextForServer', () => {
   it('swaps in the server\'s own session id and display inputs', () => {
-    const scoped = contextForServer(ctxWith([isaac, home]), home);
-    expect(scoped.profileId).toBe('p-home');
-    expect(scoped.portalUrl).toBe('http://home');
-    expect(scoped.accessToken).toBe('tok-home');
+    const scoped = contextForServer(ctxWith([warehouse, cabin]), cabin);
+    expect(scoped.profileId).toBe('p-cabin');
+    expect(scoped.portalUrl).toBe('http://cabin');
+    expect(scoped.accessToken).toBe('tok-cabin');
     expect(scoped.timezone).toBe('Europe/Berlin');
   });
 });
@@ -108,57 +108,57 @@ describe('executeScoped', () => {
     const result = await executeScoped(tool, { limit: 5 }, ctxWith());
 
     expect(tool.execute).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(result.output).summary).toBe('ran on p-isaac');
+    expect(JSON.parse(result.output).summary).toBe('ran on p-warehouse');
     // No group, so no per-server wrapper and no rewritten card path.
     expect(result.display?.[0].navigatePath).toBe('/events/7');
   });
 
   it('runs against only the named server when the model names one', async () => {
     const tool = probeTool();
-    const result = await executeScoped(tool, { server: 'home' }, ctxWith([isaac, home]));
+    const result = await executeScoped(tool, { server: 'cabin' }, ctxWith([warehouse, cabin]));
 
     expect(tool.execute).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(result.output);
     expect(parsed.servers).toHaveLength(1);
-    expect(parsed.servers[0].server).toBe('home');
-    expect(parsed.servers[0].result.portalUrl).toBe('http://home');
+    expect(parsed.servers[0].server).toBe('cabin');
+    expect(parsed.servers[0].result.portalUrl).toBe('http://cabin');
     // `server` is the wrapper's own argument, never forwarded to the tool.
     expect(parsed.servers[0].result.input).toEqual({});
   });
 
   it('reports the valid server names instead of querying one when the name is unknown', async () => {
     const tool = probeTool();
-    const result = await executeScoped(tool, { server: 'basement' }, ctxWith([isaac, home]));
+    const result = await executeScoped(tool, { server: 'basement' }, ctxWith([warehouse, cabin]));
 
     expect(tool.execute).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
-    expect(result.output).toContain('isaac');
+    expect(result.output).toContain('warehouse');
   });
 
   it('fans out over every server when the model names none', async () => {
     const tool = probeTool();
-    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+    const result = await executeScoped(tool, {}, ctxWith([warehouse, cabin]));
 
     expect(tool.execute).toHaveBeenCalledTimes(2);
     const parsed = JSON.parse(result.output);
-    expect(parsed.servers.map((s: { server: string }) => s.server)).toEqual(['isaac', 'home']);
+    expect(parsed.servers.map((s: { server: string }) => s.server)).toEqual(['warehouse', 'cabin']);
     expect(parsed.servers.map((s: { result: { summary: string } }) => s.result.summary)).toEqual([
-      'ran on p-isaac',
-      'ran on p-home',
+      'ran on p-warehouse',
+      'ran on p-cabin',
     ]);
     // The grounding fallback reads a top-level `summary` (grounding.ts), so the
     // merged result carries one naming every server.
-    expect(parsed.summary).toContain('isaac');
-    expect(parsed.summary).toContain('home');
+    expect(parsed.summary).toContain('warehouse');
+    expect(parsed.summary).toContain('cabin');
   });
 
   it('labels each card with its server and points it at that server\'s route', async () => {
-    const result = await executeScoped(probeTool(), {}, ctxWith([isaac, home]));
+    const result = await executeScoped(probeTool(), {}, ctxWith([warehouse, cabin]));
 
-    expect(result.display?.map((d) => d.server)).toEqual(['isaac', 'home']);
+    expect(result.display?.map((d) => d.server)).toEqual(['warehouse', 'cabin']);
     expect(result.display?.map((d) => d.navigatePath)).toEqual([
-      '/all/events/p-isaac/7',
-      '/all/events/p-home/7',
+      '/all/events/p-warehouse/7',
+      '/all/events/p-cabin/7',
     ]);
     // Raw ZM ids collide across servers, so the card cache key has to be
     // composite (aggregation contract).
@@ -168,11 +168,11 @@ describe('executeScoped', () => {
   it('keeps the servers that worked when one of them fails', async () => {
     const tool = probeTool();
     vi.mocked(tool.execute).mockImplementation(async (_input, ctx) => {
-      if (ctx.profileId === 'p-home') throw new Error('offline');
-      return { output: JSON.stringify({ summary: 'ran on isaac', matchCount: 2 }) };
+      if (ctx.profileId === 'p-cabin') throw new Error('offline');
+      return { output: JSON.stringify({ summary: 'ran on warehouse', matchCount: 2 }) };
     });
 
-    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+    const result = await executeScoped(tool, {}, ctxWith([warehouse, cabin]));
 
     expect(result.isError).toBeFalsy();
     const parsed = JSON.parse(result.output);
@@ -184,7 +184,7 @@ describe('executeScoped', () => {
     const tool = probeTool();
     vi.mocked(tool.execute).mockRejectedValue(new Error('offline'));
 
-    const result = await executeScoped(tool, {}, ctxWith([isaac, home]));
+    const result = await executeScoped(tool, {}, ctxWith([warehouse, cabin]));
 
     expect(result.isError).toBe(true);
     expect(result.output).toContain('offline');

--- a/app/src/lib/assistant/__tests__/system-prompt.test.ts
+++ b/app/src/lib/assistant/__tests__/system-prompt.test.ts
@@ -91,23 +91,23 @@ describe('buildSystemPrompt', () => {
     expect(p).toContain('SHOW: events=');
   });
 
-  // Refs #337: inside a server group the model has no way to know "isaac" and
-  // "home" are servers unless the prompt names them, and no reason to set the
+  // Refs #337: inside a server group the model has no way to know "warehouse" and
+  // "cabin" are servers unless the prompt names them, and no reason to set the
   // `server` argument unless it is told what omitting it means.
   it('names the servers in scope and how to scope a call to one', () => {
-    const p = buildSystemPrompt({ ...base, servers: ['isaac', 'home'] });
-    expect(p).toContain('isaac, home');
+    const p = buildSystemPrompt({ ...base, servers: ['warehouse', 'cabin'] });
+    expect(p).toContain('warehouse, cabin');
     expect(p).toContain('"server"');
     expect(p).toContain('Omit');
   });
 
   it('teaches a two-server comparison as two calls differing only in server', () => {
-    const p = buildSystemPrompt({ ...base, servers: ['isaac', 'home'] });
-    expect(p).toContain('"compare isaac and home"');
+    const p = buildSystemPrompt({ ...base, servers: ['warehouse', 'cabin'] });
+    expect(p).toContain('"compare warehouse and cabin"');
   });
 
   it('says nothing about servers on a single-server install', () => {
-    expect(buildSystemPrompt({ ...base, servers: ['isaac'] })).toBe(buildSystemPrompt(base));
+    expect(buildSystemPrompt({ ...base, servers: ['warehouse'] })).toBe(buildSystemPrompt(base));
   });
 
   it('never mentions a JSON tool-call contract or WebLLM-specific directives (model-agnostic prompt)', () => {

--- a/app/src/lib/assistant/__tests__/system-prompt.test.ts
+++ b/app/src/lib/assistant/__tests__/system-prompt.test.ts
@@ -91,6 +91,25 @@ describe('buildSystemPrompt', () => {
     expect(p).toContain('SHOW: events=');
   });
 
+  // Refs #337: inside a server group the model has no way to know "isaac" and
+  // "home" are servers unless the prompt names them, and no reason to set the
+  // `server` argument unless it is told what omitting it means.
+  it('names the servers in scope and how to scope a call to one', () => {
+    const p = buildSystemPrompt({ ...base, servers: ['isaac', 'home'] });
+    expect(p).toContain('isaac, home');
+    expect(p).toContain('"server"');
+    expect(p).toContain('Omit');
+  });
+
+  it('teaches a two-server comparison as two calls differing only in server', () => {
+    const p = buildSystemPrompt({ ...base, servers: ['isaac', 'home'] });
+    expect(p).toContain('"compare isaac and home"');
+  });
+
+  it('says nothing about servers on a single-server install', () => {
+    expect(buildSystemPrompt({ ...base, servers: ['isaac'] })).toBe(buildSystemPrompt(base));
+  });
+
   it('never mentions a JSON tool-call contract or WebLLM-specific directives (model-agnostic prompt)', () => {
     const p = buildSystemPrompt(base);
     expect(p.toLowerCase()).not.toContain('"tool"');

--- a/app/src/lib/assistant/__tests__/tools-specialize.test.ts
+++ b/app/src/lib/assistant/__tests__/tools-specialize.test.ts
@@ -77,7 +77,7 @@ describe('specializeToolSchemas', () => {
  * a group must see an enum, so guided decoding cannot invent a server name.
  */
 describe('withServerArg', () => {
-  const NAMES = ['isaac', 'home'];
+  const NAMES = ['warehouse', 'cabin'];
 
   function serverSpec(tools: ToolDefinition[], toolName = 'list_events'): Record<string, unknown> | undefined {
     const tool = tools.find((t) => t.name === toolName);
@@ -97,7 +97,7 @@ describe('withServerArg', () => {
   });
 
   it('leaves the registry untouched with fewer than two servers', () => {
-    expect(withServerArg(TOOLS, ['isaac'])).toBe(TOOLS);
+    expect(withServerArg(TOOLS, ['warehouse'])).toBe(TOOLS);
     expect(withServerArg(TOOLS, [])).toBe(TOOLS);
   });
 

--- a/app/src/lib/assistant/__tests__/tools-specialize.test.ts
+++ b/app/src/lib/assistant/__tests__/tools-specialize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { TOOLS, specializeToolSchemas } from '../tools';
+import { TOOLS, specializeToolSchemas, withServerArg } from '../tools';
 import type { ToolDefinition } from '../types';
 
 const LABELS = ['car', 'person', 'truck'];
@@ -68,5 +68,42 @@ describe('specializeToolSchemas', () => {
       Record<string, unknown>
     >;
     expect(spec.objectType.anyOf).toEqual([{ type: 'string', enum: LABELS }]);
+  });
+});
+
+/**
+ * The `server` argument only exists inside a server group (refs #337): a
+ * single-profile install must see the registry byte-identical to before, and
+ * a group must see an enum, so guided decoding cannot invent a server name.
+ */
+describe('withServerArg', () => {
+  const NAMES = ['isaac', 'home'];
+
+  function serverSpec(tools: ToolDefinition[], toolName = 'list_events'): Record<string, unknown> | undefined {
+    const tool = tools.find((t) => t.name === toolName);
+    const properties = tool?.schema.properties as Record<string, Record<string, unknown>> | undefined;
+    return properties?.server;
+  }
+
+  it('adds a server argument constrained to the servers in scope', () => {
+    const spec = serverSpec(withServerArg(TOOLS, NAMES));
+    expect(spec?.type).toBe('string');
+    expect(spec?.enum).toEqual(NAMES);
+  });
+
+  it('adds it to every tool, so any read can be scoped to one server', () => {
+    const scoped = withServerArg(TOOLS, NAMES);
+    expect(scoped.every((t) => serverSpec(scoped, t.name) !== undefined)).toBe(true);
+  });
+
+  it('leaves the registry untouched with fewer than two servers', () => {
+    expect(withServerArg(TOOLS, ['isaac'])).toBe(TOOLS);
+    expect(withServerArg(TOOLS, [])).toBe(TOOLS);
+  });
+
+  it('composes with specializeToolSchemas without losing objectType constraints', () => {
+    const both = withServerArg(specializeToolSchemas(TOOLS, LABELS), NAMES);
+    expect(objectTypeSpec(both).anyOf).toBeDefined();
+    expect(serverSpec(both)?.enum).toEqual(NAMES);
   });
 });

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -142,3 +142,34 @@ describe('buildNoToolPrompt', () => {
     expect(prompt).toContain('you have retrieved nothing');
   });
 });
+
+/**
+ * Refs #337, observed live: "compare warehouse and cabin" triaged CHAT, because
+ * nothing in the triage prompt said those two words are the user's own
+ * servers. The turn then ran with no tools and answered with a greeting. The
+ * roster has to reach the classifier, not just the answering prompt.
+ */
+describe('classifyRequest inside a server group', () => {
+  it('names the servers in scope so a question naming one is about this system', async () => {
+    const provider = providerSaying('ZONEMINDER');
+    await classifyRequest(provider, 'compare warehouse and cabin', new AbortController().signal, undefined, undefined, [
+      'cabin',
+      'warehouse',
+    ]);
+
+    const [system] = vi.mocked(provider.complete).mock.calls[0];
+    expect(system).toContain('cabin, warehouse');
+  });
+
+  it('sends the unchanged prompt when there is no group', async () => {
+    const provider = providerSaying('CHAT');
+    await classifyRequest(provider, 'hello', new AbortController().signal, undefined, undefined, ['cabin']);
+    const [withOne] = vi.mocked(provider.complete).mock.calls[0];
+
+    const bare = providerSaying('CHAT');
+    await classifyRequest(bare, 'hello', new AbortController().signal);
+    const [withNone] = vi.mocked(bare.complete).mock.calls[0];
+
+    expect(withOne).toBe(withNone);
+  });
+});

--- a/app/src/lib/assistant/agent.ts
+++ b/app/src/lib/assistant/agent.ts
@@ -11,6 +11,7 @@
 import type { AssistantMessage, AssistantProvider, AssistantHost, DisplayEntity, TokenUsage, TraceEntry, ToolCall, ToolContext, ToolDefinition, ToolResult } from './types';
 import { getToolByName, isWithheldToolName, TOOLS } from './tools';
 import { validateToolInput, objectQuestionMismatch, toolCallSignature, stripOmittedArgs, repairCountEventsInterval } from './tool-helpers';
+import { executeScoped } from './server-scope';
 import { captureApiCalls } from './api-capture';
 import { extractShowDirective, filterDisplayByShow } from './display';
 import { buildGroundingCorrection, fallbackAnswerFromData, retryIsUnusable } from './grounding';
@@ -410,7 +411,11 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
     // anything, so there is no runtime decision about whether to run.
     host.onActivity({ toolName: call.name, status: 'running', input: call.input });
     try {
-      const { result: r, calls: apiCalls } = await captureApiCalls(() => def.execute(input, ctx));
+      // executeScoped, not def.execute: inside a server group this runs the
+      // tool once per server (or once against the one the model named) and
+      // merges the results. With no group on the context it calls
+      // def.execute(input, ctx) and nothing about this path changes (refs #337).
+      const { result: r, calls: apiCalls } = await captureApiCalls(() => executeScoped(def, input, ctx));
       trace({ kind: 'tool', name: call.name, input: call.input, output: r.output, isError: r.isError, apiCalls });
       if (!r.isError) toolOutputs.push(r.output);
       host.onActivity({ toolName: call.name, status: r.isError ? 'error' : 'done', input: call.input });

--- a/app/src/lib/assistant/agent.ts
+++ b/app/src/lib/assistant/agent.ts
@@ -350,7 +350,7 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
 
     // A tool called twice with identical arguments in one turn cannot return
     // anything new, so re-running it only burns iterations until the cap.
-    // Observed: asked "how many people came home today", the model called
+    // Observed: asked "how many people came cabin today", the model called
     // count_events {"interval":"1 day"} three times (that tool reports counts
     // only, never object types) and then answered from data that could not
     // contain the answer. Refusing the repeat tells it to change course

--- a/app/src/lib/assistant/contract-eval-cases.ts
+++ b/app/src/lib/assistant/contract-eval-cases.ts
@@ -119,7 +119,7 @@ export const CONTRACT_EVAL_OBJECT_LABELS = ['car', 'carrot', 'person', 'truck'];
  * Two names a model has no prior for, so a pass means it read the roster in
  * the prompt rather than recognising a word it already knew.
  */
-export const SERVER_EVAL_SERVERS = ['isaac', 'home'];
+export const SERVER_EVAL_SERVERS = ['warehouse', 'cabin'];
 
 /**
  * Cases that only exist while the app is showing a group of servers.
@@ -136,13 +136,13 @@ export const SERVER_TOOL_CASES: ToolCase[] = [
   // The question this whole feature came from: two profile names in one
   // sentence, which used to reach the model as two meaningless nouns.
   {
-    q: 'compare events in isaac and home today',
+    q: 'compare events in warehouse and cabin today',
     tool: 'list_events',
     allCalls: true,
-    args: (a) => a.server === 'isaac' || a.server === 'home',
+    args: (a) => a.server === 'warehouse' || a.server === 'cabin',
   },
-  { q: 'how many events on isaac today', tool: 'list_events', args: (a) => a.server === 'isaac' },
-  { q: 'which cameras are recording on home', tool: 'list_monitors', args: (a) => a.server === 'home' },
+  { q: 'how many events on warehouse today', tool: 'list_events', args: (a) => a.server === 'warehouse' },
+  { q: 'which cameras are recording on cabin', tool: 'list_monitors', args: (a) => a.server === 'cabin' },
   // The other half of the contract: a question that names no server must NOT
   // pick one, or the answer silently covers a fraction of what was asked.
   { q: 'what happened today', tool: 'list_events', args: (a) => a.server === undefined },

--- a/app/src/lib/assistant/contract-eval-cases.ts
+++ b/app/src/lib/assistant/contract-eval-cases.ts
@@ -112,3 +112,38 @@ export const TOOL_CASES: ToolCase[] = [
 /** The object vocabulary the cases are written against ("how many vehicles"
  *  expects car+truck). Shared with the harness so both build the same prompt. */
 export const CONTRACT_EVAL_OBJECT_LABELS = ['car', 'carrot', 'person', 'truck'];
+
+/**
+ * The servers the group cases below are written against (refs #337).
+ *
+ * Two names a model has no prior for, so a pass means it read the roster in
+ * the prompt rather than recognising a word it already knew.
+ */
+export const SERVER_EVAL_SERVERS = ['isaac', 'home'];
+
+/**
+ * Cases that only exist while the app is showing a group of servers.
+ *
+ * Deliberately a SEPARATE list rather than more entries in `TOOL_CASES`: these
+ * need a prompt naming the servers and a registry carrying the `server`
+ * argument, and `scripts/prompt-eval.mts` builds neither. Folding them into
+ * the shared list would score them there against a prompt that never mentions
+ * a server, reporting a model failure that is really a harness one. The
+ * on-device runner (`contract-eval.ts`) builds the scoped pair and runs these
+ * after the shared list.
+ */
+export const SERVER_TOOL_CASES: ToolCase[] = [
+  // The question this whole feature came from: two profile names in one
+  // sentence, which used to reach the model as two meaningless nouns.
+  {
+    q: 'compare events in isaac and home today',
+    tool: 'list_events',
+    allCalls: true,
+    args: (a) => a.server === 'isaac' || a.server === 'home',
+  },
+  { q: 'how many events on isaac today', tool: 'list_events', args: (a) => a.server === 'isaac' },
+  { q: 'which cameras are recording on home', tool: 'list_monitors', args: (a) => a.server === 'home' },
+  // The other half of the contract: a question that names no server must NOT
+  // pick one, or the answer silently covers a fraction of what was asked.
+  { q: 'what happened today', tool: 'list_events', args: (a) => a.server === undefined },
+];

--- a/app/src/lib/assistant/contract-eval.ts
+++ b/app/src/lib/assistant/contract-eval.ts
@@ -18,16 +18,22 @@
  * Nothing here reimplements a prompt.
  */
 import { buildSystemPrompt } from './system-prompt';
-import { TOOLS } from './tools';
+import { TOOLS, withServerArg } from './tools';
 import { stripOmittedArgs, coerceLabelList } from './tool-helpers';
-import { TOOL_CASES, CONTRACT_EVAL_OBJECT_LABELS, type ToolCase } from './contract-eval-cases';
+import {
+  TOOL_CASES,
+  SERVER_TOOL_CASES,
+  SERVER_EVAL_SERVERS,
+  CONTRACT_EVAL_OBJECT_LABELS,
+  type ToolCase,
+} from './contract-eval-cases';
 import type { AssistantProvider, ExecutedToolCall, ToolCall } from './types';
 import { log, LogLevel } from '../logger';
 
 /** How many cases this eval actually scores. Exported so a caller running it
  *  alongside another stage knows the combined total BEFORE either starts, and can
  *  show one progress bar that does not reach 100% and then jump back. */
-export const CONTRACT_EVAL_CASE_COUNT = TOOL_CASES.length;
+export const CONTRACT_EVAL_CASE_COUNT = TOOL_CASES.length + SERVER_TOOL_CASES.length;
 
 /** One case that did not meet its expectation, kept compact for the log line. */
 export interface ContractEvalFailure {
@@ -127,10 +133,24 @@ export async function runContractEval(
     objectLabels: CONTRACT_EVAL_OBJECT_LABELS,
   } as never);
 
+  // The same prompt and registry a turn inside a server group gets (refs #337):
+  // the roster line plus the `server` argument, pinned to those names. Built
+  // once, used only by the group cases below.
+  const scopedSystem = buildSystemPrompt({
+    now,
+    timezone,
+    zmVersion: '1.39.1',
+    locale: 'en-US',
+    objectLabels: CONTRACT_EVAL_OBJECT_LABELS,
+    servers: SERVER_EVAL_SERVERS,
+  } as never);
+  const scopedTools = withServerArg(TOOLS, SERVER_EVAL_SERVERS);
+  const isScoped = (c: ToolCase) => SERVER_TOOL_CASES.includes(c);
+
   // Every case, including the ones triage would intercept in production: deciding
   // that NO lookup is needed is half of planning, and skipping those measured only
   // the half the model finds easier.
-  const scored = TOOL_CASES;
+  const scored = [...TOOL_CASES, ...SERVER_TOOL_CASES];
   const failures: ContractEvalFailure[] = [];
   let pass = 0;
   let done = 0;
@@ -146,7 +166,9 @@ export async function runContractEval(
     for (let attempt = 0; ; attempt++) {
       const executed: Array<{ name: string; input: Record<string, unknown> }> = [];
       try {
-        const turn = await provider.chat([{ role: 'user', text: c.q }], TOOLS, system, signal, undefined, async (name, input) => {
+        const caseTools = isScoped(c) ? scopedTools : TOOLS;
+        const caseSystem = isScoped(c) ? scopedSystem : system;
+        const turn = await provider.chat([{ role: 'user', text: c.q }], caseTools, caseSystem, signal, undefined, async (name, input) => {
           executed.push({ name, input });
           return cannedResult(name, input);
         });

--- a/app/src/lib/assistant/scoped-servers.ts
+++ b/app/src/lib/assistant/scoped-servers.ts
@@ -1,0 +1,56 @@
+/**
+ * The turn's server roster, built once per question (refs #337).
+ *
+ * `ScopedServer` carries what a tool run against another server needs and the
+ * pinned profile's context cannot supply: that server's portal URL, a fresh
+ * token for its thumbnails, its streaming port and its timezone. Read at send
+ * time rather than subscribed to, because a turn is a snapshot: the answer
+ * describes the servers as they were when the question was asked.
+ *
+ * Tokens come from `getFreshAccessToken`, the auth store's own deduped entry
+ * point (auth contract), so this neither caches nor refreshes anything itself.
+ * A server whose token cannot be fetched still takes part in the turn: its
+ * data reads fine (the session layer authenticates its own requests) and only
+ * its card thumbnails come back empty, which is a far better outcome than
+ * dropping a server from an answer that claims to cover every server.
+ */
+
+import type { Profile } from '../../api/types';
+import type { ScopedServer } from './types';
+import { useAuthStore } from '../../stores/auth';
+import { useSettingsStore } from '../../stores/settings';
+import { resolveMinStreamingPort } from '../monitor/multiport';
+import { log, LogLevel } from '../logger';
+
+export async function buildScopedServers(profiles: readonly Profile[]): Promise<ScopedServer[]> {
+  // One server is not a group: the turn runs exactly as a single-profile turn
+  // does, with no `server` argument and no per-server wrapper anywhere.
+  if (profiles.length < 2) return [];
+
+  const { getFreshAccessToken } = useAuthStore.getState();
+  const { getProfileSettings } = useSettingsStore.getState();
+
+  return Promise.all(
+    profiles.map(async (profile) => {
+      const settings = getProfileSettings(profile.id);
+      let accessToken: string | null = null;
+      try {
+        accessToken = await getFreshAccessToken(profile.id);
+      } catch (e) {
+        log.assistant('No access token for a server in scope; its cards lose thumbnails', LogLevel.WARN, {
+          profileId: profile.id,
+          error: e,
+        });
+      }
+      return {
+        profileId: profile.id,
+        name: profile.name,
+        portalUrl: profile.portalUrl,
+        accessToken,
+        minStreamingPort: resolveMinStreamingPort(profile.minStreamingPort, settings.forceDisableMultiPort),
+        thumbnailFallbackChain: settings.thumbnailFallbackChain,
+        timezone: profile.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+      };
+    }),
+  );
+}

--- a/app/src/lib/assistant/server-scope.ts
+++ b/app/src/lib/assistant/server-scope.ts
@@ -1,0 +1,206 @@
+/**
+ * Running one tool call across a group of servers (refs #337).
+ *
+ * A virtual profile combines several ZoneMinder servers, but every tool in
+ * `tools-readonly.ts` is written against exactly one: it calls
+ * `getSession(ctx.profileId)` and builds card thumbnails from the one portal
+ * URL and token on the context. Teaching each of them to fan out would mean
+ * rewriting their summaries, hour tallies and truncation logic N times over.
+ *
+ * So the fan-out lives here instead, one level up, at the single place the
+ * agent loop executes a tool (`agent.ts`). A tool still runs against one
+ * server and knows nothing about groups; this wrapper decides WHICH server or
+ * servers, runs the tool once per server against a context swapped to that
+ * server, and merges the results into one payload that names each server.
+ *
+ * The model's half of the contract is the `server` argument (`withServerArg`
+ * in tools.ts) plus the roster in the system prompt: it sets `server` when the
+ * user names one, and omits it to cover the whole group.
+ */
+
+import type { DisplayEntity, ScopedServer, ToolContext, ToolDefinition, ToolExecuteResult } from './types';
+import { isOmittedArg } from './tool-helpers';
+
+/** The wrapper's own argument, stripped before the tool sees the input: a tool
+ *  declares `additionalProperties: false` and knows nothing about servers. */
+export const SERVER_ARG = 'server';
+
+/**
+ * Turns the model's `server` value into one of the servers in scope.
+ *
+ * Exact match first, then an unambiguous prefix, both case-insensitive: the
+ * model is asked to copy a name from the enum, and the tolerance is for the
+ * turns where it types "hom" or capitalizes. An ambiguous prefix is an error
+ * rather than a guess - answering about the wrong server is worse than asking
+ * again, because nothing in the answer would reveal the mistake.
+ */
+export function resolveServerArg(
+  raw: unknown,
+  servers: readonly ScopedServer[],
+): { server: ScopedServer } | { error: string } {
+  const needle = String(raw ?? '').trim().toLowerCase();
+  const names = servers.map((s) => s.name).join(', ');
+  if (!needle) return { error: `server is required. The servers in this view are: ${names}.` };
+
+  const exact = servers.filter((s) => s.name.toLowerCase() === needle);
+  if (exact.length === 1) return { server: exact[0] };
+
+  const prefixed = servers.filter((s) => s.name.toLowerCase().startsWith(needle));
+  if (prefixed.length === 1) return { server: prefixed[0] };
+  if (prefixed.length > 1) {
+    return {
+      error: `"${String(raw)}" matches more than one server (${prefixed.map((s) => s.name).join(', ')}). Use the full name.`,
+    };
+  }
+  return {
+    error: `There is no server named "${String(raw)}" in this view. The servers are: ${names}. Use one of those names exactly, or omit server to cover all of them.`,
+  };
+}
+
+/**
+ * The turn's context, pointed at one server.
+ *
+ * Everything server-specific is replaced together - session id, portal URL,
+ * token, streaming port, thumbnail chain, timezone - because a half-swapped
+ * context is what produces a card from one server carrying another's token.
+ * `servers` itself is dropped: the tool underneath is single-server by
+ * construction, and leaving the roster on the context it receives invites a
+ * second fan-out inside one.
+ */
+/* ponytail: `interpretWhen` stays bound to the pinned profile's timezone (the
+ * closure AskPanel built), while the arithmetic that follows it runs in the
+ * server's own zone below. The phrase-to-fields step barely depends on the
+ * zone, so the two only disagree for a phrase asked across a midnight boundary
+ * between servers in different zones. Upgrade path: make `interpretWhen` take
+ * the timezone as an argument and re-bind it here. */
+export function contextForServer(ctx: ToolContext, server: ScopedServer): ToolContext {
+  return {
+    ...ctx,
+    servers: undefined,
+    profileId: server.profileId,
+    portalUrl: server.portalUrl ?? ctx.portalUrl,
+    accessToken: server.accessToken ?? null,
+    minStreamingPort: server.minStreamingPort ?? ctx.minStreamingPort,
+    thumbnailFallbackChain: server.thumbnailFallbackChain ?? ctx.thumbnailFallbackChain,
+    timezone: server.timezone ?? ctx.timezone,
+  };
+}
+
+/** Cards, labelled with the server they came from and pointed at that
+ *  server's all-mode deep route. The raw ZM id is not unique across servers
+ *  (aggregation contract), so the card's cache key becomes a composite; the
+ *  navigate path gets the same treatment for the same reason. */
+function tagDisplay(display: DisplayEntity[] | undefined, server: ScopedServer): DisplayEntity[] {
+  return (display ?? []).map((entity) => ({
+    ...entity,
+    server: server.name,
+    profileId: server.profileId,
+    cacheKey: `${server.profileId}:${entity.cacheKey ?? entity.id}`,
+    navigatePath:
+      entity.kind === 'event'
+        ? `/all/events/${server.profileId}/${entity.id}`
+        : `/all/monitors/${server.profileId}/${entity.id}`,
+  }));
+}
+
+/** A tool's own output, parsed when it is the JSON every read tool returns, so
+ *  the merged payload nests real objects instead of escaped strings the model
+ *  then has to unescape. */
+function parseOutput(output: string): unknown {
+  try {
+    return JSON.parse(output);
+  } catch {
+    return output;
+  }
+}
+
+interface ServerRun {
+  server: string;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * The merged payload.
+ *
+ * `summary` is deliberately at the top level and deliberately a string:
+ * `fallbackAnswerFromData` (grounding.ts) reads exactly that field when a
+ * model fails to write an answer of its own, and a group turn must not lose
+ * that safety net. It names each server because a total that does not say
+ * which server it came from is the bug this whole change exists to fix.
+ */
+function mergeRuns(runs: ServerRun[]): string {
+  const summary = runs
+    .map((run) => {
+      const inner = (run.result as { summary?: unknown } | undefined)?.summary;
+      if (run.error) return `${run.server}: ${run.error}`;
+      return `${run.server}: ${typeof inner === 'string' && inner ? inner : 'no summary'}`;
+    })
+    .join(' ');
+  return JSON.stringify({ summary, servers: runs });
+}
+
+/**
+ * Executes one tool call for the turn's server scope.
+ *
+ * Three paths, in the order they are decided:
+ * - No group (a single-profile install, or a context without a roster): the
+ *   tool runs exactly as it always did, same context object, no wrapper around
+ *   its output. Every existing single-server behavior and test depends on this.
+ * - `server` named: resolved, then run once against that server.
+ * - `server` omitted inside a group: run once per server, in parallel, and
+ *   merged.
+ *
+ * A server that fails does not fail the call: its message rides in the merged
+ * payload next to the servers that answered, because "the other three servers
+ * saw nothing" is still an answer. Only an all-failed call is an error, and
+ * then the messages are what the model gets.
+ */
+export async function executeScoped(
+  def: ToolDefinition,
+  input: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<ToolExecuteResult> {
+  const servers = ctx.servers ?? [];
+  const { [SERVER_ARG]: rawServer, ...toolInput } = input;
+
+  if (servers.length < 2) return def.execute(toolInput, ctx);
+
+  const targets: ScopedServer[] = [];
+  if (!isOmittedArg(rawServer)) {
+    const resolved = resolveServerArg(rawServer, servers);
+    if ('error' in resolved) return { output: resolved.error, isError: true };
+    targets.push(resolved.server);
+  } else {
+    targets.push(...servers);
+  }
+
+  const outcomes = await Promise.all(
+    targets.map(async (server) => {
+      try {
+        const result = await def.execute(toolInput, contextForServer(ctx, server));
+        // A tool that reports its own failure (safeExecute's `isError`) counts
+        // as a failed server, not as data: its `output` is a message.
+        if (result.isError) return { server, error: result.output, display: [] as DisplayEntity[] };
+        return { server, result, display: tagDisplay(result.display, server) };
+      } catch (e) {
+        return { server, error: e instanceof Error ? e.message : 'Tool failed', display: [] as DisplayEntity[] };
+      }
+    }),
+  );
+
+  const runs: ServerRun[] = outcomes.map((outcome) =>
+    outcome.error !== undefined
+      ? { server: outcome.server.name, error: outcome.error }
+      : { server: outcome.server.name, result: parseOutput(outcome.result!.output) },
+  );
+  const allFailed = outcomes.every((outcome) => outcome.error !== undefined);
+  if (allFailed) {
+    return {
+      output: outcomes.map((outcome) => `${outcome.server.name}: ${outcome.error}`).join('\n'),
+      isError: true,
+    };
+  }
+
+  return { output: mergeRuns(runs), display: outcomes.flatMap((outcome) => outcome.display) };
+}

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -15,6 +15,29 @@ import { buildObjectLabelLine } from './object-labels';
  *  that survives below earned its place through a measured failure; the eval
  *  harness (scripts/prompt-eval.mts) is where a new rule proves it pays rent
  *  before it is added. */
+/**
+ * What the model is told about a group of servers (refs #337).
+ *
+ * Three sentences, each answering a question the model cannot answer from the
+ * conversation alone: which words in the question are server names, how to
+ * read one server, and what a result looks like when it read all of them.
+ * Without the first, "compare events in isaac and home" is two unknown nouns
+ * and the turn queries one server and calls it the answer.
+ *
+ * The comparison sentence deliberately mirrors the period-comparison rule
+ * further down ("compare may to june" = two calls): the shape is already
+ * taught, so this only names the argument that varies.
+ */
+function serverLines(servers: readonly string[]): string[] {
+  if (servers.length < 2) return [];
+  const names = servers.join(', ');
+  return [
+    `This view combines several ZoneMinder servers: ${names}. Those words are server names, not monitors or places.`,
+    `Every tool takes a "server" argument. Set it to one of those names when the user names a server. Omit it to cover all of them: the result then carries one entry per server under "servers", and every count you quote must say which server it came from.`,
+    `A question comparing two servers is one call per server, differing only in "server": "compare ${servers[0]} and ${servers[1]}" is exactly {"server":"${servers[0]}"} then {"server":"${servers[1]}"}.`,
+  ];
+}
+
 export function buildSystemPrompt(ctx: SystemPromptContext): string {
   // Spelled out as a plain calendar date, not just the ISO instant: small
   // models are unreliable converting an ISO timestamp into "what day is
@@ -28,6 +51,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     `Today's date is ${todayLabel} in timezone ${ctx.timezone} (current instant: ${ctx.now.toISOString()}).`,
     `ZoneMinder version: ${ctx.zmVersion}.`,
     'Treat this system context and tool results as ground truth. Fetch mutable facts with tools before stating them; never invent ids or results.',
+    // Only inside a group, and only when it holds more than one server: a
+    // single-server install must read the prompt it always read, since every
+    // added line moves tool selection on a small model (refs #337, #259).
+    ...serverLines(ctx.servers ?? []),
     '',
     // Split from the answer-style rules on purpose: stated as one flat list,
     // style rules read to a small model as instructions about the WHOLE reply

--- a/app/src/lib/assistant/system-prompt.ts
+++ b/app/src/lib/assistant/system-prompt.ts
@@ -21,7 +21,7 @@ import { buildObjectLabelLine } from './object-labels';
  * Three sentences, each answering a question the model cannot answer from the
  * conversation alone: which words in the question are server names, how to
  * read one server, and what a result looks like when it read all of them.
- * Without the first, "compare events in isaac and home" is two unknown nouns
+ * Without the first, "compare events in warehouse and cabin" is two unknown nouns
  * and the turn queries one server and calls it the answer.
  *
  * The comparison sentence deliberately mirrors the period-comparison rule

--- a/app/src/lib/assistant/tools.ts
+++ b/app/src/lib/assistant/tools.ts
@@ -80,6 +80,42 @@ export function specializeToolSchemas(
 }
 
 /**
+ * The same tools with a `server` argument naming the servers in scope
+ * (refs #337).
+ *
+ * Injected rather than declared in the registry for the same reason
+ * `specializeToolSchemas` injects object labels: the valid values are the
+ * user's own profile names, known only at turn time, and an enum is what makes
+ * a wrong one impossible to generate on a guided-decoding backend rather than
+ * merely correctable afterwards.
+ *
+ * Fewer than two servers returns `tools` unchanged, by identity: a
+ * single-profile install must see the registry it has always seen, argument
+ * for argument, so no prompt-sensitive backend shifts behavior because a
+ * feature it cannot use exists.
+ */
+export function withServerArg(tools: ToolDefinition[], serverNames: readonly string[]): ToolDefinition[] {
+  if (serverNames.length < 2) return tools;
+  const names = [...serverNames];
+  return tools.map((tool) => ({
+    ...tool,
+    schema: {
+      ...tool.schema,
+      properties: {
+        ...(tool.schema.properties ?? {}),
+        server: {
+          type: 'string',
+          enum: names,
+          description:
+            'Which server to read, named exactly as listed here. Set it when the user names a server. ' +
+            'Omit it to cover every server: the result is then grouped per server.',
+        },
+      },
+    },
+  }));
+}
+
+/**
  * Names the assistant used to expose, kept ONLY so the agent loop can explain
  * itself when a model asks for one (they appear in model training data and in
  * older conversations). This is a list of strings, deliberately not a registry

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -60,7 +60,7 @@ export type RequestKind = 'zoneminder' | 'chat' | 'action';
  *  constrained JSON. Editing the existing list instead costs no length and
  *  measured 34/36. Add nothing here without re-running `prompt-eval.mts
  *  triage`. */
-const TRIAGE_PROMPT = [
+const triagePromptLines = (servers: readonly string[]): string[] => [
   'You classify one user message for a ZoneMinder security-camera app. Reply with EXACTLY one word.',
   '',
   'Decide by WHAT THE USER WANTS DONE and WHAT IT CONCERNS, whatever language the message is in:',
@@ -73,13 +73,30 @@ const TRIAGE_PROMPT = [
   '  screen in the app. Questions and commands alike, in any language: "summarize <any period>",',
   '  "what happened <any period>", "how many <thing> came <any period>", "did anyone come by",',
   '  "show me <camera>".',
+  // Refs #337, observed live: "compare warehouse and cabin" classified CHAT, and
+  // the tool-less turn answered it with a greeting. The names of the user's
+  // own servers are the one piece of context that decides such a message, and
+  // nothing else in this prompt can supply it. Written INTO the ZONEMINDER
+  // list, not appended as a block: the comment above records that an appended
+  // block costs accuracy while editing this list costs none.
+  ...(servers.length >= 2
+    ? [`  A message naming one of this view's servers (${servers.join(', ')}) is about THIS system.`]
+    : []),
   'ACTION - a request to CHANGE something here: arm or disarm a monitor, enable or disable a camera,',
   '  trigger or cancel an alarm, change the run state or a monitor function, delete or archive an event.',
   'CHAT - anything NOT about this system: greetings, thanks, small talk, questions about you, general',
   '  knowledge, or summarizing something that is not this system\'s activity.',
   '',
   'Reply with one word: ZONEMINDER, ACTION, or CHAT.',
-].join('\n');
+];
+
+/** The classifier's prompt for a turn covering `servers`. Fewer than two names
+ *  it identically to the string this file has always sent. */
+function buildTriagePrompt(servers: readonly string[]): string {
+  return triagePromptLines(servers).join('\n');
+}
+
+const TRIAGE_PROMPT = buildTriagePrompt([]);
 
 /** The verdict as a schema, for a backend that can constrain generation to it
  *  (see `AssistantProvider.complete`). Constrained, the reply is exactly
@@ -137,6 +154,10 @@ export async function classifyRequest(
    *  accepted. */
   onTrace?: (entry: TraceEntry) => void,
   onStatus?: (status: AssistantStatus) => void,
+  /** Servers this view combines (refs #337). Their names go into the prompt,
+   *  because a message that names one is about this system and nothing else
+   *  here can tell the classifier that. */
+  servers: readonly string[] = [],
 ): Promise<RequestKind> {
   try {
     // `complete`, not `chat`: a classifier handed the tool catalog, the
@@ -144,7 +165,7 @@ export async function classifyRequest(
     // instead of returning a verdict. The schema constrains a backend that
     // can enforce it to `{"kind":"..."}`; the parser still accepts the loose
     // one-word reply from a backend that cannot.
-    const result = await provider.complete(TRIAGE_PROMPT, question, signal, TRIAGE_SCHEMA as unknown as Record<string, unknown>, onStatus);
+    const result = await provider.complete(buildTriagePrompt(servers), question, signal, TRIAGE_SCHEMA as unknown as Record<string, unknown>, onStatus);
     if (result.exchange) {
       onTrace?.({ kind: 'exchange', exchange: { ...result.exchange, backend: `${result.exchange.backend} (triage)` } });
     }

--- a/app/src/lib/assistant/types.ts
+++ b/app/src/lib/assistant/types.ts
@@ -25,6 +25,12 @@ export interface DisplayEntity {
    *  preview to resolve the streaming port (refs #270). Unset for monitors,
    *  whose own `id` is the monitor. */
   monitorId?: string;
+  /** Which server this row came from, set only while the turn covers a group
+   *  of them (refs #337). The card renders it, because "Front Door" means
+   *  nothing when two servers both have one. */
+  server?: string;
+  /** That server's profile, for the card's all-mode deep route. */
+  profileId?: ProfileId;
 }
 
 /** One entry in the conversation. Assistant turns carry text and/or toolCalls;
@@ -193,8 +199,36 @@ export interface ResolvedTimeframe {
   fields: import('./event-range').WindowFields;
 }
 
+/**
+ * One server a turn may read, while the app is showing a group of them
+ * (refs #337).
+ *
+ * The display fields repeat the same-named `ToolContext` fields because they
+ * differ per server: a card built for `home` with `isaac`'s portal URL and
+ * token renders a broken thumbnail. `contextForServer` (server-scope.ts)
+ * swaps this whole set in before a tool runs, so tools stay single-server and
+ * never learn that a group exists.
+ */
+export interface ScopedServer {
+  profileId: ProfileId;
+  /** The profile's name, as the user typed it and as the model must name it. */
+  name: string;
+  portalUrl?: string;
+  accessToken?: string | null;
+  minStreamingPort?: number;
+  thumbnailFallbackChain?: ThumbnailFallbackEntry[];
+  /** The server's own timezone: "today" ends at a different instant on a
+   *  server in Berlin than on one in New York. */
+  timezone?: string;
+}
+
 export interface ToolContext {
   profileId: ProfileId;
+  /** Every server this turn may read, when the app is showing a group
+   *  (refs #337). Absent or single means an ordinary single-server turn, which
+   *  runs exactly as it did before: `executeScoped` hands the tool this
+   *  context untouched.  */
+  servers?: ScopedServer[];
   /** The question this turn is answering, so a tool can check that a
    *  model-supplied phrase came from the user rather than from an example in
    *  the prompt (see `list_events`' `when`). */
@@ -414,4 +448,8 @@ export interface SystemPromptContext {
   timezone: string;
   locale: string;
   zmVersion: string;
+  /** Names of the servers this view combines (refs #337). Fewer than two
+   *  drops every server line, so a single-server install reads the prompt it
+   *  always read. */
+  servers?: string[];
 }

--- a/app/src/lib/assistant/types.ts
+++ b/app/src/lib/assistant/types.ts
@@ -204,7 +204,7 @@ export interface ResolvedTimeframe {
  * (refs #337).
  *
  * The display fields repeat the same-named `ToolContext` fields because they
- * differ per server: a card built for `home` with `isaac`'s portal URL and
+ * differ per server: a card built for `cabin` with `warehouse`'s portal URL and
  * token renders a broken thumbnail. `contextForServer` (server-scope.ts)
  * swaps this whole set in before a tool runs, so tools stay single-server and
  * never learn that a group exists.

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1463,6 +1463,7 @@
     "backend_ollama": "Ollama",
     "placeholder": "Frage zu deinen Kameras...",
     "pinned_to": "Angeheftet an {{profile}}",
+    "covers_all_servers": "Modell von {{profile}} · Antworten umfassen alle Server",
     "send": "Senden",
     "abort": "Stopp",
     "thinking": "Denkt nach...",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1463,6 +1463,7 @@
     "backend_ollama": "Ollama",
     "placeholder": "Ask about your cameras...",
     "pinned_to": "Pinned to {{profile}}",
+    "covers_all_servers": "Model from {{profile}} · answers cover all servers",
     "send": "Send",
     "abort": "Stop",
     "thinking": "Thinking...",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1463,6 +1463,7 @@
     "backend_ollama": "Ollama",
     "placeholder": "Pregunta sobre tus cámaras...",
     "pinned_to": "Anclado a {{profile}}",
+    "covers_all_servers": "Modelo de {{profile}} · las respuestas cubren todos los servidores",
     "send": "Enviar",
     "abort": "Detener",
     "thinking": "Pensando...",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1463,6 +1463,7 @@
     "backend_ollama": "Ollama",
     "placeholder": "Posez une question sur vos caméras...",
     "pinned_to": "Épinglé à {{profile}}",
+    "covers_all_servers": "Modèle de {{profile}} · les réponses couvrent tous les serveurs",
     "send": "Envoyer",
     "abort": "Arrêter",
     "thinking": "Réflexion...",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1463,6 +1463,7 @@
     "backend_ollama": "Ollama",
     "placeholder": "询问你的摄像头...",
     "pinned_to": "已固定到 {{profile}}",
+    "covers_all_servers": "模型来自 {{profile}} · 回答涵盖所有服务器",
     "send": "发送",
     "abort": "停止",
     "thinking": "思考中...",

--- a/app/src/pages/ProfileForm.tsx
+++ b/app/src/pages/ProfileForm.tsx
@@ -293,11 +293,7 @@ export default function ProfileForm() {
 
       // Generate profile name if not provided
       const finalProfileName = profileName.trim() || (
-        confirmedPortalUrl.includes('demo.zoneminder.com')
-          ? 'Demo Server'
-          : confirmedPortalUrl.includes('isaac')
-            ? 'Isaac Server'
-            : 'My ZoneMinder'
+        confirmedPortalUrl.includes('demo.zoneminder.com') ? 'Demo Server' : 'My ZoneMinder'
       );
 
       log.profileForm('Adding new profile', LogLevel.INFO, { profileName: finalProfileName });

--- a/app/src/tests/agents-contracts.test.ts
+++ b/app/src/tests/agents-contracts.test.ts
@@ -114,7 +114,10 @@ describe('AGENTS.md stays portable', () => {
     // Claude-only shim). Raising this budget is a deliberate act that needs
     // a reason in the commit message, like the lint ratchet (C7). Lowering
     // it is always welcome.
-    const WORD_BUDGET = 2000;
+    // 2000 -> 2050 (refs #337): the assistant tool-loop contract gained the
+    // multi-server path, and the entry was already compressed to pay for most
+    // of it. A contract nobody can find is worse than 50 words.
+    const WORD_BUDGET = 2050;
     const words = (f: string) =>
       fs.readFileSync(path.join(repoRoot, f), 'utf8').split(/\s+/).filter(Boolean).length;
     const total = words('AGENTS.md') + words('AGENTS.project.md') + words('CLAUDE.md');

--- a/docs/developer-guide/15-assistant.rst
+++ b/docs/developer-guide/15-assistant.rst
@@ -121,7 +121,7 @@ With a group, three things change together, and they have to agree or the
 feature is worse than not having it:
 
 - The system prompt gains a roster (``serverLines`` in ``system-prompt.ts``)
-  naming the servers, so "isaac" is a server name to the model rather than an
+  naming the servers, so "warehouse" is a server name to the model rather than an
   unknown noun.
 - The registry gains a ``server`` argument whose ``enum`` is those same names
   (``withServerArg`` in ``tools.ts``), which makes an invented server name
@@ -132,6 +132,14 @@ feature is worse than not having it:
   through ``resolveServerArg``, and runs the tool once against
   ``contextForServer``. With no ``server`` it runs once per server in parallel
   and merges.
+
+The roster reaches the classifier too, and has to. ``classifyRequest``
+(``triage.ts``) decides whether a turn gets tools at all, and it ran before
+anything knew what "warehouse" was: "compare warehouse and cabin" classified CHAT and
+the tool-less turn answered it with a greeting. The names go into the existing
+ZONEMINDER list rather than an appended block, for the reason that file's own
+comment gives - an appended block measured worse - and drop out entirely below
+two servers.
 
 The merged payload is ``{summary, servers: [{server, result | error}]}``.
 ``summary`` is a top-level string on purpose: ``fallbackAnswerFromData``

--- a/docs/developer-guide/15-assistant.rst
+++ b/docs/developer-guide/15-assistant.rst
@@ -99,6 +99,58 @@ model corrects from within the same turn; what passes runs through
 ``captureApiCalls`` so the transcript records the ZoneMinder requests the
 tool actually made.
 
+Answering about a group of servers (``server-scope.ts``)
+-------------------------------------------------------
+
+Every tool in ``tools-readonly.ts`` is written against one server: it calls
+``getSession(ctx.profileId)`` and builds card thumbnails from the single
+``portalUrl``/``accessToken`` pair on the context. A virtual profile combines
+several servers, so something has to decide which of them a call runs against.
+That decision does not live in the tools. It lives one level up, at the single
+line in ``agent.ts`` where a call executes, which calls ``executeScoped``
+instead of ``def.execute``.
+
+``ToolContext.servers`` carries the roster (``ScopedServer``: profile id, name,
+portal URL, token, streaming port, thumbnail chain, timezone), built once per
+question by ``buildScopedServers`` (``scoped-servers.ts``) from the profiles in
+scope. Fewer than two entries means no group, and ``executeScoped`` hands the
+tool the context untouched: a single-profile install runs the path it always
+ran, byte for byte.
+
+With a group, three things change together, and they have to agree or the
+feature is worse than not having it:
+
+- The system prompt gains a roster (``serverLines`` in ``system-prompt.ts``)
+  naming the servers, so "isaac" is a server name to the model rather than an
+  unknown noun.
+- The registry gains a ``server`` argument whose ``enum`` is those same names
+  (``withServerArg`` in ``tools.ts``), which makes an invented server name
+  undecodable on a guided-decoding backend rather than merely correctable
+  afterwards. Same mechanism as ``specializeToolSchemas`` for object labels.
+- ``executeScoped`` strips ``server`` from the input (tools declare
+  ``additionalProperties: false`` and know nothing about groups), resolves it
+  through ``resolveServerArg``, and runs the tool once against
+  ``contextForServer``. With no ``server`` it runs once per server in parallel
+  and merges.
+
+The merged payload is ``{summary, servers: [{server, result | error}]}``.
+``summary`` is a top-level string on purpose: ``fallbackAnswerFromData``
+(``grounding.ts``) reads exactly that field when a model fails to write an
+answer, and a group turn must not lose that safety net. A server that fails
+rides in the payload next to the ones that answered; only an all-failed call is
+an error, because "the other three servers saw nothing" is still an answer.
+
+Result cards from a group carry ``server`` and ``profileId``
+(``DisplayEntity``), which ``AssistantResultCards`` renders as a label and uses
+to route to ``/all/events/:profileId/:id``. The cache key becomes
+``profileId:id`` for the reason the aggregation contract gives: raw ZoneMinder
+ids collide across servers. The same rule is why a monitor card from another
+server gets no live preview - ``useMonitors`` is the pinned profile's query,
+and monitor 3 is a different camera on each server.
+
+The pinned profile still decides the backend, its settings and the thread; it
+no longer decides which servers get asked.
+
 Picking the backend (``providers/provider.ts``)
 -----------------------------------------------
 

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -69,7 +69,7 @@ Ninjii only knows what its tools can look up: your monitors, events, groups, tag
 
 When you are looking at a group of servers, Ninjii knows the group's servers by name and answers about all of them.
 
-Name a server and it looks there only: "how many events on isaac today". Name none and it asks every server in the group and reports each one separately, so a total always says which server it came from. Name two and you get the comparison: "compare events in isaac and home today". The names it knows are your profile names, exactly as they appear on the Profiles screen, so renaming a profile renames it for Ninjii too.
+Name a server and it looks there only: "how many events on warehouse today". Name none and it asks every server in the group and reports each one separately, so a total always says which server it came from. Name two and you get the comparison: "compare events in warehouse and cabin today". The names it knows are your profile names, exactly as they appear on the Profiles screen, so renaming a profile renames it for Ninjii too.
 
 Every event and monitor card underneath the answer is labelled with the server it came from, and opening one takes you to that server's screen. Two servers can each have a camera called "Front Door", and the label is how you tell those apart.
 
@@ -81,7 +81,7 @@ A group with one enabled server behaves exactly like a single server: no names, 
 
 The assistant is read-only. It can look things up, and that is all. It cannot arm or disarm a monitor, trigger or cancel an alarm, change a monitor's function, change the run state, or delete or archive an event.
 
-This is deliberate. The assistant works by having a language model choose which action matches your words, and a model can misread a request: "clear out today's events" is one phrasing away from deleting them, and "I'm home" is one phrasing away from changing your run state. Earlier versions asked you to confirm each action first, but that put the entire safeguard on a single tap, in a dialog that looks the same whether the model understood you or not. Deleting an event cannot be undone, and a monitor left disarmed records nothing.
+This is deliberate. The assistant works by having a language model choose which action matches your words, and a model can misread a request: "clear out today's events" is one phrasing away from deleting them, and "I'm cabin" is one phrasing away from changing your run state. Earlier versions asked you to confirm each action first, but that put the entire safeguard on a single tap, in a dialog that looks the same whether the model understood you or not. Deleting an event cannot be undone, and a monitor left disarmed records nothing.
 
 Ask for one of these and the assistant will say it cannot do it and point you to the screen where you can: monitors and arming on **Monitors**, run state on **Server**, deleting and archiving on the event itself. Doing it there means you picked the target yourself.
 

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -65,6 +65,18 @@ Ask it to change something, such as "arm the backyard camera" or "delete event 1
 
 Ninjii only knows what its tools can look up: your monitors, events, groups, tags, and server health. Ask it something unrelated to this ZoneMinder server and it answers as an ordinary assistant would, without pretending to have looked anything up.
 
+## Asking about several servers
+
+When you are looking at a group of servers, Ninjii knows the group's servers by name and answers about all of them.
+
+Name a server and it looks there only: "how many events on isaac today". Name none and it asks every server in the group and reports each one separately, so a total always says which server it came from. Name two and you get the comparison: "compare events in isaac and home today". The names it knows are your profile names, exactly as they appear on the Profiles screen, so renaming a profile renames it for Ninjii too.
+
+Every event and monitor card underneath the answer is labelled with the server it came from, and opening one takes you to that server's screen. Two servers can each have a camera called "Front Door", and the label is how you tell those apart.
+
+The picker at the top of the chat window still names one server, and that is deliberate: it decides which server's assistant settings run the conversation (the backend, model and history length), not which servers get asked. Its own conversation history stays with it, so switching it gives you a separate thread.
+
+A group with one enabled server behaves exactly like a single server: no names, no per-server breakdown.
+
 ## The assistant cannot change anything
 
 The assistant is read-only. It can look things up, and that is all. It cannot arm or disarm a monitor, trigger or cancel an alarm, change a monitor's function, change the run state, or delete or archive an event.


### PR DESCRIPTION
## What

Inside a virtual profile (a group of servers), Ninjii answered about the pinned member only, and profile names meant nothing to it: "compare events in isaac and home today" reached the model as two unknown nouns.

Now the assistant knows the group's servers by name, scopes a lookup to one when the user names one, and fans out over all of them when the user names none.

## How

- `executeScoped` (`app/src/lib/assistant/server-scope.ts`) wraps the single line in `agent.ts` where a tool call runs. It resolves the model's `server` argument, or runs the tool once per server against a context swapped to that server (`contextForServer`: session id, portal URL, token, streaming port, thumbnail chain, timezone), then merges. Tools stay single-server and never learn a group exists.
- `withServerArg` (`tools.ts`) adds a `server` argument whose `enum` is the servers in scope, so a guided-decoding backend cannot generate a server that is not there. Same mechanism as `specializeToolSchemas` for object labels.
- `serverLines` (`system-prompt.ts`) names the servers and states what omitting `server` means.
- `buildScopedServers` (`scoped-servers.ts`) builds the roster once per question, tokens through the auth store's own `getFreshAccessToken`.
- Result cards carry `server`/`profileId`: labelled in the UI, keyed and routed by profile (raw ZM ids collide across servers), and no live preview for a card from another server, since `useMonitors` is the pinned profile's query.
- The pinned picker's caption now says what it decides (which server's model and settings run the conversation), not which servers get asked.

Fewer than two servers returns the prompt and the registry unchanged, by identity, so a single-profile install runs the path it always ran.

## Verification

- `npm run gates`: 4084 passed, 2 skipped; build; three lints (backlog 202, within baseline).
- New: `server-scope.test.ts` (resolution, per-server context, fan-out, partial and total failure, card labelling/routing), `withServerArg` cases, prompt roster cases, cross-server card cases.
- `SERVER_TOOL_CASES` added to the on-device contract eval, run with the scoped prompt and registry. Kept out of `TOOL_CASES` deliberately: `scripts/prompt-eval.mts` builds neither, and folding them in would report a harness failure as a model one.
- No e2e scenario: the visible changes are a card label and a caption, and the behavior change is in the tool layer, which the unit tests cover. Device e2e is manual-only.

## Notes

- Instruction-file word budget 2000 → 2050, reason in the commit message (the gate asks for one).
- Known ceiling, marked `ponytail:` in `server-scope.ts`: `interpretWhen` stays bound to the pinned profile's timezone while the window arithmetic runs in each server's own zone. They only disagree for a phrase asked across a midnight boundary between servers in different zones.

Refs #337

Claude assisting @pliablepixels